### PR TITLE
ci: pin Milvus standalone setup script

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -116,7 +116,7 @@ jobs:
 
     - name: Setup Milvus
       run: |
-        curl -sfL https://raw.githubusercontent.com/milvus-io/milvus/master/scripts/standalone_embed.sh -o standalone_embed.sh
+        curl -sfL https://raw.githubusercontent.com/milvus-io/milvus/6da09b8b02b1/scripts/standalone_embed.sh -o standalone_embed.sh
         bash standalone_embed.sh start
       working-directory: ${{ runner.temp }}
 


### PR DESCRIPTION
## Motivation

The unit test workflow downloads Milvus' `standalone_embed.sh` from the upstream `master` branch. Milvus recently changed that script to use `milvusdb/milvus:v3.0-beta`, which can fail to start in CI because the image now runs as `milvus:milvus` and cannot create `/var/lib/milvus/data` in the mounted volume.

When the container exits, the upstream script keeps waiting for a healthy container forever, so the GitHub Actions job gets stuck in `Setup Milvus`.

## Changes

Pin the Milvus standalone setup script to commit `6da09b8b02b1`, which still uses `milvusdb/milvus:v2.6.14` and matches the previously passing CI behavior.

## Validation

- Parsed `.github/workflows/build_test.yml` as YAML locally.
- Ran `git diff --check`.
- Locally reproduced that the current upstream script uses `v3.0-beta` and exits with `permission denied` while `v2.6.14` starts successfully.
