### PR TITLE
Fix hidden and expired items in recommendation results

### DIFF
--- a/logics/recommend.go
+++ b/logics/recommend.go
@@ -167,20 +167,27 @@ func (r *Recommender) filterAvailableItems(items []data.Item) []data.Item {
 	})
 }
 
-// filterAvailableScores removes hidden or expired items when current item metadata is available.
-func (r *Recommender) filterAvailableScores(ctx context.Context, scores []cache.Score) ([]cache.Score, error) {
-	if len(scores) == 0 {
-		return scores, nil
+func (r *Recommender) batchGetItemsMap(ctx context.Context, ids []string) (map[string]data.Item, error) {
+	if len(ids) == 0 {
+		return map[string]data.Item{}, nil
 	}
-	items, err := r.dataClient.BatchGetItems(ctx, lo.Map(scores, func(score cache.Score, _ int) string {
-		return score.Id
-	}))
+	items, err := r.dataClient.BatchGetItems(ctx, ids)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	itemsMap := make(map[string]data.Item, len(items))
 	for _, item := range items {
 		itemsMap[item.ItemId] = item
+	}
+	return itemsMap, nil
+}
+
+func (r *Recommender) filterAvailableScores(ctx context.Context, scores []cache.Score) ([]cache.Score, error) {
+	itemsMap, err := r.batchGetItemsMap(ctx, lo.Map(scores, func(score cache.Score, _ int) string {
+		return score.Id
+	}))
+	if err != nil {
+		return nil, errors.Trace(err)
 	}
 	expireBefore := r.expireBefore()
 	return lo.Filter(scores, func(score cache.Score, _ int) bool {
@@ -195,8 +202,7 @@ func (r *Recommender) searchAvailableScores(ctx context.Context, collection, sub
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		scores, err = r.filterAvailableScores(ctx, scores)
-		return scores, errors.Trace(err)
+		return r.filterAvailableScores(ctx, scores)
 	}
 	results := make([]cache.Score, 0, r.config.CacheSize)
 	for begin := 0; ; begin += r.config.CacheSize {
@@ -204,8 +210,8 @@ func (r *Recommender) searchAvailableScores(ctx context.Context, collection, sub
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		n := len(scores)
-		if n == 0 {
+		pageSize := len(scores)
+		if pageSize == 0 {
 			return results, nil
 		}
 		scores, err = r.filterAvailableScores(ctx, scores)
@@ -216,7 +222,7 @@ func (r *Recommender) searchAvailableScores(ctx context.Context, collection, sub
 		if len(results) >= r.config.CacheSize {
 			return results[:r.config.CacheSize], nil
 		}
-		if n < r.config.CacheSize {
+		if pageSize < r.config.CacheSize {
 			return results, nil
 		}
 	}
@@ -294,7 +300,6 @@ func (r *Recommender) recommendNonPersonalized(name string) RecommenderFunc {
 		} else {
 			categories = r.categories
 		}
-		// fetch items from cache
 		items, err := r.searchAvailableScores(ctx, cache.NonPersonalized, name, categories)
 		if err != nil {
 			return nil, "", errors.Trace(err)
@@ -305,14 +310,13 @@ func (r *Recommender) recommendNonPersonalized(name string) RecommenderFunc {
 			return nil, "", errors.Trace(err)
 		}
 		// remove excluded items
-		return lo.Filter(items, func(item cache.Score, index int) bool {
+		return lo.Filter(items, func(item cache.Score, _ int) bool {
 			return !r.excludeSet.Contains(item.Id)
 		}), digest, nil
 	}
 }
 
 func (r *Recommender) recommendCollaborative(ctx context.Context) ([]cache.Score, string, error) {
-	// fetch items from cache
 	items, err := r.searchAvailableScores(ctx, cache.CollaborativeFiltering, r.userId, r.categories)
 	if err != nil {
 		return nil, "", errors.Trace(err)
@@ -323,7 +327,7 @@ func (r *Recommender) recommendCollaborative(ctx context.Context) ([]cache.Score
 		return nil, "", errors.Trace(err)
 	}
 	// remove excluded items
-	return lo.Filter(items, func(item cache.Score, index int) bool {
+	return lo.Filter(items, func(item cache.Score, _ int) bool {
 		return !r.excludeSet.Contains(item.Id)
 	}), digest, nil
 }
@@ -416,13 +420,9 @@ func (r *Recommender) recommendUserToUser(name string) RecommenderFunc {
 		ids := lo.Map(elems, func(elem heap.Elem[string, float64], _ int) string {
 			return elem.Value
 		})
-		items, err := r.dataClient.BatchGetItems(ctx, ids)
+		itemsMap, err := r.batchGetItemsMap(ctx, ids)
 		if err != nil {
 			return nil, "", errors.Trace(err)
-		}
-		itemsMap := make(map[string]data.Item)
-		for _, item := range items {
-			itemsMap[item.ItemId] = item
 		}
 		expireBefore := r.expireBefore()
 		for _, elem := range elems {

--- a/logics/recommend.go
+++ b/logics/recommend.go
@@ -97,7 +97,7 @@ func (r *Recommender) IsColdStart() bool {
 
 func (r *Recommender) Recommend(ctx context.Context, limit int) (result []cache.Score, err error) {
 	if !strings.EqualFold(r.config.Ranker.Type, "none") {
-		scores, err := r.cacheClient.SearchScores(ctx, cache.Recommend, r.userId, r.categories, 0, r.config.CacheSize)
+		scores, err := r.searchAvailableScores(ctx, cache.Recommend, r.userId, r.categories)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -146,6 +146,106 @@ func (r *Recommender) RecommendSequential(ctx context.Context, result []cache.Sc
 	return result, util.MD5(digests...), nil
 }
 
+func (r *Recommender) expireBefore() time.Time {
+	if r.config.DataSource.ItemTTL == 0 {
+		return time.Time{}
+	}
+	return time.Now().AddDate(0, 0, -int(r.config.DataSource.ItemTTL))
+}
+
+func availableItem(item data.Item, expireBefore time.Time) bool {
+	if item.IsHidden {
+		return false
+	}
+	return expireBefore.IsZero() || item.Timestamp.IsZero() || !item.Timestamp.Before(expireBefore)
+}
+
+func (r *Recommender) filterAvailableItems(items []data.Item) []data.Item {
+	expireBefore := r.expireBefore()
+	return lo.Filter(items, func(item data.Item, _ int) bool {
+		return availableItem(item, expireBefore)
+	})
+}
+
+// filterAvailableScores removes hidden or expired items when current item metadata is available.
+func (r *Recommender) filterAvailableScores(ctx context.Context, scores []cache.Score) ([]cache.Score, error) {
+	if len(scores) == 0 {
+		return scores, nil
+	}
+	items, err := r.dataClient.BatchGetItems(ctx, lo.Map(scores, func(score cache.Score, _ int) string {
+		return score.Id
+	}))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	itemsMap := make(map[string]data.Item, len(items))
+	for _, item := range items {
+		itemsMap[item.ItemId] = item
+	}
+	expireBefore := r.expireBefore()
+	return lo.Filter(scores, func(score cache.Score, _ int) bool {
+		item, ok := itemsMap[score.Id]
+		return !ok || availableItem(item, expireBefore)
+	}), nil
+}
+
+func (r *Recommender) searchAvailableScores(ctx context.Context, collection, subset string, categories []string) ([]cache.Score, error) {
+	if r.config.CacheSize <= 0 {
+		scores, err := r.cacheClient.SearchScores(ctx, collection, subset, categories, 0, -1)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		scores, err = r.filterAvailableScores(ctx, scores)
+		return scores, errors.Trace(err)
+	}
+	results := make([]cache.Score, 0, r.config.CacheSize)
+	for begin := 0; ; begin += r.config.CacheSize {
+		scores, err := r.cacheClient.SearchScores(ctx, collection, subset, categories, begin, begin+r.config.CacheSize)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		n := len(scores)
+		if n == 0 {
+			return results, nil
+		}
+		scores, err = r.filterAvailableScores(ctx, scores)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		results = append(results, scores...)
+		if len(results) >= r.config.CacheSize {
+			return results[:r.config.CacheSize], nil
+		}
+		if n < r.config.CacheSize {
+			return results, nil
+		}
+	}
+}
+
+func (r *Recommender) getLatestAvailableItems(ctx context.Context) ([]data.Item, error) {
+	if r.config.CacheSize <= 0 {
+		items, err := r.dataClient.GetLatestItems(ctx, 0, r.categories)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		return r.filterAvailableItems(items), nil
+	}
+	for n := r.config.CacheSize; ; n += r.config.CacheSize {
+		items, err := r.dataClient.GetLatestItems(ctx, n, r.categories)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		m := len(items)
+		items = r.filterAvailableItems(items)
+		if len(items) >= r.config.CacheSize {
+			return items[:r.config.CacheSize], nil
+		}
+		if m < n {
+			return items, nil
+		}
+	}
+}
+
 func (r *Recommender) parse(fullname string) (RecommenderFunc, error) {
 	if fullname == CollaborativeRecommender {
 		return r.recommendCollaborative, nil
@@ -169,7 +269,7 @@ func (r *Recommender) parse(fullname string) (RecommenderFunc, error) {
 }
 
 func (r *Recommender) recommendLatest(ctx context.Context) ([]cache.Score, string, error) {
-	items, err := r.dataClient.GetLatestItems(ctx, r.config.CacheSize, r.categories)
+	items, err := r.getLatestAvailableItems(ctx)
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
@@ -195,7 +295,7 @@ func (r *Recommender) recommendNonPersonalized(name string) RecommenderFunc {
 			categories = r.categories
 		}
 		// fetch items from cache
-		items, err := r.cacheClient.SearchScores(ctx, cache.NonPersonalized, name, categories, 0, r.config.CacheSize)
+		items, err := r.searchAvailableScores(ctx, cache.NonPersonalized, name, categories)
 		if err != nil {
 			return nil, "", errors.Trace(err)
 		}
@@ -213,7 +313,7 @@ func (r *Recommender) recommendNonPersonalized(name string) RecommenderFunc {
 
 func (r *Recommender) recommendCollaborative(ctx context.Context) ([]cache.Score, string, error) {
 	// fetch items from cache
-	items, err := r.cacheClient.SearchScores(ctx, cache.CollaborativeFiltering, r.userId, r.categories, 0, r.config.CacheSize)
+	items, err := r.searchAvailableScores(ctx, cache.CollaborativeFiltering, r.userId, r.categories)
 	if err != nil {
 		return nil, "", errors.Trace(err)
 	}
@@ -246,7 +346,7 @@ func (r *Recommender) recommendItemToItem(name string) RecommenderFunc {
 		categories := make(map[string][]string)
 		digests := mapset.NewSet[string]()
 		for _, feedback := range userFeedback {
-			similarItems, err := r.cacheClient.SearchScores(ctx, cache.ItemToItem, cache.Key(name, feedback.ItemId), r.categories, 0, r.config.CacheSize)
+			similarItems, err := r.searchAvailableScores(ctx, cache.ItemToItem, cache.Key(name, feedback.ItemId), r.categories)
 			if err != nil {
 				return nil, "", errors.Trace(err)
 			}
@@ -324,8 +424,11 @@ func (r *Recommender) recommendUserToUser(name string) RecommenderFunc {
 		for _, item := range items {
 			itemsMap[item.ItemId] = item
 		}
+		expireBefore := r.expireBefore()
 		for _, elem := range elems {
-			if item, ok := itemsMap[elem.Value]; ok && lo.Every(item.Categories, r.categories) {
+			if item, ok := itemsMap[elem.Value]; ok &&
+				lo.Every(item.Categories, r.categories) &&
+				availableItem(item, expireBefore) {
 				results = append(results, cache.Score{
 					Id:         item.ItemId,
 					Score:      elem.Weight,
@@ -368,6 +471,10 @@ func (r *Recommender) recommendExternal(name string) RecommenderFunc {
 					Id: itemId,
 				})
 			}
+		}
+		scores, err = r.filterAvailableScores(ctx, scores)
+		if err != nil {
+			return nil, "", errors.Trace(err)
 		}
 		return scores, externalConfig.Hash(), nil
 	}

--- a/logics/recommend_test.go
+++ b/logics/recommend_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorse-io/gorse/common/expression"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/storage/cache"
 	"github.com/gorse-io/gorse/storage/data"
@@ -51,6 +52,13 @@ func (suite *RecommenderTestSuite) TearDownSuite() {
 	err := suite.dataClient.Close()
 	suite.NoError(err)
 	err = suite.cacheClient.Close()
+	suite.NoError(err)
+}
+
+func (suite *RecommenderTestSuite) SetupTest() {
+	err := suite.dataClient.Purge()
+	suite.NoError(err)
+	err = suite.cacheClient.Purge()
 	suite.NoError(err)
 }
 
@@ -108,16 +116,23 @@ func (suite *RecommenderTestSuite) TestLatest() {
 
 func (suite *RecommenderTestSuite) TestCollaborative() {
 	recommends := make([]cache.Score, 20)
+	items := make([]data.Item, 20)
 	for i := 0; i < 20; i++ {
 		recommends[i] = cache.Score{
 			Id:    fmt.Sprintf("item_%d", i),
 			Score: float64(i),
 		}
+		items[i] = data.Item{
+			ItemId: fmt.Sprintf("item_%d", i),
+		}
 		if i%2 == 0 {
 			recommends[i].Categories = []string{"cat_1"}
+			items[i].Categories = []string{"cat_1"}
 		}
 	}
-	err := suite.cacheClient.AddScores(suite.T().Context(), cache.CollaborativeFiltering, "user_1", recommends)
+	err := suite.dataClient.BatchInsertItems(suite.T().Context(), items)
+	suite.NoError(err)
+	err = suite.cacheClient.AddScores(suite.T().Context(), cache.CollaborativeFiltering, "user_1", recommends)
 	suite.NoError(err)
 	err = suite.cacheClient.Set(suite.T().Context(), cache.String(cache.Key(cache.CollaborativeFilteringDigest, "user_1"), "digest"))
 	suite.NoError(err)
@@ -218,6 +233,238 @@ func (suite *RecommenderTestSuite) TestNonPersonalized() {
 	}
 }
 
+func (suite *RecommenderTestSuite) TestRecommendFallbackNonPersonalizedSkipsExpiredItems() {
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.NonPersonalized, "ttl", []cache.Score{
+		{Id: "non_personalized_expired", Score: 5, Categories: []string{""}},
+		{Id: "non_personalized_valid_1", Score: 4, Categories: []string{""}},
+		{Id: "non_personalized_valid_2", Score: 3, Categories: []string{""}},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.Set(suite.T().Context(), cache.String(cache.Key(cache.NonPersonalizedDigest, "ttl"), "digest"))
+	suite.NoError(err)
+	now := time.Now()
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "non_personalized_expired", Timestamp: now.Add(-48 * time.Hour)},
+		{ItemId: "non_personalized_valid_1", Timestamp: now.Add(-time.Hour)},
+		{ItemId: "non_personalized_valid_2", Timestamp: now.Add(-2 * time.Hour)},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize: 2,
+		DataSource: config.DataSourceConfig{
+			ItemTTL: 1,
+		},
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+		Fallback: config.FallbackConfig{
+			Recommenders: []string{"non-personalized/ttl"},
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "non_personalized_user", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 2)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "non_personalized_valid_1", Score: 4, Categories: []string{""}},
+		{Id: "non_personalized_valid_2", Score: 3, Categories: []string{""}},
+	}, scores)
+}
+
+func (suite *RecommenderTestSuite) TestRecommendFallbackItemToItemSkipsExpiredItems() {
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.ItemToItem, cache.Key("default", "item_to_item_seed"), []cache.Score{
+		{Id: "item_to_item_expired", Score: 5},
+		{Id: "item_to_item_valid_1", Score: 4},
+		{Id: "item_to_item_valid_2", Score: 3},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.Set(suite.T().Context(), cache.String(cache.Key(cache.ItemToItemDigest, "default", "item_to_item_seed"), "digest"))
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertFeedback(suite.T().Context(), []data.Feedback{
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "item_to_item_user", ItemId: "item_to_item_seed"}},
+	}, true, true, false)
+	suite.NoError(err)
+	now := time.Now()
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "item_to_item_expired", Timestamp: now.Add(-48 * time.Hour)},
+		{ItemId: "item_to_item_valid_1", Timestamp: now.Add(-time.Hour)},
+		{ItemId: "item_to_item_valid_2", Timestamp: now.Add(-2 * time.Hour)},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize:   2,
+		ContextSize: 10,
+		DataSource: config.DataSourceConfig{
+			ItemTTL:               1,
+			PositiveFeedbackTypes: []expression.FeedbackTypeExpression{expression.MustParseFeedbackTypeExpression("click")},
+		},
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+		Fallback: config.FallbackConfig{
+			Recommenders: []string{"item-to-item/default"},
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "item_to_item_user", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 2)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "item_to_item_valid_1", Score: 4},
+		{Id: "item_to_item_valid_2", Score: 3},
+	}, scores)
+}
+
+func (suite *RecommenderTestSuite) TestRecommendFallbackLatestSkipsExpiredItems() {
+	now := time.Now()
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.Recommend, "ttl_user", []cache.Score{
+		{Id: "ttl_rec_expired", Score: 10},
+		{Id: "ttl_rec_valid", Score: 9},
+		{Id: "ttl_rec_valid_2", Score: 8},
+	})
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "ttl_rec_expired", Timestamp: now.Add(-48 * time.Hour)},
+		{ItemId: "ttl_rec_valid", Timestamp: now.Add(-time.Hour)},
+		{ItemId: "ttl_rec_valid_2", Timestamp: now.Add(-2 * time.Hour)},
+		{ItemId: "ttl_latest_valid", Timestamp: now.Add(time.Hour)},
+		{ItemId: "ttl_latest_expired", Timestamp: now.Add(-47 * time.Hour)},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize: 2,
+		DataSource: config.DataSourceConfig{
+			ItemTTL: 1,
+		},
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+		Fallback: config.FallbackConfig{
+			Recommenders: []string{"latest"},
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "ttl_user", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 3)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "ttl_rec_valid", Score: 9},
+		{Id: "ttl_rec_valid_2", Score: 8},
+		{Id: "ttl_latest_valid", Score: float64(now.Add(time.Hour).Unix())},
+	}, scores)
+}
+
+func (suite *RecommenderTestSuite) TestRecommendFallbackUserToUserSkipsHiddenItems() {
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.Recommend, "user_to_user_target", []cache.Score{
+		{Id: "user_to_user_base_1", Score: 99},
+		{Id: "user_to_user_base_2", Score: 98},
+		{Id: "user_to_user_base_3", Score: 97},
+		{Id: "user_to_user_base_4", Score: 96},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.AddScores(suite.T().Context(), cache.UserToUser, cache.Key("default", "user_to_user_target"), []cache.Score{
+		{Id: "similar_user_1", Score: 2},
+		{Id: "similar_user_2", Score: 1.5},
+		{Id: "similar_user_3", Score: 1},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.Set(suite.T().Context(), cache.String(cache.Key(cache.UserToUserDigest, "default", "user_to_user_target"), "digest"))
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertFeedback(suite.T().Context(), []data.Feedback{
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "user_to_user_target", ItemId: "user_to_user_base_1"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "user_to_user_target", ItemId: "user_to_user_base_2"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "user_to_user_target", ItemId: "user_to_user_base_3"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "user_to_user_target", ItemId: "user_to_user_base_4"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "similar_user_1", ItemId: "user_to_user_item_11"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "similar_user_2", ItemId: "user_to_user_item_12"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "similar_user_2", ItemId: "user_to_user_item_48"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "similar_user_3", ItemId: "user_to_user_item_13"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "similar_user_3", ItemId: "user_to_user_item_48"}},
+	}, true, true, false)
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "user_to_user_item_48", IsHidden: true},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize: 10,
+		UserToUser: []config.UserToUserConfig{{
+			Name: "default",
+		}},
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+		Fallback: config.FallbackConfig{
+			Recommenders: []string{"user-to-user/default"},
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "user_to_user_target", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 3)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "user_to_user_item_11", Score: 2},
+		{Id: "user_to_user_item_12", Score: 1.5},
+		{Id: "user_to_user_item_13", Score: 1},
+	}, scores)
+}
+
+func (suite *RecommenderTestSuite) TestRecommendFallbackCollaborativeSkipsHiddenItems() {
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.Recommend, "collaborative_target", []cache.Score{
+		{Id: "collaborative_base_1", Score: 99},
+		{Id: "collaborative_base_2", Score: 98},
+		{Id: "collaborative_base_3", Score: 97},
+		{Id: "collaborative_base_4", Score: 96},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.AddScores(suite.T().Context(), cache.CollaborativeFiltering, "collaborative_target", []cache.Score{
+		{Id: "collaborative_item_13", Score: 79},
+		{Id: "collaborative_item_14", Score: 78},
+		{Id: "collaborative_item_15", Score: 77},
+		{Id: "collaborative_item_16", Score: 76},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.Set(suite.T().Context(), cache.String(cache.Key(cache.CollaborativeFilteringDigest, "collaborative_target"), "digest"))
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertFeedback(suite.T().Context(), []data.Feedback{
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "collaborative_target", ItemId: "collaborative_base_1"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "collaborative_target", ItemId: "collaborative_base_2"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "collaborative_target", ItemId: "collaborative_base_3"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "collaborative_target", ItemId: "collaborative_base_4"}},
+	}, true, true, false)
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "collaborative_item_13", IsHidden: true},
+		{ItemId: "collaborative_item_14"},
+		{ItemId: "collaborative_item_15"},
+		{ItemId: "collaborative_item_16"},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize: 3,
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+		Fallback: config.FallbackConfig{
+			Recommenders: []string{"collaborative"},
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "collaborative_target", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 3)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "collaborative_item_14", Score: 78},
+		{Id: "collaborative_item_15", Score: 77},
+		{Id: "collaborative_item_16", Score: 76},
+	}, scores)
+}
+
 func (suite *RecommenderTestSuite) TestExternal() {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		userId := r.URL.Query().Get("user_id")
@@ -243,11 +490,19 @@ func (suite *RecommenderTestSuite) TestExternal() {
 	suite.NoError(err)
 
 	cfg := config.RecommendConfig{
+		DataSource: config.DataSourceConfig{
+			ItemTTL: 1,
+		},
 		External: []config.ExternalConfig{{
 			Script: fmt.Sprintf(`fetch("%s?user_id=user_1").body`, ts.URL),
 			Name:   "test",
 		}},
 	}
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "item_200", IsHidden: true},
+		{ItemId: "item_300", Timestamp: time.Now().Add(-48 * time.Hour)},
+	})
+	suite.NoError(err)
 	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "user_1", nil)
 	suite.NoError(err)
 	recommendFunc := recommender.recommendExternal("test")
@@ -256,8 +511,6 @@ func (suite *RecommenderTestSuite) TestExternal() {
 	suite.Equal(cfg.External[0].Hash(), digest)
 	suite.Equal([]cache.Score{
 		{Id: "item_100", Score: 0},
-		{Id: "item_200", Score: 0},
-		{Id: "item_300", Score: 0},
 	}, scores)
 }
 

--- a/logics/recommend_test.go
+++ b/logics/recommend_test.go
@@ -317,6 +317,56 @@ func (suite *RecommenderTestSuite) TestRecommendFallbackItemToItemSkipsExpiredIt
 	}, scores)
 }
 
+func (suite *RecommenderTestSuite) TestRecommendFallbackItemToItemKeepsPerSeedCacheSize() {
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.ItemToItem, cache.Key("default", "item_to_item_seed_1"), []cache.Score{
+		{Id: "item_to_item_hidden", Score: 11},
+		{Id: "item_to_item_a", Score: 10},
+		{Id: "item_to_item_b", Score: 9},
+		{Id: "item_to_item_z", Score: 5},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.AddScores(suite.T().Context(), cache.ItemToItem, cache.Key("default", "item_to_item_seed_2"), []cache.Score{
+		{Id: "item_to_item_z", Score: 8},
+		{Id: "item_to_item_c", Score: 7},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.Set(suite.T().Context(), cache.String(cache.Key(cache.ItemToItemDigest, "default", "item_to_item_seed_1"), "digest_1"))
+	suite.NoError(err)
+	err = suite.cacheClient.Set(suite.T().Context(), cache.String(cache.Key(cache.ItemToItemDigest, "default", "item_to_item_seed_2"), "digest_2"))
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertFeedback(suite.T().Context(), []data.Feedback{
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "item_to_item_limit_user", ItemId: "item_to_item_seed_1"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "item_to_item_limit_user", ItemId: "item_to_item_seed_2"}},
+	}, true, true, false)
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "item_to_item_hidden", IsHidden: true},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize:   2,
+		ContextSize: 10,
+		DataSource: config.DataSourceConfig{
+			PositiveFeedbackTypes: []expression.FeedbackTypeExpression{expression.MustParseFeedbackTypeExpression("click")},
+		},
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+		Fallback: config.FallbackConfig{
+			Recommenders: []string{"item-to-item/default"},
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "item_to_item_limit_user", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 2)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "item_to_item_a", Score: 10},
+		{Id: "item_to_item_b", Score: 9},
+	}, scores)
+}
+
 func (suite *RecommenderTestSuite) TestRecommendFallbackLatestSkipsExpiredItems() {
 	now := time.Now()
 	err := suite.cacheClient.AddScores(suite.T().Context(), cache.Recommend, "ttl_user", []cache.Score{
@@ -354,6 +404,118 @@ func (suite *RecommenderTestSuite) TestRecommendFallbackLatestSkipsExpiredItems(
 		{Id: "ttl_rec_valid", Score: 9},
 		{Id: "ttl_rec_valid_2", Score: 8},
 		{Id: "ttl_latest_valid", Score: float64(now.Add(time.Hour).Unix())},
+	}, scores)
+}
+
+func (suite *RecommenderTestSuite) TestRecommendRankerDoesNotBackfillPastExcludedItems() {
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.Recommend, "ranker_excluded_user", []cache.Score{
+		{Id: "ranker_seen", Score: 10},
+		{Id: "ranker_valid", Score: 9},
+		{Id: "ranker_deeper", Score: 8},
+	})
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertFeedback(suite.T().Context(), []data.Feedback{
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "ranker_excluded_user", ItemId: "ranker_seen"}},
+	}, true, true, false)
+	suite.NoError(err)
+	now := time.Now()
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "ranker_valid", Timestamp: now.Add(-time.Hour)},
+		{ItemId: "ranker_deeper", Timestamp: now.Add(-2 * time.Hour)},
+		{ItemId: "ranker_fallback", Timestamp: now.Add(time.Hour)},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize: 2,
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+		Fallback: config.FallbackConfig{
+			Recommenders: []string{"latest"},
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "ranker_excluded_user", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 2)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "ranker_valid", Score: 9},
+		{Id: "ranker_fallback", Score: float64(now.Add(time.Hour).Unix())},
+	}, scores)
+}
+
+func (suite *RecommenderTestSuite) TestRecommendRankerSkipsUnavailableItemsAndKeepsCacheOnlyIds() {
+	now := time.Now()
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.Recommend, "ranker_user", []cache.Score{
+		{Id: "ranker_hidden", Score: 10},
+		{Id: "ranker_expired", Score: 9},
+		{Id: "ranker_cache_only", Score: 8},
+		{Id: "ranker_valid", Score: 7},
+	})
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "ranker_hidden", IsHidden: true},
+		{ItemId: "ranker_expired", Timestamp: now.Add(-48 * time.Hour)},
+		{ItemId: "ranker_valid", Timestamp: now.Add(-time.Hour)},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize: 2,
+		DataSource: config.DataSourceConfig{
+			ItemTTL: 1,
+		},
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "ranker_user", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 2)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "ranker_cache_only", Score: 8},
+		{Id: "ranker_valid", Score: 7},
+	}, scores)
+}
+
+func (suite *RecommenderTestSuite) TestRecommendRankerDoesNotBackfillPastExcludedItemsWhenSkippingUnavailableItems() {
+	err := suite.cacheClient.AddScores(suite.T().Context(), cache.Recommend, "ranker_mixed_user", []cache.Score{
+		{Id: "ranker_mixed_seen", Score: 10},
+		{Id: "ranker_mixed_hidden", Score: 9},
+		{Id: "ranker_mixed_valid", Score: 8},
+		{Id: "ranker_mixed_deeper", Score: 7},
+	})
+	suite.NoError(err)
+	err = suite.dataClient.BatchInsertFeedback(suite.T().Context(), []data.Feedback{
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "ranker_mixed_user", ItemId: "ranker_mixed_seen"}},
+	}, true, true, false)
+	suite.NoError(err)
+	now := time.Now()
+	err = suite.dataClient.BatchInsertItems(suite.T().Context(), []data.Item{
+		{ItemId: "ranker_mixed_hidden", IsHidden: true},
+		{ItemId: "ranker_mixed_valid", Timestamp: now.Add(-time.Hour)},
+		{ItemId: "ranker_mixed_fallback", Timestamp: now.Add(time.Hour)},
+	})
+	suite.NoError(err)
+
+	cfg := config.RecommendConfig{
+		CacheSize: 2,
+		Ranker: config.RankerConfig{
+			Type: "fm",
+		},
+		Fallback: config.FallbackConfig{
+			Recommenders: []string{"latest"},
+		},
+	}
+	recommender, err := NewRecommender(cfg, suite.cacheClient, suite.dataClient, true, "ranker_mixed_user", nil)
+	suite.NoError(err)
+	scores, err := recommender.Recommend(suite.T().Context(), 2)
+	suite.NoError(err)
+	suite.Equal([]cache.Score{
+		{Id: "ranker_mixed_valid", Score: 8},
+		{Id: "ranker_mixed_fallback", Score: float64(now.Add(time.Hour).Unix())},
 	}, scores)
 }
 


### PR DESCRIPTION
Fixes #764

## Summary

Recommendation results could still include hidden items and items older than `item_ttl`.

Filter cached and fallback recommendation results against current item metadata, and keep scanning past filtered entries so valid items still fill the response. Keep cache-only IDs without item rows unchanged.

## Testing

- `go test ./logics ./server ./worker -count=1`
- `go test ./... -run '^$' -count=1`
