### PR TITLE
Empty category name and missing category entry should be two different options

### DIFF
--- a/server/rest.go
+++ b/server/rest.go
@@ -2015,6 +2015,13 @@ func ReadCategories(request *restful.Request) []string {
 	} else if queryValues := request.QueryParameters("category"); len(queryValues) > 0 {
 		return queryValues
 	} else {
+		_, ok := request.PathParameters()["category"]
+		if !ok {
+			_, ok = request.Request.URL.Query()["category"]
+			if !ok {
+				return nil
+			}
+		}
 		return []string{""}
 	}
 }


### PR DESCRIPTION
Empty category and missing category entry will be treat as different
```
// Get items with empty category
GET /api/popular/?category=
```
```
// Get items in all category
GET /api/popular
```