### PR TITLE
Compress embedding vectors in ItemCache to BF16 to save memory

### DIFF
--- a/worker/pipeline.go
+++ b/worker/pipeline.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorse-io/gorse/common/bfloats"
+
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/gorse-io/gorse/common/expression"
 	"github.com/gorse-io/gorse/common/log"
@@ -36,6 +38,41 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 )
+
+// compressLabelsEmbeddings recursively processes Labels and compresses embedding vectors to BF16.
+// This saves memory when storing items in ItemCache.
+func compressLabelsEmbeddings(labels any) any {
+	if labels == nil {
+		return nil
+	}
+	switch typed := labels.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for k, v := range typed {
+			result[k] = compressLabelsEmbeddings(v)
+		}
+		return result
+	case []any:
+		// Try to compress as embedding vector
+		if values, ok := bfloats.FromAny(typed); ok {
+			return values
+		}
+		// Otherwise recursively process each element
+		result := make([]any, len(typed))
+		for i, v := range typed {
+			result[i] = compressLabelsEmbeddings(v)
+		}
+		return result
+	case []float32:
+		return bfloats.FromFloat32(typed)
+	case []float64:
+		return bfloats.FromFloat32(lo.Map(typed, func(f float64, _ int) float32 { return float32(f) }))
+	case []uint16:
+		return typed // Already BF16
+	default:
+		return labels
+	}
+}
 
 type Pipeline struct {
 	Config                   *config.Config
@@ -600,6 +637,7 @@ func (c *ItemCache) GetSlice(ctx context.Context, itemIds []string) ([]*data.Ite
 		return nil, errors.Trace(err)
 	}
 	for _, item := range response {
+		item.Labels = compressLabelsEmbeddings(item.Labels)
 		c.Data.Store(item.ItemId, &item)
 	}
 	items := make([]*data.Item, 0, len(itemIds))

--- a/worker/pipeline.go
+++ b/worker/pipeline.go
@@ -20,9 +20,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gorse-io/gorse/common/bfloats"
-
 	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/common/expression"
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"

--- a/worker/pipeline_test.go
+++ b/worker/pipeline_test.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/gorse-io/gorse/storage/data"
 	"github.com/stretchr/testify/suite"
 )
@@ -66,4 +68,56 @@ func (suite *PipelineTestSuite) TestGetMap() {
 
 func TestPipeline(t *testing.T) {
 	suite.Run(t, new(PipelineTestSuite))
+}
+
+func TestCompressLabelsEmbeddings(t *testing.T) {
+	// Test nil input
+	assert.Nil(t, compressLabelsEmbeddings(nil))
+
+	// Test embedding vector as []any
+	input := []any{1.0, 2.0, 3.0}
+	output := compressLabelsEmbeddings(input)
+	assert.IsType(t, []uint16{}, output)
+	assert.Len(t, output.([]uint16), 3)
+
+	// Test embedding vector as []float32
+	input32 := []float32{1.0, 2.0, 3.0}
+	output32 := compressLabelsEmbeddings(input32)
+	assert.IsType(t, []uint16{}, output32)
+	assert.Len(t, output32.([]uint16), 3)
+
+	// Test embedding vector as []float64
+	input64 := []float64{1.0, 2.0, 3.0}
+	output64 := compressLabelsEmbeddings(input64)
+	assert.IsType(t, []uint16{}, output64)
+	assert.Len(t, output64.([]uint16), 3)
+
+	// Test already compressed []uint16
+	inputU16 := []uint16{0x3f80, 0x4000, 0x4040}
+	outputU16 := compressLabelsEmbeddings(inputU16)
+	assert.Equal(t, inputU16, outputU16)
+
+	// Test map with embedding
+	mapInput := map[string]any{
+		"title": "test item",
+		"embedding": []any{1.0, 2.0, 3.0},
+	}
+	mapOutput := compressLabelsEmbeddings(mapInput)
+	assert.IsType(t, []uint16{}, mapOutput.(map[string]any)["embedding"])
+	assert.Equal(t, "test item", mapOutput.(map[string]any)["title"])
+
+	// Test nested map
+	nestedInput := map[string]any{
+		"features": map[string]any{
+			"embedding": []float32{1.0, 2.0},
+		},
+	}
+	nestedOutput := compressLabelsEmbeddings(nestedInput)
+	assert.IsType(t, []uint16{}, nestedOutput.(map[string]any)["features"].(map[string]any)["embedding"])
+
+	// Test non-embedding []any (strings)
+	strSlice := []any{"tag1", "tag2"}
+	strOutput := compressLabelsEmbeddings(strSlice)
+	assert.IsType(t, []any{}, strOutput)
+	assert.Equal(t, strSlice, strOutput)
 }

--- a/worker/pipeline_test.go
+++ b/worker/pipeline_test.go
@@ -18,9 +18,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/gorse-io/gorse/storage/data"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -99,7 +98,7 @@ func TestCompressLabelsEmbeddings(t *testing.T) {
 
 	// Test map with embedding
 	mapInput := map[string]any{
-		"title": "test item",
+		"title":     "test item",
 		"embedding": []any{1.0, 2.0, 3.0},
 	}
 	mapOutput := compressLabelsEmbeddings(mapInput)


### PR DESCRIPTION
## Summary

When items are loaded from database and cached in `ItemCache`, their `Labels` field contains embedding vectors stored as float32/float64 arrays which consume more memory. This PR adds a `compressLabelsEmbeddings` function that recursively processes `Labels` and converts embedding vectors to BF16 (uint16) format before caching.

## Changes

1. Added `compressLabelsEmbeddings` function in `worker/pipeline.go`:
   - Recursively processes Labels (supports nested maps and arrays)
   - Converts `[]float32`, `[]float64`, and numeric `[]any` to `[]uint16` (BF16)
   - Preserves already compressed `[]uint16` data
   - Preserves non-embedding arrays (e.g., string tags)

2. Modified `ItemCache.GetSlice` to compress Labels before storing items in cache

3. Added unit tests for `compressLabelsEmbeddings`

## Memory Savings

Embedding vectors stored as float32 (4 bytes per element) are compressed to BF16 (2 bytes per element), reducing memory usage by approximately 50%.

For example, with 1 million items each having a 768-dimension embedding:
- Before: ~3GB memory (4 bytes × 768 × 1M)
- After: ~1.5GB memory (2 bytes × 768 × 1M)

## Compatibility

The existing `ctr.ConvertEmbeddings` function already handles `[]uint16` input correctly, so no changes are needed for downstream processing. The CTR model converts BF16 back to float32 only during actual training/prediction.

## Testing

- Added `TestCompressLabelsEmbeddings` unit test
- All existing tests in worker/, model/ctr/, dataset/ pass