### PR TITLE
goat: Add missing error handling for objdump

### DIFF
--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -150,7 +150,10 @@ func (t *TranslateUnit) Translate() error {
 	if err != nil {
 		return err
 	}
-	dump, _ := runCommand("objdump", "-d", t.Object, "--insn-width", "16")
+	dump, err := runCommand("objdump", "-d", t.Object, "--insn-width", "16")
+	if err != nil {
+		return err
+	}
 	err = parseObjectDump(dump, assembly)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds a missing error handling when calling `objdump` which can result in some false positives.