### PR TITLE
goat: avoid unnecessary byte/string conversion

### DIFF
--- a/cmd/goat/parser_amd64.go
+++ b/cmd/goat/parser_amd64.go
@@ -105,16 +105,16 @@ func parseAssembly(path string) (map[string][]Line, error) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if attributeLine.Match([]byte(line)) {
+		if attributeLine.MatchString(line) {
 			continue
-		} else if nameLine.Match([]byte(line)) {
+		} else if nameLine.MatchString(line) {
 			functionName = strings.Split(line, ":")[0]
 			functions[functionName] = make([]Line, 0)
-		} else if labelLine.Match([]byte(line)) {
+		} else if labelLine.MatchString(line) {
 			labelName = strings.Split(line, ":")[0]
 			labelName = labelName[1:]
 			functions[functionName] = append(functions[functionName], Line{Label: labelName})
-		} else if codeLine.Match([]byte(line)) {
+		} else if codeLine.MatchString(line) {
 			asm := strings.Split(line, "#")[0]
 			asm = strings.TrimSpace(asm)
 			if labelName == "" {
@@ -140,11 +140,11 @@ func parseObjectDump(dump string, functions map[string][]Line) error {
 	)
 	for i, line := range strings.Split(dump, "\n") {
 		line = strings.TrimSpace(line)
-		if symbolLine.Match([]byte(line)) {
+		if symbolLine.MatchString(line) {
 			functionName = strings.Split(line, "<")[1]
 			functionName = strings.Split(functionName, ">")[0]
 			lineNumber = 0
-		} else if dataLine.Match([]byte(line)) {
+		} else if dataLine.MatchString(line) {
 			data := strings.Split(line, ":")[1]
 			data = strings.TrimSpace(data)
 			splits := strings.Split(data, " ")

--- a/cmd/goat/parser_arm64.go
+++ b/cmd/goat/parser_arm64.go
@@ -78,12 +78,12 @@ func parseAssembly(path string) (map[string][]Line, error) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if attributeLine.Match([]byte(line)) {
+		if attributeLine.MatchString(line) {
 			continue
-		} else if nameLine.Match([]byte(line)) {
+		} else if nameLine.MatchString(line) {
 			functionName = strings.Split(line, ":")[0]
 			functions[functionName] = make([]Line, 0)
-		} else if labelLine.Match([]byte(line)) {
+		} else if labelLine.MatchString(line) {
 			labelName = strings.Split(line, ":")[0]
 			labelName = labelName[1:]
 			lines := functions[functionName]
@@ -92,7 +92,7 @@ func parseAssembly(path string) (map[string][]Line, error) {
 			} else {
 				lines[len(lines)-1].Labels = append(lines[len(lines)-1].Labels, labelName)
 			}
-		} else if codeLine.Match([]byte(line)) {
+		} else if codeLine.MatchString(line) {
 			asm := strings.Split(line, "#")[0]
 			asm = strings.TrimSpace(asm)
 			if labelName == "" {
@@ -118,11 +118,11 @@ func parseObjectDump(dump string, functions map[string][]Line) error {
 	)
 	for i, line := range strings.Split(dump, "\n") {
 		line = strings.TrimSpace(line)
-		if symbolLine.Match([]byte(line)) {
+		if symbolLine.MatchString(line) {
 			functionName = strings.Split(line, "<")[1]
 			functionName = strings.Split(functionName, ">")[0]
 			lineNumber = 0
-		} else if dataLine.Match([]byte(line)) {
+		} else if dataLine.MatchString(line) {
 			data := strings.Split(line, ":")[1]
 			data = strings.TrimSpace(data)
 			splits := strings.Split(data, " ")


### PR DESCRIPTION
We can use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` to avoid unnecessary `[]byte` conversions and reduce allocations.

Example benchmark:

```go
package main_test

import (
	"regexp"
	"testing"
)

var testRegex = regexp.MustCompile(`\w+`)

func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := testRegex.Match([]byte("FOO")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := testRegex.MatchString("FOO"); !match {
			b.Fail()
		}
	}
}
```

Result:
```
goos: linux
goarch: amd64
pkg: github.com/zhenghaoz/gorse/cmd/goat
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	11826721	       138.9 ns/op	       3 B/op	       1 allocs/op
BenchmarkMatchString-16    	12954583	        88.85 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/zhenghaoz/gorse/cmd/goat	3.843s
```