### PR TITLE
fix: handle mixed numeric types in embedding column

### DIFF
--- a/logics/item_to_item.go
+++ b/logics/item_to_item.go
@@ -226,6 +226,30 @@ func toFloat32Slice(v any) ([]float32, error) {
 	switch val := v.(type) {
 	case []float32:
 		return val, nil
+	case []float64:
+		result := make([]float32, len(val))
+		for i, e := range val {
+			result[i] = float32(e)
+		}
+		return result, nil
+	case []int:
+		result := make([]float32, len(val))
+		for i, e := range val {
+			result[i] = float32(e)
+		}
+		return result, nil
+	case []int32:
+		result := make([]float32, len(val))
+		for i, e := range val {
+			result[i] = float32(e)
+		}
+		return result, nil
+	case []int64:
+		result := make([]float32, len(val))
+		for i, e := range val {
+			result[i] = float32(e)
+		}
+		return result, nil
 	case []any:
 		result := make([]float32, len(val))
 		for i, elem := range val {

--- a/logics/item_to_item.go
+++ b/logics/item_to_item.go
@@ -481,9 +481,10 @@ func (g *chatItemToItem) PopAll(i int) []cache.Score {
 			zap.Any("item", item), zap.Error(err))
 		return nil
 	}
-	embedding0, ok := result.([]float32)
-	if !ok {
-		log.Logger().Error("invalid column type", zap.Any("column", result))
+	embedding0, err := toFloat32Slice(result)
+	if err != nil {
+		log.Logger().Error("failed to convert column to float32 slice",
+			zap.Any("column", result), zap.Error(err))
 		return nil
 	}
 	// render template

--- a/logics/item_to_item.go
+++ b/logics/item_to_item.go
@@ -17,6 +17,7 @@ package logics
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -199,10 +200,11 @@ func (e *embeddingItemToItem) Push(item *data.Item, _ []int32) {
 			zap.Any("item", item), zap.Error(err))
 		return
 	}
-	// Check column type
-	v, ok := result.([]float32)
-	if !ok {
-		log.Logger().Error("invalid column type", zap.Any("column", result))
+	// Convert column to []float32
+	v, err := toFloat32Slice(result)
+	if err != nil {
+		log.Logger().Error("failed to convert column to float32 slice",
+			zap.Any("column", result), zap.Error(err))
 		return
 	}
 	// Check dimension
@@ -216,6 +218,36 @@ func (e *embeddingItemToItem) Push(item *data.Item, _ []int32) {
 	}
 	e.itemsLock.Unlock()
 	e.pushItem(item, v)
+}
+
+// toFloat32Slice converts an any to []float32, handling mixed numeric types
+// that may occur when reading from MongoDB (e.g., 0 stored as int instead of float32)
+func toFloat32Slice(v any) ([]float32, error) {
+	switch val := v.(type) {
+	case []float32:
+		return val, nil
+	case []any:
+		result := make([]float32, len(val))
+		for i, elem := range val {
+			switch e := elem.(type) {
+			case float32:
+				result[i] = e
+			case float64:
+				result[i] = float32(e)
+			case int:
+				result[i] = float32(e)
+			case int32:
+				result[i] = float32(e)
+			case int64:
+				result[i] = float32(e)
+			default:
+				return nil, fmt.Errorf("invalid element type %T in slice", e)
+			}
+		}
+		return result, nil
+	default:
+		return nil, fmt.Errorf("invalid column type %T", v)
+	}
 }
 
 type tagsItemToItem struct {

--- a/logics/item_to_item_test.go
+++ b/logics/item_to_item_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/dataset"
 	"github.com/gorse-io/gorse/storage/data"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -279,29 +280,85 @@ func (suite *ItemToItemTestSuite) TestChat() {
 	}
 }
 
-func (suite *ItemToItemTestSuite) TestToFloat32Slice() {
-	// Test []float32 input
-	floatSlice := []float32{0.1, 0.2, 0.3}
-	result, err := toFloat32Slice(floatSlice)
-	suite.NoError(err)
-	suite.Equal(floatSlice, result)
-
-	// Test []any with mixed numeric types (covers the MongoDB issue #1221)
-	mixedSlice := []any{float32(0.1), float64(0.2), int(0), int32(1), int64(2)}
-	result, err = toFloat32Slice(mixedSlice)
-	suite.NoError(err)
-	suite.Equal([]float32{0.1, 0.2, 0.0, 1.0, 2.0}, result)
-
-	// Test []any with invalid element type
-	invalidSlice := []any{float32(0.1), "string"}
-	_, err = toFloat32Slice(invalidSlice)
-	suite.Error(err)
-
-	// Test invalid input type
-	_, err = toFloat32Slice("string")
-	suite.Error(err)
-}
-
 func TestItemToItem(t *testing.T) {
 	suite.Run(t, new(ItemToItemTestSuite))
+}
+
+func TestToFloat32Slice(t *testing.T) {
+	floatSlice := []float32{0.1, 0.2, 0.3}
+	testCases := []struct {
+		name        string
+		input       any
+		expected    []float32
+		errContains string
+	}{
+		{
+			name:     "float32 slice",
+			input:    floatSlice,
+			expected: []float32{0.1, 0.2, 0.3},
+		},
+		{
+			name:     "float64 slice",
+			input:    []float64{0.1, 0.2, 0.3},
+			expected: []float32{0.1, 0.2, 0.3},
+		},
+		{
+			name:     "int slice",
+			input:    []int{-1, 0, 2},
+			expected: []float32{-1, 0, 2},
+		},
+		{
+			name:     "int32 slice",
+			input:    []int32{-1, 0, 2},
+			expected: []float32{-1, 0, 2},
+		},
+		{
+			name:     "int64 slice",
+			input:    []int64{-1, 0, 2},
+			expected: []float32{-1, 0, 2},
+		},
+		{
+			name:     "mixed any slice",
+			input:    []any{float32(0.1), float64(0.2), int(0), int32(1), int64(2)},
+			expected: []float32{0.1, 0.2, 0.0, 1.0, 2.0},
+		},
+		{
+			name:     "empty any slice",
+			input:    []any{},
+			expected: []float32{},
+		},
+		{
+			name:        "invalid element in any slice",
+			input:       []any{float32(0.1), "string"},
+			errContains: "invalid element type",
+		},
+		{
+			name:        "nil element in any slice",
+			input:       []any{float32(0.1), nil},
+			errContains: "invalid element type",
+		},
+		{
+			name:        "invalid input type",
+			input:       "string",
+			errContains: "invalid column type",
+		},
+		{
+			name:        "nil input",
+			input:       nil,
+			errContains: "invalid column type",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := toFloat32Slice(tc.input)
+			if tc.errContains != "" {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tc.errContains)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }

--- a/logics/item_to_item_test.go
+++ b/logics/item_to_item_test.go
@@ -279,6 +279,29 @@ func (suite *ItemToItemTestSuite) TestChat() {
 	}
 }
 
+func (suite *ItemToItemTestSuite) TestToFloat32Slice() {
+	// Test []float32 input
+	floatSlice := []float32{0.1, 0.2, 0.3}
+	result, err := toFloat32Slice(floatSlice)
+	suite.NoError(err)
+	suite.Equal(floatSlice, result)
+
+	// Test []any with mixed numeric types (covers the MongoDB issue #1221)
+	mixedSlice := []any{float32(0.1), float64(0.2), int(0), int32(1), int64(2)}
+	result, err = toFloat32Slice(mixedSlice)
+	suite.NoError(err)
+	suite.Equal([]float32{0.1, 0.2, 0.0, 1.0, 2.0}, result)
+
+	// Test []any with invalid element type
+	invalidSlice := []any{float32(0.1), "string"}
+	_, err = toFloat32Slice(invalidSlice)
+	suite.Error(err)
+
+	// Test invalid input type
+	_, err = toFloat32Slice("string")
+	suite.Error(err)
+}
+
 func TestItemToItem(t *testing.T) {
 	suite.Run(t, new(ItemToItemTestSuite))
 }

--- a/model/params.go
+++ b/model/params.go
@@ -49,7 +49,7 @@ const (
 )
 
 // Params stores hyper-parameters for an model. It is a map between strings
-// (names) and interface{}s (values). For example, hyper-parameters for SVD
+// (names) and anys (values). For example, hyper-parameters for SVD
 // is given by:
 //
 //	 base.Params{


### PR DESCRIPTION
When reading embeddings from MongoDB, numeric values may be stored as int instead of float32, causing type assertion failures in `embeddingItemToItem.Push()`.

This commit adds a `toFloat32Slice()` helper function that handles mixed numeric types (float32, float64, int, int32, int64) when converting the embedding column to `[]float32`.

Fixes #1221