### PR TITLE
fix: remove redundant slice operation in hash sum calculations

### DIFF
--- a/common/util/util.go
+++ b/common/util/util.go
@@ -95,5 +95,5 @@ func MD5(s ...string) string {
 	for _, str := range s {
 		hash.Write([]byte(str))
 	}
-	return hex.EncodeToString(hash.Sum(nil)[:])
+	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/config/config.go
+++ b/config/config.go
@@ -264,7 +264,7 @@ func (config *NonPersonalizedConfig) Hash() string {
 	hash.Write([]byte(config.Name))
 	hash.Write([]byte(config.Score))
 	hash.Write([]byte(config.Filter))
-	return hex.EncodeToString(hash.Sum(nil)[:])
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 type ItemToItemConfig struct {
@@ -291,7 +291,7 @@ func (config *ItemToItemConfig) Hash(cfg *RecommendConfig) string {
 			hash.Write([]byte(expr.String()))
 		}
 	}
-	return hex.EncodeToString(hash.Sum(nil)[:])
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 type UserToUserConfig struct {
@@ -317,7 +317,7 @@ func (config *UserToUserConfig) Hash(cfg *RecommendConfig) string {
 			hash.Write([]byte(expr.String()))
 		}
 	}
-	return hex.EncodeToString(hash.Sum(nil)[:])
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 type CollaborativeConfig struct {
@@ -341,7 +341,7 @@ func (config *CollaborativeConfig) Hash(cfg *RecommendConfig) string {
 	for _, expr := range cfg.DataSource.NegativeFeedbackTypes {
 		hash.Write([]byte(expr.String()))
 	}
-	return hex.EncodeToString(hash.Sum(nil)[:])
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 type EarlyStoppingConfig struct {
@@ -361,7 +361,7 @@ func (config *ExternalConfig) Hash() string {
 	hash := md5.New()
 	hash.Write([]byte(config.Name))
 	hash.Write([]byte(config.Script))
-	return hex.EncodeToString(hash.Sum(nil)[:])
+	return hex.EncodeToString(hash.Sum(nil))
 }
 
 type ReplacementConfig struct {


### PR DESCRIPTION
## summary 
drop the redundant [:] after hash.Sum(nil) in util.go and the five Hash() methods in config file 
Sum on a hash.Hash already returns []byte, so reslicing it does nothing
no behavior change, just less noise