### PR TITLE
database: change redis timeseries default duplicate policy to LAST

### DIFF
--- a/storage/cache/redis.go
+++ b/storage/cache/redis.go
@@ -414,8 +414,9 @@ func (r *Redis) DeleteScores(ctx context.Context, collections []string, conditio
 
 func (r *Redis) AddTimeSeriesPoints(ctx context.Context, points []TimeSeriesPoint) error {
 	p := r.client.Pipeline()
+	opt := &redis.TSOptions{DuplicatePolicy: "LAST"}
 	for _, point := range points {
-		if err := p.TSAdd(ctx, r.PointsTable()+":"+point.Name, point.Timestamp.UnixMilli(), point.Value).Err(); err != nil {
+		if err := p.TSAddWithArgs(ctx, r.PointsTable()+":"+point.Name, point.Timestamp.UnixMilli(), point.Value, opt).Err(); err != nil {
 			return errors.Trace(err)
 		}
 	}


### PR DESCRIPTION
As the redis timeseries said, the default duplicate policy is BLOCK，so the timeseries record will not update after the item was created.
https://redis.io/docs/latest/develop/data-types/timeseries/configuration/#duplicate_policy--ts-duplicate-policy

This will raise a “ERR TSDB: Error at upsert, update is not supported when DUPLICATE_POLICY is set to BLOCK mode" error.