### PR TITLE
fix(logics): filter hidden and expired items in user-to-user

### DIFF
--- a/logics/recommend.go
+++ b/logics/recommend.go
@@ -324,7 +324,14 @@ func (r *Recommender) recommendUserToUser(name string) RecommenderFunc {
 		ids := lo.Map(elems, func(elem heap.Elem[string, float64], _ int) string {
 			return elem.Value
 		})
-		items, err := r.dataClient.BatchGetItems(ctx, ids, data.GetOptions{})
+		var after *time.Time
+		if r.config.DataSource.ItemTTL > 0 {
+			after = new(time.Now().AddDate(0, 0, -int(r.config.DataSource.ItemTTL)))
+		}
+		items, err := r.dataClient.BatchGetItems(ctx, ids, data.GetOptions{
+			SkipHidden: true,
+			After:      after,
+		})
 		if err != nil {
 			return nil, "", errors.Trace(err)
 		}

--- a/logics/recommend_test.go
+++ b/logics/recommend_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorse-io/gorse/common/expression"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/storage/cache"
 	"github.com/gorse-io/gorse/storage/data"
@@ -258,6 +259,53 @@ func (suite *RecommenderTestSuite) TestExternal() {
 		{Id: "item_100", Score: 0},
 		{Id: "item_200", Score: 0},
 		{Id: "item_300", Score: 0},
+	}, scores)
+}
+
+func (suite *RecommenderTestSuite) TestUserToUser() {
+	items := []data.Item{
+		{ItemId: "item_20", Timestamp: time.Now()},
+		{ItemId: "item_21", Timestamp: time.Now()},
+		{ItemId: "item_22", Timestamp: time.Now(), IsHidden: true},
+		{ItemId: "item_23", Timestamp: time.Now().AddDate(0, 0, -10)},
+	}
+	err := suite.dataClient.BatchInsertItems(suite.T().Context(), items)
+	suite.NoError(err)
+
+	feedback := make([]data.Feedback, len(items))
+	for i, item := range items {
+		feedback[i] = data.Feedback{
+			FeedbackKey: data.FeedbackKey{
+				FeedbackType: "click",
+				UserId:       "user_2",
+				ItemId:       item.ItemId,
+			},
+		}
+	}
+	err = suite.dataClient.BatchInsertFeedback(suite.T().Context(), feedback, true, true, false)
+	suite.NoError(err)
+
+	err = suite.cacheClient.AddScores(suite.T().Context(), cache.UserToUser, cache.Key("test", "user_1"), []cache.Score{
+		{Id: "user_2", Score: 1},
+	})
+	suite.NoError(err)
+	err = suite.cacheClient.Set(suite.T().Context(), cache.String(cache.Key(cache.UserToUserDigest, "test", "user_1"), "digest"))
+	suite.NoError(err)
+
+	recommender, err := NewRecommender(config.RecommendConfig{
+		CacheSize: 10,
+		DataSource: config.DataSourceConfig{
+			PositiveFeedbackTypes: []expression.FeedbackTypeExpression{{FeedbackType: "click"}},
+			ItemTTL:               1,
+		},
+	}, suite.cacheClient, suite.dataClient, true, "user_1", nil)
+	suite.NoError(err)
+	scores, digest, err := recommender.recommendUserToUser("test")(suite.T().Context())
+	suite.NoError(err)
+	suite.Equal("digest", digest)
+	suite.ElementsMatch([]cache.Score{
+		{Id: "item_20", Score: 1},
+		{Id: "item_21", Score: 1},
 	}, scores)
 }
 


### PR DESCRIPTION
## Problem
`recommendUserToUser` in `logics/recommend.go` calls `BatchGetItems(ctx, ids, data.GetOptions{})` with empty options. Hidden items and items older than `ItemTTL` slip through into the user-facing result.

## Root Cause
`BatchGetItems` honors `SkipHidden` and `After` when passed (#1205, #1206). The user-to-user fallback never sets them. `recommendLatest` already applies `ItemTTL` through `GetLatestItems` in the same file.

## Solution
Compute `after` from `DataSource.ItemTTL` the same way `recommendLatest` does, then pass `SkipHidden: true, After: after` into the `BatchGetItems` call.

## Testing
Added `TestUserToUser` in `logics/recommend_test.go`. It seeds four items: two fresh visible, one hidden, one ten days old. With `ItemTTL: 1`, only the two fresh items return.
