### PR TITLE
fix(Readme): adjust link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ curl http://127.0.0.1:8088/api/recommend/bob?n=10
 
 For more information：
 
-- Read [official documents](https://gorse.io/docs)
+- Read [official documents](https://gorse.io/docs/master)
 - Visit [official demo](https://gitrec.gorse.io/)
 - Discuss on [Discord](https://discord.gg/x6gAtNNkAE) or [GitHub Discussion](https://github.com/gorse-io/gorse/discussions)
 


### PR DESCRIPTION
The link to the documentation was broken, this points to the right place again.

A little bit of drive-by PR but would still be nice to have the link to docs working.