### PR TITLE
Fixes #754: Allow redis+cluster prefix to valid cache store prefixes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -613,6 +613,7 @@ func (config *Config) Validate(oneModel bool) error {
 		prefixes := []string{
 			storage.RedisPrefix,
 			storage.RedissPrefix,
+			storage.RedisClusterPrefix,
 			storage.MongoPrefix,
 			storage.MongoSrvPrefix,
 			storage.MySQLPrefix,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -210,6 +210,7 @@ func TestTablePrefixCompat(t *testing.T) {
 	data, err := os.ReadFile("config.toml")
 	assert.NoError(t, err)
 	text := string(data)
+	text = strings.Replace(text, "cache_store = \"redis://localhost:6379/0\"", "cache_store = \"redis+cluster://localhost:6379/0\"", -1)
 	text = strings.Replace(text, "cache_table_prefix = \"\"", "", -1)
 	text = strings.Replace(text, "data_table_prefix = \"\"", "", -1)
 	text = strings.Replace(text, "table_prefix = \"\"", "table_prefix = \"gorse_\"", -1)
@@ -222,6 +223,7 @@ func TestTablePrefixCompat(t *testing.T) {
 	assert.Equal(t, "gorse_", config.Database.TablePrefix)
 	assert.Equal(t, "gorse_", config.Database.CacheTablePrefix)
 	assert.Equal(t, "gorse_", config.Database.DataTablePrefix)
+	assert.Equal(t, "redis+cluster://localhost:6379/0", config.Database.CacheStore)
 }
 
 func TestConfig_UserNeighborDigest(t *testing.T) {

--- a/storage/scheme.go
+++ b/storage/scheme.go
@@ -29,14 +29,15 @@ import (
 )
 
 const (
-	MySQLPrefix      = "mysql://"
-	MongoPrefix      = "mongodb://"
-	MongoSrvPrefix   = "mongodb+srv://"
-	PostgresPrefix   = "postgres://"
-	PostgreSQLPrefix = "postgresql://"
-	SQLitePrefix     = "sqlite://"
-	RedisPrefix      = "redis://"
-	RedissPrefix     = "rediss://"
+	MySQLPrefix        = "mysql://"
+	MongoPrefix        = "mongodb://"
+	MongoSrvPrefix     = "mongodb+srv://"
+	PostgresPrefix     = "postgres://"
+	PostgreSQLPrefix   = "postgresql://"
+	SQLitePrefix       = "sqlite://"
+	RedisClusterPrefix = "redis+cluster://"
+	RedisPrefix        = "redis://"
+	RedissPrefix       = "rediss://"
 )
 
 func AppendURLParams(rawURL string, params []lo.Tuple2[string, string]) (string, error) {


### PR DESCRIPTION
I added the unit test to validate in an existing prefix test but I could see it becoming it's own test if there was a want to test all the valid prefixes.