### PR TITLE
Correctly overwrite score timestamp

### DIFF
--- a/worker/worker.go
+++ b/worker/worker.go
@@ -867,15 +867,14 @@ func (w *Worker) collaborativeRecommendHNSW(rankingIndex *logics.MatrixFactoriza
 	scores := rankingIndex.Search(w.RankingModel.GetUserFactor(userIndex), w.Config.Recommend.CacheSize+excludeSet.Cardinality())
 	// save result
 	recommend := make(map[string][]string)
-	for _, score := range scores {
+	for i := range scores {
 		// the scores use the timestamp of the ranking index, which is only refreshed every so often.
 		// if we don't overwrite the timestamp here, the code below will delete all scores that were
 		// just written.
-		score.Timestamp = localStartTime
-
-		if !excludeSet.Contains(score.Id) && itemCache.IsAvailable(score.Id) {
-			for _, category := range score.Categories {
-				recommend[category] = append(recommend[category], score.Id)
+		scores[i].Timestamp = localStartTime
+		if !excludeSet.Contains(scores[i].Id) && itemCache.IsAvailable(scores[i].Id) {
+			for _, category := range scores[i].Categories {
+				recommend[category] = append(recommend[category], scores[i].Id)
 			}
 		}
 	}


### PR DESCRIPTION
Previous change in #968 was ineffectual, because the `scores` slice are struct types, not pointers (duh). My local testing setup was flawed and masked the  error still existing.

This change should actually fix the underlying issue.