### PR TITLE
Set correct timestamp on collaborative filter scores

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -868,6 +868,11 @@ func (w *Worker) collaborativeRecommendHNSW(rankingIndex *logics.MatrixFactoriza
 	// save result
 	recommend := make(map[string][]string)
 	for _, score := range scores {
+		// the scores use the timestamp of the ranking index, which is only refreshed every so often.
+		// if we don't overwrite the timestamp here, the code below will delete all scores that were
+		// just written.
+		score.Timestamp = localStartTime
+
 		if !excludeSet.Contains(score.Id) && itemCache.IsAvailable(score.Id) {
 			for _, category := range score.Categories {
 				recommend[category] = append(recommend[category], score.Id)


### PR DESCRIPTION
I was still seeing issues with collaborative filter recommendations not being written. Debugging the code revealed that this was because the scores were written to the cache with a timestamp that was before the `localStartTime` (specifically, the timestamp from the ranking index). This meant that all scores were deleted immediately after being written.