### PR TITLE
Re-Enable Redis+Cluster since RediSearch works in cluster with the right plugin.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -615,6 +615,7 @@ func (config *Config) Validate(oneModel bool) error {
 		prefixes := []string{
 			storage.RedisPrefix,
 			storage.RedissPrefix,
+			storage.RedisClusterPrefix,
 			storage.MongoPrefix,
 			storage.MongoSrvPrefix,
 			storage.MySQLPrefix,


### PR DESCRIPTION
Redis cluster support was removed in #645 for the reason:

> Remove Redis cluster support since RediSearch is unavailable on Redis cluster.

This appears to be incorrect or outdated. RediSearch can be built with RediSearch Coordinator and then works in a Redis+Cluster.

See: https://forum.redis.com/t/anything-to-do-to-get-redisearch-to-search-across-clusters/1943/6 

This information is a bit hard to find but I am running a test setup for gorse 0.4 with a redis+cluster without noticeable problems.

```
6) 1) "name"
   2) "search"
   3) "ver"
   4) (integer) 20811
   5) "path"
   6) "/opt/redis-stack/contrib/lib/module-oss.so"
   7) "args"
   8) (empty list or set)
```
   
The main branch is broken for me, so I am working based off 0.4 and am submitting the pull request for 0.4 as well.





