### PR TITLE
goat: Add -e --extra-option

### DIFF
--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -295,6 +295,10 @@ var command = &cobra.Command{
 		for _, m := range machineOptions {
 			options = append(options, "-m"+m)
 		}
+		extraOptions, _ := cmd.PersistentFlags().GetStringSlice("extra-option")
+		for _, e := range extraOptions {
+			options = append(options, e)
+		}
 		optimizeLevel, _ := cmd.PersistentFlags().GetInt("optimize-level")
 		options = append(options, fmt.Sprintf("-O%d", optimizeLevel))
 		file := NewTranslateUnit(args[0], output, options...)
@@ -308,6 +312,7 @@ var command = &cobra.Command{
 func init() {
 	command.PersistentFlags().StringP("output", "o", "", "output directory of generated files")
 	command.PersistentFlags().StringSliceP("machine-option", "m", nil, "machine option for clang")
+	command.PersistentFlags().StringSliceP("extra-option", "e", nil, "extra option for clang")
 	command.PersistentFlags().IntP("optimize-level", "O", 0, "optimization level for clang")
 }
 

--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -296,9 +296,7 @@ var command = &cobra.Command{
 			options = append(options, "-m"+m)
 		}
 		extraOptions, _ := cmd.PersistentFlags().GetStringSlice("extra-option")
-		for _, e := range extraOptions {
-			options = append(options, e)
-		}
+		options = append(options, extraOptions...)
 		optimizeLevel, _ := cmd.PersistentFlags().GetInt("optimize-level")
 		options = append(options, fmt.Sprintf("-O%d", optimizeLevel))
 		file := NewTranslateUnit(args[0], output, options...)


### PR DESCRIPTION
This adds a new option to goat that allows passing raw options to clang, which the "-m" option doesn't allow.

Example usage: `-e="--target=aarch64-arm-none-eabi"`