### PR TITLE
hnsw: add ability to configure ef search

### DIFF
--- a/base/search/hnsw_test.go
+++ b/base/search/hnsw_test.go
@@ -15,8 +15,9 @@
 package search
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHNSWConfig(t *testing.T) {
@@ -30,4 +31,7 @@ func TestHNSWConfig(t *testing.T) {
 
 	SetEFConstruction(345)(hnsw)
 	assert.Equal(t, 345, hnsw.efConstruction)
+
+	SetEF(456)(hnsw)
+	assert.Equal(t, 456, hnsw.ef)
 }


### PR DESCRIPTION
I needed a quick solution for using HNSW in Go and found this package nice, but noticed that it forces `ef` = `efConstruction`. I'm optimizing for a use case where I build an effectively static index. Build time doesn't matter to me but query speed and recall do. So I want to be able to set `efConstruction` high but keep `ef` where it is.

I've left this behaving in exactly the same manner as before as the default.