### PR TITLE
refactor: migrate embedding storage to BF16 format

### DIFF
--- a/common/bfloats/bfloats.go
+++ b/common/bfloats/bfloats.go
@@ -16,6 +16,7 @@ package bfloats
 
 import (
 	"math"
+	"reflect"
 
 	"github.com/chewxy/math32"
 )
@@ -53,4 +54,59 @@ func Euclidean(a, b []uint16) float32 {
 		return 0
 	}
 	return feature.euclidean(a, b)
+}
+
+func FromAny(v any) ([]uint16, bool) {
+	switch typed := v.(type) {
+	case []uint16:
+		return typed, true
+	case []float32:
+		return FromFloat32(typed), true
+	case nil:
+		return nil, false
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Slice {
+		return nil, false
+	}
+	values := make([]float32, rv.Len())
+	for i := range rv.Len() {
+		converted, ok := toFloat32(rv.Index(i).Interface())
+		if !ok {
+			return nil, false
+		}
+		values[i] = converted
+	}
+	return FromFloat32(values), true
+}
+
+func toFloat32(v any) (float32, bool) {
+	switch typed := v.(type) {
+	case float32:
+		return typed, true
+	case float64:
+		return float32(typed), true
+	case int:
+		return float32(typed), true
+	case int8:
+		return float32(typed), true
+	case int16:
+		return float32(typed), true
+	case int32:
+		return float32(typed), true
+	case int64:
+		return float32(typed), true
+	case uint:
+		return float32(typed), true
+	case uint8:
+		return float32(typed), true
+	case uint16:
+		return float32(typed), true
+	case uint32:
+		return float32(typed), true
+	case uint64:
+		return float32(typed), true
+	default:
+		return 0, false
+	}
 }

--- a/common/bfloats/bfloats_test.go
+++ b/common/bfloats/bfloats_test.go
@@ -26,3 +26,90 @@ func TestEuclidean(t *testing.T) {
 	assert.Equal(t, float32(19.621416), Euclidean(a, b))
 	assert.Panics(t, func() { Euclidean([]uint16{1}, nil) })
 }
+
+func TestFromAny(t *testing.T) {
+	floatSlice := []float32{0.1, 0.2, 0.3}
+	testCases := []struct {
+		name     string
+		input    any
+		expected []uint16
+		ok       bool
+	}{
+		{
+			name:     "float32 slice",
+			input:    floatSlice,
+			expected: FromFloat32([]float32{0.1, 0.2, 0.3}),
+			ok:       true,
+		},
+		{
+			name:     "bf16 slice",
+			input:    FromFloat32(floatSlice),
+			expected: FromFloat32([]float32{0.1, 0.2, 0.3}),
+			ok:       true,
+		},
+		{
+			name:     "float64 slice",
+			input:    []float64{0.1, 0.2, 0.3},
+			expected: FromFloat32([]float32{0.1, 0.2, 0.3}),
+			ok:       true,
+		},
+		{
+			name:     "int slice",
+			input:    []int{-1, 0, 2},
+			expected: FromFloat32([]float32{-1, 0, 2}),
+			ok:       true,
+		},
+		{
+			name:     "int32 slice",
+			input:    []int32{-1, 0, 2},
+			expected: FromFloat32([]float32{-1, 0, 2}),
+			ok:       true,
+		},
+		{
+			name:     "int64 slice",
+			input:    []int64{-1, 0, 2},
+			expected: FromFloat32([]float32{-1, 0, 2}),
+			ok:       true,
+		},
+		{
+			name:     "mixed any slice",
+			input:    []any{float32(0.1), float64(0.2), int(0), int32(1), int64(2)},
+			expected: FromFloat32([]float32{0.1, 0.2, 0.0, 1.0, 2.0}),
+			ok:       true,
+		},
+		{
+			name:     "empty any slice",
+			input:    []any{},
+			expected: []uint16{},
+			ok:       true,
+		},
+		{
+			name:  "invalid element in any slice",
+			input: []any{float32(0.1), "string"},
+			ok:    false,
+		},
+		{
+			name:  "nil element in any slice",
+			input: []any{float32(0.1), nil},
+			ok:    false,
+		},
+		{
+			name:  "invalid input type",
+			input: "string",
+			ok:    false,
+		},
+		{
+			name:  "nil input",
+			input: nil,
+			ok:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, ok := FromAny(tc.input)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -375,26 +375,14 @@ func (l *Labels) processLabels(labels any, parent string) any {
 		}
 		return o
 	case []any:
-		if isSliceOf[float64](typed) {
-			return bfloats.FromFloat32(lo.Map(typed, func(e any, _ int) float32 {
-				return float32(e.(float64))
-			}))
-		} else if isSliceOf[float32](typed) {
-			return bfloats.FromFloat32(lo.Map(typed, func(e any, _ int) float32 {
-				return e.(float32)
-			}))
+		if values, ok := bfloats.FromAny(typed); ok {
+			return values
 		} else if isSliceOf[string](typed) {
 			return lo.Map(typed, func(e any, _ int) ID {
 				return ID(l.values.Add(parent + ":" + e.(string)))
 			})
 		}
 		return typed
-	case []float64:
-		return bfloats.FromFloat32(lo.Map(typed, func(e float64, _ int) float32 {
-			return float32(e)
-		}))
-	case []float32:
-		return bfloats.FromFloat32(typed)
 	case string:
 		return ID(l.values.Add(parent + ":" + typed))
 	default:

--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/chewxy/math32"
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/common/util"
 	"github.com/gorse-io/gorse/model"
 	"github.com/gorse-io/gorse/storage/data"
@@ -375,15 +376,25 @@ func (l *Labels) processLabels(labels any, parent string) any {
 		return o
 	case []any:
 		if isSliceOf[float64](typed) {
-			return lo.Map(typed, func(e any, _ int) float32 {
+			return bfloats.FromFloat32(lo.Map(typed, func(e any, _ int) float32 {
 				return float32(e.(float64))
-			})
+			}))
+		} else if isSliceOf[float32](typed) {
+			return bfloats.FromFloat32(lo.Map(typed, func(e any, _ int) float32 {
+				return e.(float32)
+			}))
 		} else if isSliceOf[string](typed) {
 			return lo.Map(typed, func(e any, _ int) ID {
 				return ID(l.values.Add(parent + ":" + e.(string)))
 			})
 		}
 		return typed
+	case []float64:
+		return bfloats.FromFloat32(lo.Map(typed, func(e float64, _ int) float32 {
+			return float32(e)
+		}))
+	case []float32:
+		return bfloats.FromFloat32(typed)
 	case string:
 		return ID(l.values.Add(parent + ":" + typed))
 	default:

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -54,7 +54,17 @@ func TestDataset_AddItem(t *testing.T) {
 		},
 		Comment: "comment",
 	})
-	assert.Len(t, dataSet.GetItems(), 2)
+	dataSet.AddItem(data.Item{
+		ItemId:     "3",
+		IsHidden:   false,
+		Categories: []string{"a"},
+		Timestamp:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Labels: map[string]any{
+			"embedded": []any{1.1, 0, int32(2)},
+		},
+		Comment: "comment",
+	})
+	assert.Len(t, dataSet.GetItems(), 3)
 	assert.Equal(t, data.Item{
 		ItemId:     "1",
 		IsHidden:   false,
@@ -80,6 +90,16 @@ func TestDataset_AddItem(t *testing.T) {
 		},
 		Comment: "comment",
 	}, dataSet.GetItems()[1])
+	assert.Equal(t, data.Item{
+		ItemId:     "3",
+		IsHidden:   false,
+		Categories: []string{"a"},
+		Timestamp:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Labels: map[string]any{
+			"embedded": bfloats.FromFloat32([]float32{1.1, 0, 2}),
+		},
+		Comment: "comment",
+	}, dataSet.GetItems()[2])
 }
 
 func TestDataset_GetItemColumnValuesIDF(t *testing.T) {

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/chewxy/math32"
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/storage/data"
 	"github.com/stretchr/testify/assert"
 )
@@ -61,7 +62,7 @@ func TestDataset_AddItem(t *testing.T) {
 		Timestamp:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		Labels: map[string]any{
 			"a":        1,
-			"embedded": []float32{1.1, 2.2, 3.3},
+			"embedded": bfloats.FromFloat32([]float32{1.1, 2.2, 3.3}),
 			"tags":     []ID{0, 1, 2},
 		},
 		Comment: "comment",
@@ -73,7 +74,7 @@ func TestDataset_AddItem(t *testing.T) {
 		Timestamp:  time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 		Labels: map[string]any{
 			"a":        1,
-			"embedded": []float32{1.1, 2.2, 3.3},
+			"embedded": bfloats.FromFloat32([]float32{1.1, 2.2, 3.3}),
 			"tags":     []ID{1, 2, 0},
 			"topics":   []ID{3, 4, 5},
 		},

--- a/logics/item_to_item.go
+++ b/logics/item_to_item.go
@@ -17,7 +17,6 @@ package logics
 import (
 	"context"
 	"errors"
-	"fmt"
 	"slices"
 	"strings"
 	"sync"
@@ -201,10 +200,10 @@ func (e *embeddingItemToItem) Push(item *data.Item, _ []int32) {
 		return
 	}
 	// Convert column to BF16 vector
-	v, err := toBFloat16Slice(result)
-	if err != nil {
+	v, ok := bfloats.FromAny(result)
+	if !ok {
 		log.Logger().Error("failed to convert column to BF16 slice",
-			zap.Any("column", result), zap.Error(err))
+			zap.Any("column", result))
 		return
 	}
 	// Check dimension
@@ -218,62 +217,6 @@ func (e *embeddingItemToItem) Push(item *data.Item, _ []int32) {
 	}
 	e.itemsLock.Unlock()
 	e.pushItem(item, v)
-}
-
-// toBFloat16Slice converts an any to BF16 slice, handling mixed numeric types
-// that may occur when reading from MongoDB (e.g., 0 stored as int instead of float32)
-func toBFloat16Slice(v any) ([]uint16, error) {
-	switch val := v.(type) {
-	case []uint16:
-		return val, nil
-	case []float32:
-		return bfloats.FromFloat32(val), nil
-	case []float64:
-		result := make([]float32, len(val))
-		for i, e := range val {
-			result[i] = float32(e)
-		}
-		return bfloats.FromFloat32(result), nil
-	case []int:
-		result := make([]float32, len(val))
-		for i, e := range val {
-			result[i] = float32(e)
-		}
-		return bfloats.FromFloat32(result), nil
-	case []int32:
-		result := make([]float32, len(val))
-		for i, e := range val {
-			result[i] = float32(e)
-		}
-		return bfloats.FromFloat32(result), nil
-	case []int64:
-		result := make([]float32, len(val))
-		for i, e := range val {
-			result[i] = float32(e)
-		}
-		return bfloats.FromFloat32(result), nil
-	case []any:
-		result := make([]float32, len(val))
-		for i, elem := range val {
-			switch e := elem.(type) {
-			case float32:
-				result[i] = e
-			case float64:
-				result[i] = float32(e)
-			case int:
-				result[i] = float32(e)
-			case int32:
-				result[i] = float32(e)
-			case int64:
-				result[i] = float32(e)
-			default:
-				return nil, fmt.Errorf("invalid element type %T in slice", e)
-			}
-		}
-		return bfloats.FromFloat32(result), nil
-	default:
-		return nil, fmt.Errorf("invalid column type %T", v)
-	}
 }
 
 type tagsItemToItem struct {
@@ -483,10 +426,10 @@ func (g *chatItemToItem) PopAll(i int) []cache.Score {
 			zap.Any("item", item), zap.Error(err))
 		return nil
 	}
-	embedding0, err := toBFloat16Slice(result)
-	if err != nil {
+	embedding0, ok := bfloats.FromAny(result)
+	if !ok {
 		log.Logger().Error("failed to convert column to BF16 slice",
-			zap.Any("column", result), zap.Error(err))
+			zap.Any("column", result))
 		return nil
 	}
 	// render template

--- a/logics/item_to_item.go
+++ b/logics/item_to_item.go
@@ -29,7 +29,7 @@ import (
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
 	"github.com/gorse-io/gorse/common/ann"
-	"github.com/gorse-io/gorse/common/floats"
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/common/heap"
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/parallel"
@@ -169,7 +169,7 @@ func (b *baseItemToItem[T]) PopAll(i int) []cache.Score {
 }
 
 type embeddingItemToItem struct {
-	baseItemToItem[[]float32]
+	baseItemToItem[[]uint16]
 	dimension int
 }
 
@@ -181,12 +181,12 @@ func newEmbeddingItemToItem(cfg config.ItemToItemConfig, n int, timestamp time.T
 	if err != nil {
 		return nil, err
 	}
-	return &embeddingItemToItem{baseItemToItem: baseItemToItem[[]float32]{
+	return &embeddingItemToItem{baseItemToItem: baseItemToItem[[]uint16]{
 		name:       cfg.Name,
 		n:          n,
 		timestamp:  timestamp,
 		columnFunc: columnFunc,
-		index:      ann.NewHNSW(floats.Euclidean),
+		index:      ann.NewHNSW(bfloats.Euclidean),
 	}}, nil
 }
 
@@ -200,10 +200,10 @@ func (e *embeddingItemToItem) Push(item *data.Item, _ []int32) {
 			zap.Any("item", item), zap.Error(err))
 		return
 	}
-	// Convert column to []float32
-	v, err := toFloat32Slice(result)
+	// Convert column to BF16 vector
+	v, err := toBFloat16Slice(result)
 	if err != nil {
-		log.Logger().Error("failed to convert column to float32 slice",
+		log.Logger().Error("failed to convert column to BF16 slice",
 			zap.Any("column", result), zap.Error(err))
 		return
 	}
@@ -220,36 +220,38 @@ func (e *embeddingItemToItem) Push(item *data.Item, _ []int32) {
 	e.pushItem(item, v)
 }
 
-// toFloat32Slice converts an any to []float32, handling mixed numeric types
+// toBFloat16Slice converts an any to BF16 slice, handling mixed numeric types
 // that may occur when reading from MongoDB (e.g., 0 stored as int instead of float32)
-func toFloat32Slice(v any) ([]float32, error) {
+func toBFloat16Slice(v any) ([]uint16, error) {
 	switch val := v.(type) {
-	case []float32:
+	case []uint16:
 		return val, nil
+	case []float32:
+		return bfloats.FromFloat32(val), nil
 	case []float64:
 		result := make([]float32, len(val))
 		for i, e := range val {
 			result[i] = float32(e)
 		}
-		return result, nil
+		return bfloats.FromFloat32(result), nil
 	case []int:
 		result := make([]float32, len(val))
 		for i, e := range val {
 			result[i] = float32(e)
 		}
-		return result, nil
+		return bfloats.FromFloat32(result), nil
 	case []int32:
 		result := make([]float32, len(val))
 		for i, e := range val {
 			result[i] = float32(e)
 		}
-		return result, nil
+		return bfloats.FromFloat32(result), nil
 	case []int64:
 		result := make([]float32, len(val))
 		for i, e := range val {
 			result[i] = float32(e)
 		}
-		return result, nil
+		return bfloats.FromFloat32(result), nil
 	case []any:
 		result := make([]float32, len(val))
 		for i, elem := range val {
@@ -268,7 +270,7 @@ func toFloat32Slice(v any) ([]float32, error) {
 				return nil, fmt.Errorf("invalid element type %T in slice", e)
 			}
 		}
-		return result, nil
+		return bfloats.FromFloat32(result), nil
 	default:
 		return nil, fmt.Errorf("invalid column type %T", v)
 	}
@@ -481,9 +483,9 @@ func (g *chatItemToItem) PopAll(i int) []cache.Score {
 			zap.Any("item", item), zap.Error(err))
 		return nil
 	}
-	embedding0, err := toFloat32Slice(result)
+	embedding0, err := toBFloat16Slice(result)
 	if err != nil {
-		log.Logger().Error("failed to convert column to float32 slice",
+		log.Logger().Error("failed to convert column to BF16 slice",
 			zap.Any("column", result), zap.Error(err))
 		return nil
 	}
@@ -560,8 +562,9 @@ func (g *chatItemToItem) PopAll(i int) []cache.Score {
 	// search index
 	pq := heap.NewPriorityQueue(true)
 	for _, embedding := range embeddings {
-		score0 := floats.Euclidean(embedding, embedding0)
-		scores := g.index.SearchVector(embedding, g.n+1, true)
+		embeddingBF16 := bfloats.FromFloat32(embedding)
+		score0 := bfloats.Euclidean(embeddingBF16, embedding0)
+		scores := g.index.SearchVector(embeddingBF16, g.n+1, true)
 		for _, score := range scores {
 			if score.A != i {
 				pq.Push(int32(score.A), score.B*score0)

--- a/logics/item_to_item_test.go
+++ b/logics/item_to_item_test.go
@@ -19,13 +19,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/common/floats"
 	"github.com/gorse-io/gorse/common/mock"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/dataset"
 	"github.com/gorse-io/gorse/storage/data"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -283,88 +281,4 @@ func (suite *ItemToItemTestSuite) TestChat() {
 
 func TestItemToItem(t *testing.T) {
 	suite.Run(t, new(ItemToItemTestSuite))
-}
-
-func TestToBFloat16Slice(t *testing.T) {
-	floatSlice := []float32{0.1, 0.2, 0.3}
-	testCases := []struct {
-		name        string
-		input       any
-		expected    []uint16
-		errContains string
-	}{
-		{
-			name:     "float32 slice",
-			input:    floatSlice,
-			expected: bfloats.FromFloat32([]float32{0.1, 0.2, 0.3}),
-		},
-		{
-			name:     "bf16 slice",
-			input:    bfloats.FromFloat32(floatSlice),
-			expected: bfloats.FromFloat32([]float32{0.1, 0.2, 0.3}),
-		},
-		{
-			name:     "float64 slice",
-			input:    []float64{0.1, 0.2, 0.3},
-			expected: bfloats.FromFloat32([]float32{0.1, 0.2, 0.3}),
-		},
-		{
-			name:     "int slice",
-			input:    []int{-1, 0, 2},
-			expected: bfloats.FromFloat32([]float32{-1, 0, 2}),
-		},
-		{
-			name:     "int32 slice",
-			input:    []int32{-1, 0, 2},
-			expected: bfloats.FromFloat32([]float32{-1, 0, 2}),
-		},
-		{
-			name:     "int64 slice",
-			input:    []int64{-1, 0, 2},
-			expected: bfloats.FromFloat32([]float32{-1, 0, 2}),
-		},
-		{
-			name:     "mixed any slice",
-			input:    []any{float32(0.1), float64(0.2), int(0), int32(1), int64(2)},
-			expected: bfloats.FromFloat32([]float32{0.1, 0.2, 0.0, 1.0, 2.0}),
-		},
-		{
-			name:     "empty any slice",
-			input:    []any{},
-			expected: []uint16{},
-		},
-		{
-			name:        "invalid element in any slice",
-			input:       []any{float32(0.1), "string"},
-			errContains: "invalid element type",
-		},
-		{
-			name:        "nil element in any slice",
-			input:       []any{float32(0.1), nil},
-			errContains: "invalid element type",
-		},
-		{
-			name:        "invalid input type",
-			input:       "string",
-			errContains: "invalid column type",
-		},
-		{
-			name:        "nil input",
-			input:       nil,
-			errContains: "invalid column type",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			result, err := toBFloat16Slice(tc.input)
-			if tc.errContains != "" {
-				assert.Error(t, err)
-				assert.ErrorContains(t, err, tc.errContains)
-				return
-			}
-			assert.NoError(t, err)
-			assert.Equal(t, tc.expected, result)
-		})
-	}
 }

--- a/logics/item_to_item_test.go
+++ b/logics/item_to_item_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/common/floats"
 	"github.com/gorse-io/gorse/common/mock"
 	"github.com/gorse-io/gorse/config"
@@ -284,48 +285,53 @@ func TestItemToItem(t *testing.T) {
 	suite.Run(t, new(ItemToItemTestSuite))
 }
 
-func TestToFloat32Slice(t *testing.T) {
+func TestToBFloat16Slice(t *testing.T) {
 	floatSlice := []float32{0.1, 0.2, 0.3}
 	testCases := []struct {
 		name        string
 		input       any
-		expected    []float32
+		expected    []uint16
 		errContains string
 	}{
 		{
 			name:     "float32 slice",
 			input:    floatSlice,
-			expected: []float32{0.1, 0.2, 0.3},
+			expected: bfloats.FromFloat32([]float32{0.1, 0.2, 0.3}),
+		},
+		{
+			name:     "bf16 slice",
+			input:    bfloats.FromFloat32(floatSlice),
+			expected: bfloats.FromFloat32([]float32{0.1, 0.2, 0.3}),
 		},
 		{
 			name:     "float64 slice",
 			input:    []float64{0.1, 0.2, 0.3},
-			expected: []float32{0.1, 0.2, 0.3},
+			expected: bfloats.FromFloat32([]float32{0.1, 0.2, 0.3}),
 		},
 		{
 			name:     "int slice",
 			input:    []int{-1, 0, 2},
-			expected: []float32{-1, 0, 2},
+			expected: bfloats.FromFloat32([]float32{-1, 0, 2}),
 		},
 		{
 			name:     "int32 slice",
 			input:    []int32{-1, 0, 2},
-			expected: []float32{-1, 0, 2},
+			expected: bfloats.FromFloat32([]float32{-1, 0, 2}),
 		},
 		{
 			name:     "int64 slice",
 			input:    []int64{-1, 0, 2},
-			expected: []float32{-1, 0, 2},
+			expected: bfloats.FromFloat32([]float32{-1, 0, 2}),
 		},
 		{
 			name:     "mixed any slice",
 			input:    []any{float32(0.1), float64(0.2), int(0), int32(1), int64(2)},
-			expected: []float32{0.1, 0.2, 0.0, 1.0, 2.0},
+			expected: bfloats.FromFloat32([]float32{0.1, 0.2, 0.0, 1.0, 2.0}),
 		},
 		{
 			name:     "empty any slice",
 			input:    []any{},
-			expected: []float32{},
+			expected: []uint16{},
 		},
 		{
 			name:        "invalid element in any slice",
@@ -351,7 +357,7 @@ func TestToFloat32Slice(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := toFloat32Slice(tc.input)
+			result, err := toBFloat16Slice(tc.input)
 			if tc.errContains != "" {
 				assert.Error(t, err)
 				assert.ErrorContains(t, err, tc.errContains)

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -26,7 +26,6 @@ import (
 	"github.com/c-bata/goptuna/tpe"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/gorse-io/gorse/common/expression"
-	"github.com/gorse-io/gorse/common/floats"
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
 	"github.com/gorse-io/gorse/common/parallel"
@@ -400,7 +399,7 @@ func (m *Master) LoadDataFromDatabase(
 				for len(itemEmbeddings[itemIndex]) <= int(itemEmbeddingIndex) {
 					itemEmbeddings[itemIndex] = append(itemEmbeddings[itemIndex], nil)
 				}
-				itemEmbeddings[itemIndex][itemEmbeddingIndex] = floats.ToBF16(embedding.Value)
+				itemEmbeddings[itemIndex][itemEmbeddingIndex] = embedding.Value
 				for len(itemEmbeddingDimension) <= int(itemEmbeddingIndex) {
 					itemEmbeddingDimension = append(itemEmbeddingDimension, make(map[int]int))
 				}

--- a/model/ctr/data.go
+++ b/model/ctr/data.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/common/jsonutil"
 	"github.com/gorse-io/gorse/common/util"
 	"github.com/gorse-io/gorse/dataset"
@@ -83,7 +84,7 @@ func convertLabels(result []Label, prefix string, o any) []Label {
 
 type Embedding struct {
 	Name  string
-	Value []float32
+	Value []uint16
 }
 
 func ConvertEmbeddings(o any) []Embedding {
@@ -107,20 +108,28 @@ func convertEmbeddings(result []Embedding, prefix string, o any) []Embedding {
 				value = append(value, float32(v))
 			case float32:
 				value = append(value, v)
+			case int:
+				value = append(value, float32(v))
+			case json.Number:
 			default:
 				return result
 			}
 		}
 		result = append(result, Embedding{
 			Name:  prefix,
-			Value: value,
+			Value: bfloats.FromFloat32(value),
 		})
 	case []float64:
 		result = append(result, Embedding{
 			Name:  prefix,
-			Value: lo.Map(embeddings, func(f float64, _ int) float32 { return float32(f) }),
+			Value: bfloats.FromFloat32(lo.Map(embeddings, func(f float64, _ int) float32 { return float32(f) })),
 		})
 	case []float32:
+		result = append(result, Embedding{
+			Name:  prefix,
+			Value: bfloats.FromFloat32(embeddings),
+		})
+	case []uint16:
 		result = append(result, Embedding{
 			Name:  prefix,
 			Value: embeddings,

--- a/model/ctr/data_test.go
+++ b/model/ctr/data_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/common/floats"
 	"github.com/gorse-io/gorse/dataset"
 	"github.com/samber/lo"
@@ -73,19 +74,19 @@ func TestConvertEmbeddings(t *testing.T) {
 	embeddings = ConvertEmbeddings([]float32{1, 2, 3})
 	if assert.Len(t, embeddings, 1) {
 		assert.Equal(t, "", embeddings[0].Name)
-		assert.Equal(t, []float32{1, 2, 3}, embeddings[0].Value)
+		assert.Equal(t, bfloats.FromFloat32([]float32{1, 2, 3}), embeddings[0].Value)
 	}
 
 	embeddings = ConvertEmbeddings([]float64{1, 2, 3})
 	if assert.Len(t, embeddings, 1) {
 		assert.Equal(t, "", embeddings[0].Name)
-		assert.Equal(t, []float32{1, 2, 3}, embeddings[0].Value)
+		assert.Equal(t, bfloats.FromFloat32([]float32{1, 2, 3}), embeddings[0].Value)
 	}
 
 	embeddings = ConvertEmbeddings([]any{float64(1), float32(2), float64(3)})
 	if assert.Len(t, embeddings, 1) {
 		assert.Equal(t, "", embeddings[0].Name)
-		assert.Equal(t, []float32{1, 2, 3}, embeddings[0].Value)
+		assert.Equal(t, bfloats.FromFloat32([]float32{1, 2, 3}), embeddings[0].Value)
 	}
 
 	embeddings = ConvertEmbeddings(map[string]any{
@@ -97,8 +98,8 @@ func TestConvertEmbeddings(t *testing.T) {
 	})
 	if assert.Len(t, embeddings, 2) {
 		assert.ElementsMatch(t, []Embedding{
-			{Name: "embedding1", Value: []float32{1, 2, 3}},
-			{Name: "a.embedding2", Value: []float32{4, 5, 6}},
+			{Name: "embedding1", Value: bfloats.FromFloat32([]float32{1, 2, 3})},
+			{Name: "a.embedding2", Value: bfloats.FromFloat32([]float32{4, 5, 6})},
 		}, embeddings)
 	}
 }

--- a/model/ctr/fm.go
+++ b/model/ctr/fm.go
@@ -218,7 +218,7 @@ func (fm *AFM) BatchPredict(inputs []lo.Tuple4[string, string, []Label, []Label]
 				// dimension mismatch
 				continue
 			}
-			e[i][index] = floats.ToBF16(embedding.Value)
+			e[i][index] = embedding.Value
 		}
 	}
 	return fm.BatchInternalPredict(x, e, jobs)

--- a/model/ctr/fm_xla.go
+++ b/model/ctr/fm_xla.go
@@ -336,7 +336,7 @@ func (fm *AFM) BatchPredict(inputs []lo.Tuple4[string, string, []Label, []Label]
 				// dimension mismatch
 				continue
 			}
-			e[i][index] = floats.ToBF16(embedding.Value)
+			e[i][index] = embedding.Value
 		}
 	}
 	return fm.BatchInternalPredict(x, e, jobs)

--- a/model/ctr/model_test.go
+++ b/model/ctr/model_test.go
@@ -204,8 +204,8 @@ func TestFactorizationMachines_Classification_Synthesis(t *testing.T) {
 				},
 			},
 			[][]Embedding{
-				{{Name: "e1", Value: floats.FromBF16(embeddingsPos[0])}, {Name: "e2", Value: floats.FromBF16(embeddingsPos[1])}},
-				{{Name: "e1", Value: floats.FromBF16(embeddingsNeg[0])}, {Name: "e2", Value: floats.FromBF16(embeddingsNeg[1])}},
+				{{Name: "e1", Value: embeddingsPos[0]}, {Name: "e2", Value: embeddingsPos[1]}},
+				{{Name: "e1", Value: embeddingsNeg[0]}, {Name: "e2", Value: embeddingsNeg[1]}},
 			},
 			fitConfig.Jobs,
 		))
@@ -230,8 +230,8 @@ func TestFactorizationMachines_Classification_Synthesis(t *testing.T) {
 		[][]Embedding{
 			{},
 			{},
-			{{Name: "unknown_embedding", Value: make([]float32, 3)}},
-			{{Name: "unknown_embedding", Value: make([]float32, 3)}},
+			{{Name: "unknown_embedding", Value: make([]uint16, 3)}},
+			{{Name: "unknown_embedding", Value: make([]uint16, 3)}},
 		},
 		fitConfig.Jobs,
 	), 4)


### PR DESCRIPTION
## Summary

This PR migrates embedding storage from float32 to BF16 (bfloat16) format for memory efficiency.

### Changes
- **Item/User label embeddings**: Convert float32/float64 slices to BF16 (uint16) storage
- **CTR model**: Update `Embedding.Value` type from `[]float32` to `[]uint16`
- **Dataset processing**: Add support for direct `[]float32` and `[]float64` label input
- **Tests**: Update test cases to use BF16 format for embedded labels

### Related PRs
- #1245: Implement BF16 euclidean distance
- #1244: Fix BF16 conversion (truncation instead of rounding)
- #1238: Store item embeddings as BF16 in LoadDataFromDatabase

### Benefits
- ~50% memory reduction for embedding storage
- Maintains sufficient precision for ML workloads
- Consistent BF16 usage across the codebase