### PR TITLE
Fix panic on startup

### DIFF
--- a/base/search/ivf.go
+++ b/base/search/ivf.go
@@ -215,6 +215,9 @@ func (idx *IVF) Build(_ context.Context) {
 						nextDistance = d
 					}
 				}
+				if nextCluster == -1 {
+					return nil
+				}
 				if nextCluster != assignments[i] {
 					errorCount.Inc()
 				}


### PR DESCRIPTION
This pull fixes an index out-of-bounds error on startup. Under the right conditions this occurs every time.
Repro data available if needed.

Related to #585