### PR TITLE
Add quota limits configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ type Config struct {
 	OIDC      OIDCConfig      `mapstructure:"oidc"`
 	OpenAI    OpenAIConfig    `mapstructure:"openai"`
 	Blob      BlobConfig      `mapstructure:"blob"`
+	Quota     QuotaConfig     `mapstructure:"quota"`
 }
 
 // DatabaseConfig is the configuration for the database.
@@ -463,6 +464,16 @@ type AzureBlobConfig struct {
 	ConnectionString string `mapstructure:"connection_string"`
 }
 
+// QuotaConfig is the configuration for resource quotas.
+type QuotaConfig struct {
+	MaxUsersCount      int `mapstructure:"max_users_count" validate:"gte=0"`      // Max total number of Users (0 = no limit)
+	MaxItemsCount      int `mapstructure:"max_items_count" validate:"gte=0"`      // Max total number of Items (0 = no limit)
+	MaxLabelsSize      int `mapstructure:"max_labels_size" validate:"gte=0"`      // Max size of Labels in bytes (0 = no limit)
+	MaxCommentSize     int `mapstructure:"max_comment_size" validate:"gte=0"`     // Max size of Comment in bytes (0 = no limit)
+	MaxCategoriesCount int `mapstructure:"max_categories_count" validate:"gte=0"` // Max number of Categories per item (0 = no limit)
+	MaxCategoriesSize  int `mapstructure:"max_categories_size" validate:"gte=0"`  // Max size of Categories in bytes (0 = no limit)
+}
+
 func GetDefaultConfig() *Config {
 	return &Config{
 		Database: DatabaseConfig{
@@ -537,6 +548,14 @@ func GetDefaultConfig() *Config {
 		},
 		Blob: BlobConfig{
 			URI: MkDir("blob"),
+		},
+		Quota: QuotaConfig{
+			MaxUsersCount:      0, // No limit by default
+			MaxItemsCount:      0, // No limit by default
+			MaxLabelsSize:      0, // No limit by default
+			MaxCommentSize:     0, // No limit by default
+			MaxCategoriesCount: 0, // No limit by default
+			MaxCategoriesSize:  0, // No limit by default
 		},
 	}
 }
@@ -680,6 +699,13 @@ func setDefault() {
 	viper.SetDefault("tracing.sampler", defaultConfig.Tracing.Sampler)
 	// [blob]
 	viper.SetDefault("blob.uri", defaultConfig.Blob.URI)
+	// [quota]
+	viper.SetDefault("quota.max_users_count", defaultConfig.Quota.MaxUsersCount)
+	viper.SetDefault("quota.max_items_count", defaultConfig.Quota.MaxItemsCount)
+	viper.SetDefault("quota.max_labels_size", defaultConfig.Quota.MaxLabelsSize)
+	viper.SetDefault("quota.max_comment_size", defaultConfig.Quota.MaxCommentSize)
+	viper.SetDefault("quota.max_categories_count", defaultConfig.Quota.MaxCategoriesCount)
+	viper.SetDefault("quota.max_categories_size", defaultConfig.Quota.MaxCategoriesSize)
 }
 
 type configBinding struct {
@@ -733,6 +759,12 @@ var bindings = []configBinding{
 	{"recommend.ranker.reranker_api.url", "RERANKER_URL"},
 	{"recommend.ranker.reranker_api.model", "RERANKER_MODEL"},
 	{"recommend.ranker.reranker_api.auth_token", "RERANKER_AUTH_TOKEN"},
+	{"quota.max_users_count", "GORSE_QUOTA_MAX_USERS_COUNT"},
+	{"quota.max_items_count", "GORSE_QUOTA_MAX_ITEMS_COUNT"},
+	{"quota.max_labels_size", "GORSE_QUOTA_MAX_LABELS_SIZE"},
+	{"quota.max_comment_size", "GORSE_QUOTA_MAX_COMMENT_SIZE"},
+	{"quota.max_categories_count", "GORSE_QUOTA_MAX_CATEGORIES_COUNT"},
+	{"quota.max_categories_size", "GORSE_QUOTA_MAX_CATEGORIES_SIZE"},
 }
 
 // LoadConfig loads configuration from toml file.

--- a/config/config.toml
+++ b/config/config.toml
@@ -442,3 +442,23 @@ embedding_tpm = 1200000
 
 # Log file for OpenAI API.
 log_file = "openai.log"
+
+[quota]
+
+# Maximum total number of Users. 0 means no limit.
+max_users_count = 0
+
+# Maximum total number of Items. 0 means no limit.
+max_items_count = 0
+
+# Maximum size of Labels in bytes. Multi-byte UTF-8 characters count by bytes. 0 means no limit.
+max_labels_size = 0
+
+# Maximum size of Comment in bytes. Multi-byte UTF-8 characters count by bytes. 0 means no limit.
+max_comment_size = 0
+
+# Maximum number of Categories per item. 0 means no limit.
+max_categories_count = 0
+
+# Maximum size of Categories JSON in bytes. Multi-byte UTF-8 characters count by bytes. 0 means no limit.
+max_categories_size = 0

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -254,6 +254,12 @@ func TestBindEnv(t *testing.T) {
 		{"RERANKER_AUTH_TOKEN", "<reranker_auth_token>"},
 		{"RERANKER_URL", "<reranker_url>"},
 		{"RERANKER_MODEL", "<reranker_model>"},
+		{"GORSE_QUOTA_MAX_USERS_COUNT", "9"},
+		{"GORSE_QUOTA_MAX_ITEMS_COUNT", "10"},
+		{"GORSE_QUOTA_MAX_LABELS_SIZE", "11"},
+		{"GORSE_QUOTA_MAX_COMMENT_SIZE", "12"},
+		{"GORSE_QUOTA_MAX_CATEGORIES_COUNT", "13"},
+		{"GORSE_QUOTA_MAX_CATEGORIES_SIZE", "14"},
 	}
 	for _, variable := range variables {
 		t.Setenv(variable.key, variable.value)
@@ -305,6 +311,12 @@ func TestBindEnv(t *testing.T) {
 	assert.Equal(t, "<reranker_auth_token>", config.Recommend.Ranker.RerankerAPI.AuthToken)
 	assert.Equal(t, "<reranker_url>", config.Recommend.Ranker.RerankerAPI.URL)
 	assert.Equal(t, "<reranker_model>", config.Recommend.Ranker.RerankerAPI.Model)
+	assert.Equal(t, 9, config.Quota.MaxUsersCount)
+	assert.Equal(t, 10, config.Quota.MaxItemsCount)
+	assert.Equal(t, 11, config.Quota.MaxLabelsSize)
+	assert.Equal(t, 12, config.Quota.MaxCommentSize)
+	assert.Equal(t, 13, config.Quota.MaxCategoriesCount)
+	assert.Equal(t, 14, config.Quota.MaxCategoriesSize)
 
 	// check default values
 	assert.Equal(t, 100, config.Recommend.CacheSize)
@@ -529,6 +541,12 @@ func (s *ValidateTestSuite) TestSearchColumns() {
 
 func TestValidate(t *testing.T) {
 	suite.Run(t, new(ValidateTestSuite))
+}
+
+func (s *ValidateTestSuite) TestQuota() {
+	s.NoError(s.Validate())
+	s.Quota.MaxLabelsSize = -1
+	s.Error(s.Validate())
 }
 
 func (s *ValidateTestSuite) TestCacheStore() {

--- a/server/rest.go
+++ b/server/rest.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gorse-io/gorse/common/event"
 	"github.com/gorse-io/gorse/common/expression"
 	"github.com/gorse-io/gorse/common/heap"
+	"github.com/gorse-io/gorse/common/jsonutil"
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/logics"
@@ -1037,6 +1038,149 @@ type Success struct {
 	RowAffected int
 }
 
+func validateJSONSize(name string, value any, limit int) error {
+	if limit <= 0 || value == nil {
+		return nil
+	}
+	buf := jsonutil.MustMarshal(value)
+	if len(buf) > limit {
+		return errors.Errorf("%s size exceeds limit (%d > %d bytes)", name, len(buf), limit)
+	}
+	return nil
+}
+
+func validateItemSize(item data.Item, quota config.QuotaConfig) error {
+	if err := validateJSONSize("item labels", item.Labels, quota.MaxLabelsSize); err != nil {
+		return err
+	}
+	if quota.MaxCommentSize > 0 && len(item.Comment) > quota.MaxCommentSize {
+		return errors.Errorf("item comment size exceeds limit (%d > %d bytes)",
+			len(item.Comment), quota.MaxCommentSize)
+	}
+	if quota.MaxCategoriesCount > 0 && len(item.Categories) > quota.MaxCategoriesCount {
+		return errors.Errorf("item categories count exceeds limit (%d > %d)",
+			len(item.Categories), quota.MaxCategoriesCount)
+	}
+	if len(item.Categories) > 0 {
+		if err := validateJSONSize("item categories", item.Categories, quota.MaxCategoriesSize); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateItemPatchSize(patch data.ItemPatch, quota config.QuotaConfig) error {
+	if err := validateJSONSize("item labels", patch.Labels, quota.MaxLabelsSize); err != nil {
+		return err
+	}
+	if quota.MaxCommentSize > 0 && patch.Comment != nil && len(*patch.Comment) > quota.MaxCommentSize {
+		return errors.Errorf("item comment size exceeds limit (%d > %d bytes)",
+			len(*patch.Comment), quota.MaxCommentSize)
+	}
+	if quota.MaxCategoriesCount > 0 && patch.Categories != nil && len(patch.Categories) > quota.MaxCategoriesCount {
+		return errors.Errorf("item categories count exceeds limit (%d > %d)",
+			len(patch.Categories), quota.MaxCategoriesCount)
+	}
+	if patch.Categories != nil {
+		if err := validateJSONSize("item categories", patch.Categories, quota.MaxCategoriesSize); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateUserSize(user data.User, quota config.QuotaConfig) error {
+	if err := validateJSONSize("user labels", user.Labels, quota.MaxLabelsSize); err != nil {
+		return err
+	}
+	if quota.MaxCommentSize > 0 && len(user.Comment) > quota.MaxCommentSize {
+		return errors.Errorf("user comment size exceeds limit (%d > %d bytes)",
+			len(user.Comment), quota.MaxCommentSize)
+	}
+	return nil
+}
+
+func validateUserPatchSize(patch data.UserPatch, quota config.QuotaConfig) error {
+	if err := validateJSONSize("user labels", patch.Labels, quota.MaxLabelsSize); err != nil {
+		return err
+	}
+	if quota.MaxCommentSize > 0 && patch.Comment != nil && len(*patch.Comment) > quota.MaxCommentSize {
+		return errors.Errorf("user comment size exceeds limit (%d > %d bytes)",
+			len(*patch.Comment), quota.MaxCommentSize)
+	}
+	return nil
+}
+
+func validateFeedbackSize(feedback data.Feedback, quota config.QuotaConfig) error {
+	if err := validateJSONSize("feedback labels", feedback.Labels, quota.MaxLabelsSize); err != nil {
+		return err
+	}
+	if quota.MaxCommentSize > 0 && len(feedback.Comment) > quota.MaxCommentSize {
+		return errors.Errorf("feedback comment size exceeds limit (%d > %d bytes)",
+			len(feedback.Comment), quota.MaxCommentSize)
+	}
+	return nil
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		unique = append(unique, value)
+	}
+	return unique
+}
+
+func (s *RestServer) checkUserCountLimit(ctx context.Context, userIds []string) error {
+	limit := s.Config.Quota.MaxUsersCount
+	if limit <= 0 {
+		return nil
+	}
+	totalUsers, err := s.DataClient.CountUsers(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	newUsers := 0
+	for _, userId := range uniqueStrings(userIds) {
+		if _, err = s.DataClient.GetUser(ctx, userId); err != nil {
+			if errors.Is(err, errors.NotFound) {
+				newUsers++
+				continue
+			}
+			return errors.Trace(err)
+		}
+	}
+	if totalUsers+newUsers > limit {
+		return errors.Errorf("users count exceeds limit (%d > %d)", totalUsers+newUsers, limit)
+	}
+	return nil
+}
+
+func (s *RestServer) checkItemCountLimit(ctx context.Context, itemIds []string) error {
+	limit := s.Config.Quota.MaxItemsCount
+	if limit <= 0 {
+		return nil
+	}
+	totalItems, err := s.DataClient.CountItems(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	uniqueItemIds := uniqueStrings(itemIds)
+	existedItems, err := s.DataClient.BatchGetItems(ctx, uniqueItemIds, data.GetOptions{ReturnId: true})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	newItems := len(uniqueItemIds) - len(existedItems)
+	if totalItems+newItems > limit {
+		return errors.Errorf("items count exceeds limit (%d > %d)", totalItems+newItems, limit)
+	}
+	return nil
+}
+
 func (s *RestServer) insertUser(request *restful.Request, response *restful.Response) {
 	ctx := context.Background()
 	if request != nil && request.Request != nil {
@@ -1050,6 +1194,14 @@ func (s *RestServer) insertUser(request *restful.Request, response *restful.Resp
 	}
 	// validate labels
 	if err := data.ValidateLabels(temp.Labels); err != nil {
+		BadRequest(response, err)
+		return
+	}
+	if err := validateUserSize(temp, s.Config.Quota); err != nil {
+		BadRequest(response, err)
+		return
+	}
+	if err := s.checkUserCountLimit(ctx, []string{temp.UserId}); err != nil {
 		BadRequest(response, err)
 		return
 	}
@@ -1080,6 +1232,10 @@ func (s *RestServer) modifyUser(request *restful.Request, response *restful.Resp
 	}
 	// validate labels
 	if err := data.ValidateLabels(patch.Labels); err != nil {
+		BadRequest(response, err)
+		return
+	}
+	if err := validateUserPatchSize(patch, s.Config.Quota); err != nil {
 		BadRequest(response, err)
 		return
 	}
@@ -1131,6 +1287,16 @@ func (s *RestServer) insertUsers(request *restful.Request, response *restful.Res
 			BadRequest(response, err)
 			return
 		}
+		if err := validateUserSize(user, s.Config.Quota); err != nil {
+			BadRequest(response, err)
+			return
+		}
+	}
+	if err := s.checkUserCountLimit(ctx, lo.Map(temp, func(user data.User, index int) string {
+		return user.UserId
+	})); err != nil {
+		BadRequest(response, err)
+		return
 	}
 	// range temp and achieve user
 	if err := s.DataClient.BatchInsertUsers(ctx, temp); err != nil {
@@ -1257,6 +1423,12 @@ func (s *RestServer) batchInsertItems(ctx context.Context, response *restful.Res
 	for _, item := range existedItems {
 		existedItemsSet[item.ItemId] = item
 	}
+	if err = s.checkItemCountLimit(ctx, lo.Map(temp, func(item Item, index int) string {
+		return item.ItemId
+	})); err != nil {
+		BadRequest(response, err)
+		return
+	}
 	loadExistedItemsTime = time.Since(start)
 
 	start = time.Now()
@@ -1270,14 +1442,19 @@ func (s *RestServer) batchInsertItems(ctx context.Context, response *restful.Res
 				return
 			}
 		}
-		items = append(items, data.Item{
+		dataItem := data.Item{
 			ItemId:     item.ItemId,
 			IsHidden:   item.IsHidden,
 			Categories: item.Categories,
 			Timestamp:  timestamp,
 			Labels:     item.Labels,
 			Comment:    item.Comment,
-		})
+		}
+		if err = validateItemSize(dataItem, s.Config.Quota); err != nil {
+			BadRequest(response, err)
+			return
+		}
+		items = append(items, dataItem)
 		// update items cache
 		if err = s.CacheClient.UpdateScores(ctx, cache.ItemCache, nil, item.ItemId, cache.ScorePatch{
 			Categories: withWildCard(item.Categories),
@@ -1371,6 +1548,10 @@ func (s *RestServer) modifyItem(request *restful.Request, response *restful.Resp
 	}
 	// validate labels
 	if err := data.ValidateLabels(patch.Labels); err != nil {
+		BadRequest(response, err)
+		return
+	}
+	if err := validateItemPatchSize(patch, s.Config.Quota); err != nil {
 		BadRequest(response, err)
 		return
 	}
@@ -1498,6 +1679,10 @@ func (s *RestServer) insertItemCategory(request *restful.Request, response *rest
 	if !lo.Contains(item.Categories, category) {
 		item.Categories = append(item.Categories, category)
 	}
+	if err = validateItemSize(item, s.Config.Quota); err != nil {
+		BadRequest(response, err)
+		return
+	}
 	// insert category to database
 	if err = s.DataClient.BatchInsertItems(ctx, []data.Item{item}); err != nil {
 		InternalServerError(response, err)
@@ -1592,6 +1777,26 @@ func (s *RestServer) insertFeedback(overwrite bool) func(request *restful.Reques
 			items.Add(feedbackLiterTime[i].ItemId)
 			feedback[i], err = feedbackLiterTime[i].ToDataFeedback()
 			if err != nil {
+				BadRequest(response, err)
+				return
+			}
+			if err = data.ValidateLabels(feedback[i].Labels); err != nil {
+				BadRequest(response, err)
+				return
+			}
+			if err = validateFeedbackSize(feedback[i], s.Config.Quota); err != nil {
+				BadRequest(response, err)
+				return
+			}
+		}
+		if s.Config.Server.AutoInsertUser {
+			if err = s.checkUserCountLimit(ctx, users.ToSlice()); err != nil {
+				BadRequest(response, err)
+				return
+			}
+		}
+		if s.Config.Server.AutoInsertItem {
+			if err = s.checkItemCountLimit(ctx, items.ToSlice()); err != nil {
 				BadRequest(response, err)
 				return
 			}

--- a/server/rest.go
+++ b/server/rest.go
@@ -1038,101 +1038,65 @@ type Success struct {
 	RowAffected int
 }
 
-func validateJSONSize(name string, value any, limit int) error {
-	if limit <= 0 || value == nil {
+func (s *RestServer) checkLabelsSize(labels any) error {
+	limit := s.Config.Quota.MaxLabelsSize
+	if limit <= 0 || labels == nil {
 		return nil
 	}
-	buf := jsonutil.MustMarshal(value)
+	buf := jsonutil.MustMarshal(labels)
 	if len(buf) > limit {
-		return errors.Errorf("%s size exceeds limit (%d > %d bytes)", name, len(buf), limit)
+		return errors.Errorf("labels size exceeds limit (%d > %d bytes)", len(buf), limit)
 	}
 	return nil
 }
 
-func validateItemSize(item data.Item, quota config.QuotaConfig) error {
-	if err := validateJSONSize("item labels", item.Labels, quota.MaxLabelsSize); err != nil {
-		return err
-	}
-	if quota.MaxCommentSize > 0 && len(item.Comment) > quota.MaxCommentSize {
-		return errors.Errorf("item comment size exceeds limit (%d > %d bytes)",
-			len(item.Comment), quota.MaxCommentSize)
-	}
-	if quota.MaxCategoriesCount > 0 && len(item.Categories) > quota.MaxCategoriesCount {
+func (s *RestServer) checkCategoriesSize(categories []string) error {
+	countLimit := s.Config.Quota.MaxCategoriesCount
+	if countLimit > 0 && len(categories) > countLimit {
 		return errors.Errorf("item categories count exceeds limit (%d > %d)",
-			len(item.Categories), quota.MaxCategoriesCount)
+			len(categories), countLimit)
 	}
-	if len(item.Categories) > 0 {
-		if err := validateJSONSize("item categories", item.Categories, quota.MaxCategoriesSize); err != nil {
-			return err
+	sizeLimit := s.Config.Quota.MaxCategoriesSize
+	if sizeLimit <= 0 {
+		return nil
+	}
+	for _, category := range categories {
+		if len(category) > sizeLimit {
+			return errors.Errorf("category size exceeds limit (%d > %d bytes)", len(category), sizeLimit)
 		}
 	}
 	return nil
 }
 
-func validateItemPatchSize(patch data.ItemPatch, quota config.QuotaConfig) error {
-	if err := validateJSONSize("item labels", patch.Labels, quota.MaxLabelsSize); err != nil {
-		return err
-	}
-	if quota.MaxCommentSize > 0 && patch.Comment != nil && len(*patch.Comment) > quota.MaxCommentSize {
-		return errors.Errorf("item comment size exceeds limit (%d > %d bytes)",
-			len(*patch.Comment), quota.MaxCommentSize)
-	}
-	if quota.MaxCategoriesCount > 0 && patch.Categories != nil && len(patch.Categories) > quota.MaxCategoriesCount {
-		return errors.Errorf("item categories count exceeds limit (%d > %d)",
-			len(patch.Categories), quota.MaxCategoriesCount)
-	}
-	if patch.Categories != nil {
-		if err := validateJSONSize("item categories", patch.Categories, quota.MaxCategoriesSize); err != nil {
-			return err
-		}
+func (s *RestServer) checkCommentSize(comment string) error {
+	limit := s.Config.Quota.MaxCommentSize
+	if limit > 0 && len(comment) > limit {
+		return errors.Errorf("comment size exceeds limit (%d > %d bytes)", len(comment), limit)
 	}
 	return nil
 }
 
-func validateUserSize(user data.User, quota config.QuotaConfig) error {
-	if err := validateJSONSize("user labels", user.Labels, quota.MaxLabelsSize); err != nil {
+func (s *RestServer) checkItemSize(item data.Item) error {
+	if err := s.checkLabelsSize(item.Labels); err != nil {
 		return err
 	}
-	if quota.MaxCommentSize > 0 && len(user.Comment) > quota.MaxCommentSize {
-		return errors.Errorf("user comment size exceeds limit (%d > %d bytes)",
-			len(user.Comment), quota.MaxCommentSize)
+	if err := s.checkCommentSize(item.Comment); err != nil {
+		return err
+	}
+	if err := s.checkCategoriesSize(item.Categories); err != nil {
+		return err
 	}
 	return nil
 }
 
-func validateUserPatchSize(patch data.UserPatch, quota config.QuotaConfig) error {
-	if err := validateJSONSize("user labels", patch.Labels, quota.MaxLabelsSize); err != nil {
+func (s *RestServer) checkUserSize(user data.User) error {
+	if err := s.checkLabelsSize(user.Labels); err != nil {
 		return err
 	}
-	if quota.MaxCommentSize > 0 && patch.Comment != nil && len(*patch.Comment) > quota.MaxCommentSize {
-		return errors.Errorf("user comment size exceeds limit (%d > %d bytes)",
-			len(*patch.Comment), quota.MaxCommentSize)
-	}
-	return nil
-}
-
-func validateFeedbackSize(feedback data.Feedback, quota config.QuotaConfig) error {
-	if err := validateJSONSize("feedback labels", feedback.Labels, quota.MaxLabelsSize); err != nil {
+	if err := s.checkCommentSize(user.Comment); err != nil {
 		return err
 	}
-	if quota.MaxCommentSize > 0 && len(feedback.Comment) > quota.MaxCommentSize {
-		return errors.Errorf("feedback comment size exceeds limit (%d > %d bytes)",
-			len(feedback.Comment), quota.MaxCommentSize)
-	}
 	return nil
-}
-
-func uniqueStrings(values []string) []string {
-	seen := make(map[string]struct{}, len(values))
-	unique := make([]string, 0, len(values))
-	for _, value := range values {
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		unique = append(unique, value)
-	}
-	return unique
 }
 
 func (s *RestServer) checkUserCountLimit(ctx context.Context, userIds []string) error {
@@ -1142,20 +1106,11 @@ func (s *RestServer) checkUserCountLimit(ctx context.Context, userIds []string) 
 	}
 	totalUsers, err := s.DataClient.CountUsers(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		log.Logger().Warn("failed to check user count limit", zap.Error(err))
+		return nil
 	}
-	newUsers := 0
-	for _, userId := range uniqueStrings(userIds) {
-		if _, err = s.DataClient.GetUser(ctx, userId); err != nil {
-			if errors.Is(err, errors.NotFound) {
-				newUsers++
-				continue
-			}
-			return errors.Trace(err)
-		}
-	}
-	if totalUsers+newUsers > limit {
-		return errors.Errorf("users count exceeds limit (%d > %d)", totalUsers+newUsers, limit)
+	if totalUsers+len(userIds) > limit {
+		return errors.Errorf("users count exceeds limit (%d > %d)", totalUsers+len(userIds), limit)
 	}
 	return nil
 }
@@ -1167,16 +1122,11 @@ func (s *RestServer) checkItemCountLimit(ctx context.Context, itemIds []string) 
 	}
 	totalItems, err := s.DataClient.CountItems(ctx)
 	if err != nil {
-		return errors.Trace(err)
+		log.Logger().Warn("failed to check item count limit", zap.Error(err))
+		return nil
 	}
-	uniqueItemIds := uniqueStrings(itemIds)
-	existedItems, err := s.DataClient.BatchGetItems(ctx, uniqueItemIds, data.GetOptions{ReturnId: true})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	newItems := len(uniqueItemIds) - len(existedItems)
-	if totalItems+newItems > limit {
-		return errors.Errorf("items count exceeds limit (%d > %d)", totalItems+newItems, limit)
+	if totalItems+len(itemIds) > limit {
+		return errors.Errorf("items count exceeds limit (%d > %d)", totalItems+len(itemIds), limit)
 	}
 	return nil
 }
@@ -1197,12 +1147,12 @@ func (s *RestServer) insertUser(request *restful.Request, response *restful.Resp
 		BadRequest(response, err)
 		return
 	}
-	if err := validateUserSize(temp, s.Config.Quota); err != nil {
-		BadRequest(response, err)
+	if err := s.checkUserSize(temp); err != nil {
+		TooManyRequests(response, err)
 		return
 	}
 	if err := s.checkUserCountLimit(ctx, []string{temp.UserId}); err != nil {
-		BadRequest(response, err)
+		TooManyRequests(response, err)
 		return
 	}
 	if err := s.DataClient.BatchInsertUsers(ctx, []data.User{temp}); err != nil {
@@ -1235,9 +1185,15 @@ func (s *RestServer) modifyUser(request *restful.Request, response *restful.Resp
 		BadRequest(response, err)
 		return
 	}
-	if err := validateUserPatchSize(patch, s.Config.Quota); err != nil {
-		BadRequest(response, err)
+	if err := s.checkLabelsSize(patch.Labels); err != nil {
+		TooManyRequests(response, err)
 		return
+	}
+	if patch.Comment != nil {
+		if err := s.checkCommentSize(*patch.Comment); err != nil {
+			TooManyRequests(response, err)
+			return
+		}
 	}
 	if err := s.DataClient.ModifyUser(ctx, userId, patch); err != nil {
 		InternalServerError(response, err)
@@ -1287,15 +1243,15 @@ func (s *RestServer) insertUsers(request *restful.Request, response *restful.Res
 			BadRequest(response, err)
 			return
 		}
-		if err := validateUserSize(user, s.Config.Quota); err != nil {
-			BadRequest(response, err)
+		if err := s.checkUserSize(user); err != nil {
+			TooManyRequests(response, err)
 			return
 		}
 	}
 	if err := s.checkUserCountLimit(ctx, lo.Map(temp, func(user data.User, index int) string {
 		return user.UserId
 	})); err != nil {
-		BadRequest(response, err)
+		TooManyRequests(response, err)
 		return
 	}
 	// range temp and achieve user
@@ -1426,7 +1382,7 @@ func (s *RestServer) batchInsertItems(ctx context.Context, response *restful.Res
 	if err = s.checkItemCountLimit(ctx, lo.Map(temp, func(item Item, index int) string {
 		return item.ItemId
 	})); err != nil {
-		BadRequest(response, err)
+		TooManyRequests(response, err)
 		return
 	}
 	loadExistedItemsTime = time.Since(start)
@@ -1450,8 +1406,8 @@ func (s *RestServer) batchInsertItems(ctx context.Context, response *restful.Res
 			Labels:     item.Labels,
 			Comment:    item.Comment,
 		}
-		if err = validateItemSize(dataItem, s.Config.Quota); err != nil {
-			BadRequest(response, err)
+		if err = s.checkItemSize(dataItem); err != nil {
+			TooManyRequests(response, err)
 			return
 		}
 		items = append(items, dataItem)
@@ -1551,9 +1507,21 @@ func (s *RestServer) modifyItem(request *restful.Request, response *restful.Resp
 		BadRequest(response, err)
 		return
 	}
-	if err := validateItemPatchSize(patch, s.Config.Quota); err != nil {
-		BadRequest(response, err)
+	if err := s.checkLabelsSize(patch.Labels); err != nil {
+		TooManyRequests(response, err)
 		return
+	}
+	if patch.Comment != nil {
+		if err := s.checkCommentSize(*patch.Comment); err != nil {
+			TooManyRequests(response, err)
+			return
+		}
+	}
+	if patch.Categories != nil {
+		if err := s.checkCategoriesSize(patch.Categories); err != nil {
+			TooManyRequests(response, err)
+			return
+		}
 	}
 	// remove hidden item from cache
 	if patch.IsHidden != nil {
@@ -1679,8 +1647,8 @@ func (s *RestServer) insertItemCategory(request *restful.Request, response *rest
 	if !lo.Contains(item.Categories, category) {
 		item.Categories = append(item.Categories, category)
 	}
-	if err = validateItemSize(item, s.Config.Quota); err != nil {
-		BadRequest(response, err)
+	if err = s.checkItemSize(item); err != nil {
+		TooManyRequests(response, err)
 		return
 	}
 	// insert category to database
@@ -1784,20 +1752,24 @@ func (s *RestServer) insertFeedback(overwrite bool) func(request *restful.Reques
 				BadRequest(response, err)
 				return
 			}
-			if err = validateFeedbackSize(feedback[i], s.Config.Quota); err != nil {
-				BadRequest(response, err)
+			if err = s.checkLabelsSize(feedback[i].Labels); err != nil {
+				TooManyRequests(response, err)
+				return
+			}
+			if err = s.checkCommentSize(feedback[i].Comment); err != nil {
+				TooManyRequests(response, err)
 				return
 			}
 		}
 		if s.Config.Server.AutoInsertUser {
 			if err = s.checkUserCountLimit(ctx, users.ToSlice()); err != nil {
-				BadRequest(response, err)
+				TooManyRequests(response, err)
 				return
 			}
 		}
 		if s.Config.Server.AutoInsertItem {
 			if err = s.checkItemCountLimit(ctx, items.ToSlice()); err != nil {
-				BadRequest(response, err)
+				TooManyRequests(response, err)
 				return
 			}
 		}
@@ -1978,6 +1950,15 @@ func BadRequest(response *restful.Response, err error) {
 	response.Header().Set("Access-Control-Allow-Origin", "*")
 	log.ResponseLogger(response).Error("bad request", zap.Error(err))
 	if err = response.WriteError(http.StatusBadRequest, err); err != nil {
+		log.ResponseLogger(response).Error("failed to write error", zap.Error(err))
+	}
+}
+
+// TooManyRequests returns a too many requests error.
+func TooManyRequests(response *restful.Response, err error) {
+	response.Header().Set("Access-Control-Allow-Origin", "*")
+	log.ResponseLogger(response).Error("too many requests", zap.Error(err))
+	if err = response.WriteError(http.StatusTooManyRequests, err); err != nil {
 		log.ResponseLogger(response).Error("failed to write error", zap.Error(err))
 	}
 }

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -570,6 +570,172 @@ func (suite *ServerTestSuite) TestItems() {
 		End()
 }
 
+func (suite *ServerTestSuite) TestQuota() {
+	t := suite.T()
+
+	suite.Config.Quota.MaxUsersCount = 1
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/user").
+		Header("X-API-Key", apiKey).
+		JSON(data.User{UserId: "limited-user-1"}).
+		Expect(t).
+		Status(http.StatusOK).
+		End()
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/user").
+		Header("X-API-Key", apiKey).
+		JSON(data.User{UserId: "limited-user-2"}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/users").
+		Header("X-API-Key", apiKey).
+		JSON([]data.User{{UserId: "limited-user-1", Comment: "updated"}}).
+		Expect(t).
+		Status(http.StatusOK).
+		End()
+	suite.Config.Quota.MaxUsersCount = 0
+
+	suite.Config.Quota.MaxItemsCount = 1
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/item").
+		Header("X-API-Key", apiKey).
+		JSON(Item{ItemId: "limited-item-1"}).
+		Expect(t).
+		Status(http.StatusOK).
+		End()
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/item").
+		Header("X-API-Key", apiKey).
+		JSON(Item{ItemId: "limited-item-2"}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/items").
+		Header("X-API-Key", apiKey).
+		JSON([]Item{{ItemId: "limited-item-1", Comment: "updated"}}).
+		Expect(t).
+		Status(http.StatusOK).
+		End()
+	suite.Config.Quota.MaxItemsCount = 0
+
+	suite.Config.Quota.MaxCommentSize = 3
+	apittestUser := data.User{UserId: "oversized-user-comment", Comment: "toolong"}
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/user").
+		Header("X-API-Key", apiKey).
+		JSON(apittestUser).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	comment := "toolong"
+	apitest.New().
+		Handler(suite.handler).
+		Patch("/api/user/oversized-user-comment").
+		Header("X-API-Key", apiKey).
+		JSON(data.UserPatch{Comment: &comment}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	suite.Config.Quota.MaxCommentSize = 0
+	suite.Config.Quota.MaxLabelsSize = 5
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/users").
+		Header("X-API-Key", apiKey).
+		JSON([]data.User{{UserId: "oversized-user-labels", Labels: []string{"abcdef"}}}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	suite.Config.Quota.MaxLabelsSize = 0
+	suite.Config.Quota.MaxCommentSize = 3
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/item").
+		Header("X-API-Key", apiKey).
+		JSON(Item{ItemId: "oversized-item-comment", Comment: "toolong"}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	itemComment := "toolong"
+	apitest.New().
+		Handler(suite.handler).
+		Patch("/api/item/oversized-item-comment").
+		Header("X-API-Key", apiKey).
+		JSON(data.ItemPatch{Comment: &itemComment}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	suite.Config.Quota.MaxCommentSize = 0
+	suite.Config.Quota.MaxLabelsSize = 5
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/items").
+		Header("X-API-Key", apiKey).
+		JSON([]Item{{ItemId: "oversized-item-labels", Labels: []string{"abcdef"}}}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	suite.Config.Quota.MaxLabelsSize = 0
+	suite.Config.Quota.MaxCategoriesCount = 1
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/item").
+		Header("X-API-Key", apiKey).
+		JSON(Item{ItemId: "too-many-categories", Categories: []string{"a", "b"}}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	suite.Config.Quota.MaxCategoriesCount = 0
+	suite.Config.Quota.MaxCategoriesSize = 5
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/item").
+		Header("X-API-Key", apiKey).
+		JSON(Item{ItemId: "oversized-categories", Categories: []string{"abcdef"}}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	suite.Config.Quota.MaxCategoriesSize = 0
+	suite.Config.Quota.MaxLabelsSize = 5
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/feedback").
+		Header("X-API-Key", apiKey).
+		JSON([]Feedback{{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "u", ItemId: "i"}, Labels: []string{"abcdef"}}}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+
+	suite.Config.Quota.MaxLabelsSize = 0
+	suite.Config.Quota.MaxCommentSize = 3
+	apitest.New().
+		Handler(suite.handler).
+		Post("/api/feedback").
+		Header("X-API-Key", apiKey).
+		JSON([]Feedback{{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "u", ItemId: "i"}, Comment: "toolong"}}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		End()
+}
+
 func (suite *ServerTestSuite) TestSearchItems() {
 	t := suite.T()
 

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -588,15 +588,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON(data.User{UserId: "limited-user-2"}).
 		Expect(t).
-		Status(http.StatusBadRequest).
-		End()
-	apitest.New().
-		Handler(suite.handler).
-		Post("/api/users").
-		Header("X-API-Key", apiKey).
-		JSON([]data.User{{UserId: "limited-user-1", Comment: "updated"}}).
-		Expect(t).
-		Status(http.StatusOK).
+		Status(http.StatusTooManyRequests).
 		End()
 	suite.Config.Quota.MaxUsersCount = 0
 
@@ -615,15 +607,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON(Item{ItemId: "limited-item-2"}).
 		Expect(t).
-		Status(http.StatusBadRequest).
-		End()
-	apitest.New().
-		Handler(suite.handler).
-		Post("/api/items").
-		Header("X-API-Key", apiKey).
-		JSON([]Item{{ItemId: "limited-item-1", Comment: "updated"}}).
-		Expect(t).
-		Status(http.StatusOK).
+		Status(http.StatusTooManyRequests).
 		End()
 	suite.Config.Quota.MaxItemsCount = 0
 
@@ -635,7 +619,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON(apittestUser).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	comment := "toolong"
@@ -645,7 +629,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON(data.UserPatch{Comment: &comment}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	suite.Config.Quota.MaxCommentSize = 0
@@ -656,7 +640,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON([]data.User{{UserId: "oversized-user-labels", Labels: []string{"abcdef"}}}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	suite.Config.Quota.MaxLabelsSize = 0
@@ -667,7 +651,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON(Item{ItemId: "oversized-item-comment", Comment: "toolong"}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	itemComment := "toolong"
@@ -677,7 +661,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON(data.ItemPatch{Comment: &itemComment}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	suite.Config.Quota.MaxCommentSize = 0
@@ -688,7 +672,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON([]Item{{ItemId: "oversized-item-labels", Labels: []string{"abcdef"}}}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	suite.Config.Quota.MaxLabelsSize = 0
@@ -699,7 +683,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON(Item{ItemId: "too-many-categories", Categories: []string{"a", "b"}}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	suite.Config.Quota.MaxCategoriesCount = 0
@@ -710,7 +694,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON(Item{ItemId: "oversized-categories", Categories: []string{"abcdef"}}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	suite.Config.Quota.MaxCategoriesSize = 0
@@ -721,7 +705,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON([]Feedback{{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "u", ItemId: "i"}, Labels: []string{"abcdef"}}}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 
 	suite.Config.Quota.MaxLabelsSize = 0
@@ -732,7 +716,7 @@ func (suite *ServerTestSuite) TestQuota() {
 		Header("X-API-Key", apiKey).
 		JSON([]Feedback{{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "u", ItemId: "i"}, Comment: "toolong"}}).
 		Expect(t).
-		Status(http.StatusBadRequest).
+		Status(http.StatusTooManyRequests).
 		End()
 }
 

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -621,18 +621,16 @@ func (suite *ServerTestSuite) TestQuota() {
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
-	comment := "toolong"
 	apitest.New().
 		Handler(suite.handler).
 		Patch("/api/user/oversized-user-comment").
 		Header("X-API-Key", apiKey).
-		JSON(data.UserPatch{Comment: &comment}).
+		JSON(data.UserPatch{Comment: new("toolong")}).
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
 	suite.Config.Quota.MaxCommentSize = 0
+
 	suite.Config.Quota.MaxLabelsSize = 5
 	apitest.New().
 		Handler(suite.handler).
@@ -642,8 +640,8 @@ func (suite *ServerTestSuite) TestQuota() {
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
 	suite.Config.Quota.MaxLabelsSize = 0
+
 	suite.Config.Quota.MaxCommentSize = 3
 	apitest.New().
 		Handler(suite.handler).
@@ -653,18 +651,16 @@ func (suite *ServerTestSuite) TestQuota() {
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
-	itemComment := "toolong"
 	apitest.New().
 		Handler(suite.handler).
 		Patch("/api/item/oversized-item-comment").
 		Header("X-API-Key", apiKey).
-		JSON(data.ItemPatch{Comment: &itemComment}).
+		JSON(data.ItemPatch{Comment: new("toolong")}).
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
 	suite.Config.Quota.MaxCommentSize = 0
+
 	suite.Config.Quota.MaxLabelsSize = 5
 	apitest.New().
 		Handler(suite.handler).
@@ -674,8 +670,8 @@ func (suite *ServerTestSuite) TestQuota() {
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
 	suite.Config.Quota.MaxLabelsSize = 0
+
 	suite.Config.Quota.MaxCategoriesCount = 1
 	apitest.New().
 		Handler(suite.handler).
@@ -685,8 +681,8 @@ func (suite *ServerTestSuite) TestQuota() {
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
 	suite.Config.Quota.MaxCategoriesCount = 0
+
 	suite.Config.Quota.MaxCategoriesSize = 5
 	apitest.New().
 		Handler(suite.handler).
@@ -696,8 +692,8 @@ func (suite *ServerTestSuite) TestQuota() {
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
 	suite.Config.Quota.MaxCategoriesSize = 0
+
 	suite.Config.Quota.MaxLabelsSize = 5
 	apitest.New().
 		Handler(suite.handler).
@@ -707,8 +703,8 @@ func (suite *ServerTestSuite) TestQuota() {
 		Expect(t).
 		Status(http.StatusTooManyRequests).
 		End()
-
 	suite.Config.Quota.MaxLabelsSize = 0
+
 	suite.Config.Quota.MaxCommentSize = 3
 	apitest.New().
 		Handler(suite.handler).


### PR DESCRIPTION
## Summary

This PR adds configurable quota limits to prevent oversized payloads and unbounded record growth in SaaS deployments.

## Changes

- **Config**: Added `QuotaConfig` with total user/item count limits plus shared payload limits for item, user, and feedback data.
- **Validation**: Added helpers for item/user/feedback insert and patch payloads.
- **Enforcement**: Integrated quota checks into REST write paths for users, items, item categories, and feedback auto-insert paths.
- **Coverage**: Added config, validator, and REST API tests for exceeded quotas.

## Configuration Example

```toml
[quota]
max_users_count = 1000000          # Max total users
max_items_count = 1000000          # Max total items
max_labels_size = 65536            # Max labels JSON size for item/user/feedback
max_comment_size = 1024            # Max comment size for item/user/feedback
max_categories_count = 10          # Max categories per item
max_categories_size = 4096         # Max item categories JSON size
```

## Notes

- All quotas default to `0` (no limit) for backward compatibility.
- Label and comment limits are shared by items, users, and feedback.
- Category limits apply to items only.
- Size quotas are measured in bytes after JSON serialization for structured fields; multi-byte UTF-8 characters count by bytes.
- Count quotas apply to total users/items and only count newly inserted records, so updates to existing users/items remain allowed.
- Quotas are per deployment/config, not per-tenant quotas.

## Reference

Inspired by Pinecone's approach to data limits for vector database SaaS:
- [Pinecone Limits Documentation](https://docs.pinecone.io/reference/limits)
