### PR TITLE
Fix redis empty category

### DIFF
--- a/server/rest.go
+++ b/server/rest.go
@@ -1872,7 +1872,7 @@ func (s *RestServer) getTypedUserItemFeedback(request *restful.Request, response
 	itemId := request.PathParameter("item-id")
 	if feedback, err := s.DataClient.GetUserItemFeedback(ctx, userId, itemId, feedbackType); err != nil {
 		InternalServerError(response, err)
-	} else if feedbackType == "" {
+	} else if feedbackType == "" || len(feedback) == 0 {
 		Text(response, "{}")
 	} else {
 		Ok(response, feedback[0])

--- a/storage/cache/redis.go
+++ b/storage/cache/redis.go
@@ -475,6 +475,9 @@ func decodeCategory(s string) (string, error) {
 	if err != nil {
 		return "", errors.Trace(err)
 	}
+	if len(b) == 0 {
+		return "", nil
+	}
 	return string(b[1:]), nil
 }
 
@@ -496,7 +499,9 @@ func decodeCategories(s string) ([]string, error) {
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		categories = append(categories, category)
+		if len(category) > 0 {
+			categories = append(categories, category)
+		}
 	}
 	return categories, nil
 }


### PR DESCRIPTION
When setting `auto_insert_item = true`, user feedback with a nonexist itemid will generate a empty record in the database, this action will cause bellow panic
```
Apr 27 01:01:21 test gorse-in-one[1304502]: 2025/04/27 01:01:21 http: panic serving 192.168.0.2:54280: runtime error: slice bounds out of range [1:0]
Apr 27 01:01:21 test gorse-in-one[1304502]: goroutine 13846 [running]:
Apr 27 01:01:21 test gorse-in-one[1304502]: net/http.(*conn).serve.func1()
Apr 27 01:01:21 test gorse-in-one[1304502]:         net/http/server.go:1947 +0xbe
Apr 27 01:01:21 test gorse-in-one[1304502]: panic({0x5a172a417f20?, 0xc000176768?})
Apr 27 01:01:21 test gorse-in-one[1304502]:         runtime/panic.go:792 +0x132
Apr 27 01:01:21 test gorse-in-one[1304502]: github.com/zhenghaoz/gorse/storage/cache.decodeCategory({0x0?, 0x0?})
Apr 27 01:01:21 test gorse-in-one[1304502]:         github.com/zhenghaoz/gorse/storage/cache/redis.go:478 +0x88
Apr 27 01:01:21 test gorse-in-one[1304502]: github.com/zhenghaoz/gorse/storage/cache.decodeCategories({0x0?, 0x1?})
Apr 27 01:01:21 test gorse-in-one[1304502]:         github.com/zhenghaoz/gorse/storage/cache/redis.go:495 +0x91
Apr 27 01:01:21 test gorse-in-one[1304502]: github.com/zhenghaoz/gorse/storage/cache.(*Redis).SearchScores(0xc0005e7560, {0x5a172a535188, 0xc0008753e0}, {0x5a17286cb052?,>
Apr 27 01:01:21 test gorse-in-one[1304502]:         github.com/zhenghaoz/gorse/storage/cache/redis.go:316 +0x82e
Apr 27 01:01:21 test gorse-in-one[1304502]: github.com/zhenghaoz/gorse/server.(*RestServer).SearchDocuments(0xc000666788, {0x5a17286cb052, 0xc}, {0xc00179a0e0, 0xb}, {0x0>
Apr 27 01:01:21 test gorse-in-one[1304502]:         github.com/zhenghaoz/gorse/server/rest.go:653 +0x38a
Apr 27 01:01:21 test gorse-in-one[1304502]: github.com/zhenghaoz/gorse/master.(*Master).getItemToItem(0xc000666788, 0xc00083a000, 0xc000690070)
Apr 27 01:01:21 test gorse-in-one[1304502]:         github.com/zhenghaoz/gorse/master/rest.go:863 +0x1b2
Apr 27 01:01:21 test gorse-in-one[1304502]: github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0xc000718000?, 0x5a172a535188?, 0xc0008753e0?)
```
and also this one
```
Apr 27 01:58:09 test gorse-in-one[1429087]: 2025/04/27 01:58:09 http: panic serving 192.168.0.2:51256: runtime error: index out of range [0] with length 0
Apr 27 01:58:09 test gorse-in-one[1429087]: goroutine 574 [running]:
Apr 27 01:58:09 test gorse-in-one[1429087]: net/http.(*conn).serve.func1()
Apr 27 01:58:09 test gorse-in-one[1429087]:         net/http/server.go:1947 +0xbe
Apr 27 01:58:09 test gorse-in-one[1429087]: panic({0x5d3777f7af20?, 0xc002d5fb48?})
Apr 27 01:58:09 test gorse-in-one[1429087]:         runtime/panic.go:792 +0x132
Apr 27 01:58:09 test gorse-in-one[1429087]: github.com/zhenghaoz/gorse/server.(*RestServer).getTypedUserItemFeedback(0xc000672788, 0xc002d7ebe0, 0xc000752bd0)
Apr 27 01:58:09 test gorse-in-one[1429087]:         github.com/zhenghaoz/gorse/server/rest.go:1878 +0x245
Apr 27 01:58:09 test gorse-in-one[1429087]: github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0xc0006617c0?, 0x5d3778098188?, 0xc002d6aae0?)
Apr 27 01:58:09 test gorse-in-one[1429087]:         github.com/emicklei/go-restful/v3@v3.9.0/filter.go:23 +0x53
Apr 27 01:58:09 test gorse-in-one[1429087]: go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful.OTelFilter.func1(0xc002d7ebe0, 0xc00075>
Apr 27 01:58:09 test gorse-in-one[1429087]:         go.opentelemetry.io/contrib/instrumentation/github.com/emicklei/go-restful/otelrestful@v0.36.4/restful.go:65 +0x46f
Apr 27 01:58:09 test gorse-in-one[1429087]: github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0x200000003?, 0x0?, 0x0?)
Apr 27 01:58:09 test gorse-in-one[1429087]:         github.com/emicklei/go-restful/v3@v3.9.0/filter.go:21 +0x42
Apr 27 01:58:09 test gorse-in-one[1429087]: github.com/zhenghaoz/gorse/server.(*RestServer).MetricsFilter(0x148?, 0xc002d7ebe0, 0xc000752bd0, 0xc002c7fdb0)
Apr 27 01:58:09 test gorse-in-one[1429087]:         github.com/zhenghaoz/gorse/server/rest.go:161 +0x66
```