### PR TITLE
Fix non personalized data race

### DIFF
--- a/logics/non_personalized.go
+++ b/logics/non_personalized.go
@@ -28,10 +28,12 @@ import (
 	"go.uber.org/zap"
 	"reflect"
 	"sort"
+	"sync"
 	"time"
 )
 
 type NonPersonalized struct {
+	sync.Mutex
 	name       string
 	timestamp  time.Time
 	scoreFunc  *vm.Program
@@ -147,6 +149,8 @@ func (l *NonPersonalized) Push(item data.Item, feedback []data.Feedback) {
 		return
 	}
 	// Add to heap
+	l.Lock()
+	defer l.Unlock()
 	l.heaps[""].Push(item.ItemId, score)
 	for _, group := range item.Categories {
 		if _, exist := l.heaps[group]; !exist {
@@ -158,6 +162,8 @@ func (l *NonPersonalized) Push(item data.Item, feedback []data.Feedback) {
 
 func (l *NonPersonalized) PopAll() []cache.Score {
 	scores := make(map[string]*cache.Score)
+	l.Lock()
+	defer l.Unlock()
 	for category, h := range l.heaps {
 		names, values := h.PopAll()
 		for i, name := range names {


### PR DESCRIPTION
After change the n_jobs > 1, gorse service will panic with this log:
```
Apr 24 20:22:54 test gorse-in-one[1231493]: fatal error: concurrent map read and map write
Apr 24 20:22:54 test gorse-in-one[1231493]: goroutine 145 [running]:
Apr 24 20:22:54 test gorse-in-one[1231493]: github.com/zhenghaoz/gorse/logics.(*NonPersonalized).Push(0xc000a8a6e0, {{0xc000648380, 0x20}, 0x0, {0xc000656900, 0x3, 0x4}, {0x1139ca40, 0xedf9c0aaa, 0x0}, ...}, ...)
Apr 24 20:22:54 test gorse-in-one[1231493]:         /home/runner/work/gorse/gorse/logics/non_personalized.go:150 +0x4ea
Apr 24 20:22:54 test gorse-in-one[1231493]: github.com/zhenghaoz/gorse/master.(*Master).LoadDataFromDatabase.func2(0x524c66ab166a5109?, 0xc3ea583eaa4aef77?)
Apr 24 20:22:54 test gorse-in-one[1231493]:         /home/runner/work/gorse/gorse/master/tasks.go:1644 +0x78e
Apr 24 20:22:54 test gorse-in-one[1231493]: github.com/zhenghaoz/gorse/base/parallel.Parallel.func2(0x3)
Apr 24 20:22:54 test gorse-in-one[1231493]:         /home/runner/work/gorse/gorse/base/parallel/parallel.go:69 +0xb0
Apr 24 20:22:54 test gorse-in-one[1231493]: created by github.com/zhenghaoz/gorse/base/parallel.Parallel in goroutine 47
Apr 24 20:22:54 test gorse-in-one[1231493]:         /home/runner/work/gorse/gorse/base/parallel/parallel.go:59 +0x127
```