### PR TITLE
Don't drop collaborative filter cache

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -881,7 +881,7 @@ func (w *Worker) collaborativeRecommendHNSW(rankingIndex *logics.MatrixFactoriza
 		log.Logger().Error("failed to cache collaborative filtering recommendation result", zap.String("user_id", userId), zap.Error(err))
 		return nil, 0, errors.Trace(err)
 	}
-	if err := w.CacheClient.DeleteScores(ctx, []string{cache.CollaborativeRecommend}, cache.ScoreCondition{Before: &localStartTime}); err != nil {
+	if err := w.CacheClient.DeleteScores(ctx, []string{cache.CollaborativeRecommend}, cache.ScoreCondition{Before: &localStartTime, Subset: proto.String(userId)}); err != nil {
 		log.Logger().Error("failed to delete stale collaborative filtering recommendation result", zap.String("user_id", userId), zap.Error(err))
 		return nil, 0, errors.Trace(err)
 	}


### PR DESCRIPTION
I was troubleshooting the collaborative filter cache on `0.5.0-alpha.3`, because I couldn't ever get any results. Checking the cache, it turns out there were cached scores only for a single user. I then happened to notice a line in the logs:
```json
{"level":"warn","ts":1742640774.941021,"msg":"trace","elapsed":0.141572246,"rows":200,"sql":"DELETE FROM \"documents\" WHERE collection in ('collaborative_recommend') and timestamp < '2025-03-22 10:52:54.693'"}
```
So it seemed that it was dropping _basically all_ collaborative filter scores. Looking at the code, I believe it's missing a filter condition to only delete the cached scores for the user that was just updated.

Should you choose to merge this, would it be possible to also release a new docker image?

Thanks!