### PR TITLE
Update config.toml

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -115,10 +115,13 @@ popular_window = "720h"
 # The type of neighbors for users. There are three types:
 #   similar: Neighbors are found by number of common labels.
 #   related: Neighbors are found by number of common liked items.
-#   auto: If a user have labels, neighbors are found by number of common labels.
-#         If this user have no labels, neighbors are found by number of common liked items.
+#   auto: average of relevance and similarity. 
+#         Correlation refers to the number of common items of users (or the number of common users of items), 
+#         and similarity refers to the number of common tags between the two. In the new version, 
+#         "automatic" is the average value of correlation and similarity.
 # The default value is "auto".
-neighbor_type = "similar"
+neighbor_type = "auto"
+
 
 # Enable approximate user neighbor searching using vector index. The default value is true.
 enable_index = true


### PR DESCRIPTION
https://mp.weixin.qq.com/s/gVzUK2v-lZ9-fEIwgX1jzw

将“自动”相似物品/用户类型修改为相关度和相似度的平均值。相关指用户的共同物品数量（或者物品的共同用户数量），相似指两者的共同标签数量，新版本中“自动”为相关度和相似度的平均值。