### PR TITLE
refactor: rename gorse-cli to gorse-bench

### DIFF
--- a/cmd/gorse-bench/main.go
+++ b/cmd/gorse-bench/main.go
@@ -51,7 +51,7 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "gorse-cli",
+	Use:   "gorse-bench",
 	Short: "Gorse command line tool",
 	Run: func(cmd *cobra.Command, args []string) {
 		_ = cmd.Help()
@@ -59,7 +59,7 @@ var rootCmd = &cobra.Command{
 }
 
 var benchLLMCmd = &cobra.Command{
-	Use:   "bench-llm",
+	Use:   "llm",
 	Short: "Benchmark LLM models for ranking",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Load configuration
@@ -467,7 +467,7 @@ func EvaluateEmbedding(cfg *config.Config, train, test dataset.CFSplit, embeddin
 }
 
 var benchEmbeddingCmd = &cobra.Command{
-	Use:   "bench-embedding",
+	Use:   "embedding",
 	Short: "Benchmark embedding models for item-to-item",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Load configuration


### PR DESCRIPTION
## Summary

Rename the benchmarking tool to better reflect its purpose.

### Changes
- Rename `cmd/gorse-cli` directory to `cmd/gorse-bench`
- Change root command from `gorse-cli` to `gorse-bench`
- Rename `bench-llm` command to `llm`
- Rename `bench-embedding` command to `embedding`

### Usage after changes
```bash
gorse-bench llm --config config.toml
gorse-bench embedding --config config.toml
```

### Why
The tool is specifically for benchmarking LLM and embedding models, not a general CLI tool. The shorter command names are also more convenient.