### PR TITLE
refactor: drop redundant int64 in newrandomgenerator

### DIFF
--- a/common/util/random.go
+++ b/common/util/random.go
@@ -28,7 +28,7 @@ type RandomGenerator struct {
 
 // NewRandomGenerator creates a RandomGenerator.
 func NewRandomGenerator(seed int64) RandomGenerator {
-	return RandomGenerator{rand.New(rand.NewSource(int64(seed)))}
+	return RandomGenerator{rand.New(rand.NewSource(seed))}
 }
 
 // UniformVector makes a vec filled with uniform random floats,


### PR DESCRIPTION
### description:
  remove redundant int64(seed) cast in NewRandomGenerator
seed is already int64 from the function signature