### PR TITLE
fix(monitor): clamp Span.Progress Count to Total

### DIFF
--- a/common/monitor/progress.go
+++ b/common/monitor/progress.go
@@ -158,6 +158,14 @@ func (s *Span) Progress() Progress {
 		}
 		parentCount += childTotal * child.Count / child.Total
 	}
+	// Clamp parentCount to parentTotal. The "zero-total child is complete"
+	// fallback above can otherwise push parentCount beyond parentTotal when
+	// the parent has already consumed its own count and a running child is
+	// reporting no work units, which would surface as >100% progress in the
+	// dashboard.
+	if parentCount > parentTotal {
+		parentCount = parentTotal
+	}
 	return Progress{
 		Name:       s.name,
 		Status:     s.status,

--- a/common/monitor/progress_overflow_test.go
+++ b/common/monitor/progress_overflow_test.go
@@ -1,0 +1,25 @@
+package monitor
+
+import (
+	"context"
+	"testing"
+)
+
+// TestProgress_ZeroTotalChildDoesNotExceed100Percent pins the behavior of the
+// zero-total child fallback in Span.Progress. Before the clamp, a parent
+// with total=2,count=2 plus a running child with total=0 would return
+// Count=3,Total=2 (150%), which confused the dashboard progress bar.
+//
+// The clamp ensures Count <= Total for every case the fallback handles.
+func TestProgress_ZeroTotalChildDoesNotExceed100Percent(t *testing.T) {
+	_, parent := Start(context.Background(), "parent", 2)
+	parent.Add(2) // parent's own work is complete
+
+	ctx := context.WithValue(context.Background(), spanKeyName, parent)
+	_, _ = Start(ctx, "child", 0)
+
+	got := parent.Progress()
+	if got.Count > got.Total {
+		t.Fatalf("Progress.Count (%d) exceeds Progress.Total (%d)", got.Count, got.Total)
+	}
+}


### PR DESCRIPTION
## Problem

After #1208 removed the divide-by-zero panic in `Span.Progress`, the "zero-total child is complete" fallback can push `parentCount` above `parentTotal` when the parent has already consumed its own count and a running child is reporting zero total.

With a parent `total=2, count=2` plus one running child with `total=0`, `Span.Progress()` returns `Progress{Count: 3, Total: 2}`. The dashboard progress bar at `/api/dashboard/tasks` renders this as 150%.

## Root Cause

`common/monitor/progress.go:138-169`:

```go
parentTotal := s.total * childTotal
parentCount := s.count * childTotal
for _, child := range children {
    if child.Total == 0 {
        parentCount += childTotal   // treat zero-total child as complete
        continue
    }
    parentCount += childTotal * child.Count / child.Total
}
```

When `s.count * childTotal == parentTotal` and the zero-total branch fires, `parentCount` exceeds `parentTotal` by one `childTotal` unit. There is no clamp before the `Progress{}` value is returned.

## Solution

Clamp `parentCount` to `parentTotal` just before returning:

```go
if parentCount > parentTotal {
    parentCount = parentTotal
}
```

This is the minimal change that keeps the "zero-total child is complete" semantics from #1208 while restoring the `0 <= Count <= Total` invariant.

## Testing

New pinning test in `common/monitor/progress_overflow_test.go`:

```go
func TestProgress_ZeroTotalChildDoesNotExceed100Percent(t *testing.T) {
    _, parent := Start(context.Background(), "parent", 2)
    parent.Add(2)

    ctx := context.WithValue(context.Background(), spanKeyName, parent)
    _, _ = Start(ctx, "child", 0)

    got := parent.Progress()
    if got.Count > got.Total {
        t.Fatalf("Progress.Count (%d) exceeds Progress.Total (%d)", got.Count, got.Total)
    }
}
```

- Before the clamp, this test fails with `Count (3) exceeds Total (2)`.
- After the clamp, all existing `common/monitor` tests (including `TestProgress/divide_by_zero`, `TestProgress/child_with_zero_total`, `TestProgress/all_children_with_zero_total` added in #1208) still pass.

## Scope

Single-hunk fix plus a targeted regression test. No behavioural change for the non-overflowing cases; the clamp only engages on the exact scenario #1208 could not reach.

Fixes #1241