### PR TITLE
refactor: move context size check after feedback append

### DIFF
--- a/logics/recommend.go
+++ b/logics/recommend.go
@@ -242,11 +242,11 @@ func (r *Recommender) recommendItemToItem(name string) RecommenderFunc {
 		data.SortFeedbacks(r.userFeedback)
 		userFeedback := make([]data.Feedback, 0, r.config.CacheSize)
 		for _, feedback := range r.userFeedback {
-			if r.online && r.config.ContextSize <= len(userFeedback) {
-				break
-			}
 			if expression.MatchFeedbackTypeExpressions(r.config.DataSource.PositiveFeedbackTypes, feedback.FeedbackType, feedback.Value) {
 				userFeedback = append(userFeedback, feedback)
+				if r.online && r.config.ContextSize <= len(userFeedback) {
+					break
+				}
 			}
 		}
 		// collect scores


### PR DESCRIPTION
## Summary

Move the `ContextSize` check inside the positive feedback check block for clearer logic flow.

## Changes

```go
// Before
for _, feedback := range r.userFeedback {
    if r.online && r.config.ContextSize <= len(userFeedback) {
        break
    }
    if expression.MatchFeedbackTypeExpressions(...) {
        userFeedback = append(userFeedback, feedback)
    }
}

// After  
for _, feedback := range r.userFeedback {
    if expression.MatchFeedbackTypeExpressions(...) {
        userFeedback = append(userFeedback, feedback)
        if r.online && r.config.ContextSize <= len(userFeedback) {
            break
        }
    }
}
```

## Rationale

The functionality remains the same, but the code now more clearly expresses the intent: check the limit **after** adding a positive feedback, not before processing each feedback.

This addresses issue #1230 - while the original code does work correctly, the new version is clearer about when the size check should happen.

## Testing

- [ ] Code compiles correctly
- [ ] Existing tests pass