### PR TITLE
Resolve issues in the current master branch

### DIFF
--- a/storage/cache/redis.go
+++ b/storage/cache/redis.go
@@ -449,8 +449,7 @@ func (r *Redis) AddTimeSeriesPoints(ctx context.Context, points []TimeSeriesPoin
 func (r *Redis) GetTimeSeriesPoints(ctx context.Context, name string, begin, end time.Time) ([]TimeSeriesPoint, error) {
 	// The tag `name` most likely contains a `/', and the snippet below
 	// escapes it with `\` to ensure proper functioning of RediSearch
-	// filters. For more context, refer to the issue at:
-	// https://github.com/RediSearch/RediSearch/issues/2566.
+	// filters.
 	escaped_name := strings.ReplaceAll(name, "/", "\\/")
 
 	result, err := r.client.Do(ctx, "FT.SEARCH", r.PointsTable(),


### PR DESCRIPTION
Here's a summary of the fixes:

1. Revised the `@timestamp:[-inf,%d]` filter to `@timestamp:[-inf (%d]` in `DeleteDocuments()` to ensure the correct deletion logic, focusing on records with timestamps less than the provided value.

2. When a tag name contains a forward slash `/`, the `RedisSearch` filter fails to work; the issue is resolved by escaping the forward slash with a backward slash `\`.

3. Updated `GetTimeSeriesPoints()` to utilize `DESC` order to make sure the dashboard displays the latest data.

4. Addressed the need for `/api/dashboard/rates` to send an empty array rather than `null`, particularly when the positive feedbacks data is empty. This adjustment ensures the successful rendering of the feedback rate graph on the dashboard UI.