### PR TITLE
refactor: remove duplicate bfloat16 conversion functions from floats package

### DIFF
--- a/common/floats/floats.go
+++ b/common/floats/floats.go
@@ -225,29 +225,6 @@ func Sqrt(a []float32) {
 	}
 }
 
-func ToBF16(values []float32) []uint16 {
-	if values == nil {
-		return nil
-	}
-	encoded := make([]uint16, len(values))
-	for i, value := range values {
-		bits := math.Float32bits(value)
-		encoded[i] = uint16(bits >> 16)
-	}
-	return encoded
-}
-
-func FromBF16(values []uint16) []float32 {
-	if values == nil {
-		return nil
-	}
-	decoded := make([]float32, len(values))
-	for i, value := range values {
-		decoded[i] = math.Float32frombits(uint32(value) << 16)
-	}
-	return decoded
-}
-
 // Dot two vectors.
 func Dot(a, b []float32) (ret float32) {
 	if len(a) != len(b) {

--- a/common/floats/floats_test.go
+++ b/common/floats/floats_test.go
@@ -15,7 +15,6 @@
 package floats
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,20 +39,6 @@ func TestZero(t *testing.T) {
 	assert.Equal(t, []float32{0, 0, 0, 0, 0, 0}, a)
 }
 
-func TestToBF16(t *testing.T) {
-	assert.Nil(t, ToBF16(nil))
-	assert.Equal(t, []uint16{0x0000, 0x3f80, 0xc020, 0x3f8c}, ToBF16([]float32{0, 1, -2.5, 1.1}))
-}
-
-func TestFromBF16(t *testing.T) {
-	assert.Nil(t, FromBF16(nil))
-	decoded := FromBF16([]uint16{0x0000, 0x3f80, 0xc020, 0x3f8c})
-	assert.Len(t, decoded, 4)
-	assert.Equal(t, uint32(0x00000000), math.Float32bits(decoded[0]))
-	assert.Equal(t, uint32(0x3f800000), math.Float32bits(decoded[1]))
-	assert.Equal(t, uint32(0xc0200000), math.Float32bits(decoded[2]))
-	assert.Equal(t, uint32(0x3f8c0000), math.Float32bits(decoded[3]))
-}
 
 func TestAdd(t *testing.T) {
 	a := []float32{1, 2, 3, 4}

--- a/model/ctr/data_test.go
+++ b/model/ctr/data_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 
 	"github.com/gorse-io/gorse/common/bfloats"
-	"github.com/gorse-io/gorse/common/floats"
 	"github.com/gorse-io/gorse/dataset"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -136,7 +135,7 @@ func TestDataset_Split(t *testing.T) {
 			{A: int32(3*i + 2), B: 1},
 		})
 		dataSet.ItemEmbeddings = append(dataSet.ItemEmbeddings, [][]uint16{
-			floats.ToBF16([]float32{float32(i), float32(i) + 0.1, float32(i) + 0.2}),
+			bfloats.FromFloat32([]float32{float32(i), float32(i) + 0.1, float32(i) + 0.2}),
 		})
 	}
 	for i := range numUsers {
@@ -175,7 +174,7 @@ func TestDataset_Split(t *testing.T) {
 		dataSet.Index.CountUsers() + dataSet.Index.CountItems() + dataSet.Index.CountUserLabels() + 8,
 		0,
 	}, features)
-	assert.InDeltaSlice(t, []float32{2, 2.09375, 2.1875}, floats.FromBF16(embeddings[0]), 0.001)
+	assert.InDeltaSlice(t, []float32{2, 2.09375, 2.1875}, bfloats.ToFloat32(embeddings[0]), 0.001)
 	assert.Equal(t, []float32{1, 1, 1, 1, 1, 1, 1, 0.5}, values)
 	assert.Equal(t, float32(-1), target)
 

--- a/model/ctr/fm.go
+++ b/model/ctr/fm.go
@@ -26,7 +26,7 @@ import (
 	"github.com/c-bata/goptuna"
 	"github.com/chewxy/math32"
 	"github.com/gorse-io/gorse/common/encoding"
-	"github.com/gorse-io/gorse/common/floats"
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
 	"github.com/gorse-io/gorse/common/nn"
@@ -546,7 +546,7 @@ func (fm *AFM) convertToTensors(x []lo.Tuple2[[]int32, []float32], e [][][]uint1
 		}
 		for j := range fm.embeddingDim {
 			if len(e[i]) > j && len(e[i][j]) == fm.embeddingDim[j] {
-				alignedEmbeddings[j] = append(alignedEmbeddings[j], floats.FromBF16(e[i][j])...)
+				alignedEmbeddings[j] = append(alignedEmbeddings[j], bfloats.ToFloat32(e[i][j])...)
 			} else {
 				alignedEmbeddings[j] = append(alignedEmbeddings[j], make([]float32, fm.embeddingDim[j])...)
 			}

--- a/model/ctr/fm_xla.go
+++ b/model/ctr/fm_xla.go
@@ -273,7 +273,7 @@ func (fm *AFM) BatchInternalPredict(x []lo.Tuple2[[]int32, []float32], e [][][]u
 			}
 			for j := range fm.embeddingDim {
 				if len(e[start+i]) > j && len(e[start+i][j]) == fm.embeddingDim[j] {
-					copy(additionalData[j][i*fm.embeddingDim[j]:], floats.FromBF16(e[start+i][j]))
+					copy(additionalData[j][i*fm.embeddingDim[j]:], bfloats.ToFloat32(e[start+i][j]))
 				}
 			}
 		}
@@ -449,7 +449,7 @@ func (d *ctrDataset) Yield() (spec any, inputs []*tensors.Tensor, labels []*tens
 		}
 		for j := range d.embeddingDim {
 			if len(embeddings) > j && len(embeddings[j]) == d.embeddingDim[j] {
-				copy(additionalData[j][i*d.embeddingDim[j]:], floats.FromBF16(embeddings[j]))
+				copy(additionalData[j][i*d.embeddingDim[j]:], bfloats.ToFloat32(embeddings[j]))
 			}
 		}
 		// Convert target from {-1, 1} to {0, 1} for GoMLX BinaryCrossentropy

--- a/model/ctr/model_test.go
+++ b/model/ctr/model_test.go
@@ -18,7 +18,7 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/gorse-io/gorse/common/floats"
+	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/dataset"
 	"github.com/gorse-io/gorse/model"
 	"github.com/samber/lo"
@@ -150,8 +150,8 @@ func newSynthesisDataset() *Dataset {
 	dataSet.ItemEmbeddingIndex.Add("e2")
 	dataSet.ItemEmbeddingDimension = []int{3, 4}
 	dataSet.ItemEmbeddings = [][][]uint16{
-		{floats.ToBF16([]float32{0.8, 0.8, 0.8}), floats.ToBF16([]float32{0.1, 0.1, 0.1, 0.1})},
-		{floats.ToBF16([]float32{-0.8, -0.8, -0.8}), floats.ToBF16([]float32{-0.1, -0.1, -0.1, -0.1})},
+		{bfloats.FromFloat32([]float32{0.8, 0.8, 0.8}), bfloats.FromFloat32([]float32{0.1, 0.1, 0.1, 0.1})},
+		{bfloats.FromFloat32([]float32{-0.8, -0.8, -0.8}), bfloats.FromFloat32([]float32{-0.1, -0.1, -0.1, -0.1})},
 	}
 
 	dataSet.Users = []int32{0, 0, 1, 1}


### PR DESCRIPTION
## Problem

The `ToBF16` and `FromBF16` functions in `common/floats` package are duplicated with `FromFloat32` and `ToFloat32` in `common/bfloats` package. Both implementations have identical logic:

- `floats.ToBF16` = `bfloats.FromFloat32`: converts float32 → uint16 by taking upper 16 bits
- `floats.FromBF16` = `bfloats.ToFloat32`: converts uint16 → float32 by shifting left 16 bits

This duplication creates maintenance burden and potential inconsistency.

## Solution

Remove the duplicate functions from `floats` package and update all references to use `bfloats` package functions instead.

## Changes

- Deleted `ToBF16` and `FromBF16` from `common/floats/floats.go`
- Deleted related tests from `common/floats/floats_test.go`
- Updated `model/ctr/fm.go`, `model/ctr/fm_xla.go` to use `bfloats.ToFloat32`
- Updated `model/ctr/data_test.go`, `model/ctr/model_test.go` to use `bfloats.FromFloat32` and `bfloats.ToFloat32`