### PR TITLE
refactor: rename llm benchmark to reranker

### DIFF
--- a/cmd/gorse-bench/main.go
+++ b/cmd/gorse-bench/main.go
@@ -176,7 +176,7 @@ func EvaluateAFM(cfg *config.Config, train, test *ctr.Dataset, exportUserAUC boo
 	var count float32
 	for userIndex, posIndices := range positives {
 		negIndices := negatives[userIndex]
-		if len(negIndices) == 0 || feedbackCount[userIndex] == 0 || feedbackCount[userIndex] > cfg.Recommend.ContextSize {
+		if len(posIndices) == 0 || len(negIndices) == 0 || feedbackCount[userIndex] == 0 || feedbackCount[userIndex] > cfg.Recommend.ContextSize {
 			continue
 		}
 		var posPredictions, negPredictions []float32
@@ -264,7 +264,7 @@ func EvaluateReranker(cfg *config.Config, train, test *ctr.Dataset, items []data
 	lo.Must0(parallel.ForEach(context.Background(), slices.Collect(maps.Keys(positives)), runtime.NumCPU(), func(_ int, userIndex int32) {
 		posIndices := positives[userIndex]
 		negIndices := negatives[userIndex]
-		if len(negIndices) == 0 {
+		if len(posIndices) == 0 || len(negIndices) == 0 {
 			return
 		}
 		candidates := make([]*data.Item, 0, len(posIndices)+len(negIndices))

--- a/cmd/gorse-bench/main.go
+++ b/cmd/gorse-bench/main.go
@@ -58,9 +58,9 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-var benchLLMCmd = &cobra.Command{
-	Use:   "llm",
-	Short: "Benchmark LLM models for ranking",
+var benchRerankerCmd = &cobra.Command{
+	Use:   "reranker",
+	Short: "Benchmark reranker models for ranking",
 	Run: func(cmd *cobra.Command, args []string) {
 		// Load configuration
 		configPath, _ := cmd.Flags().GetString("config")
@@ -93,7 +93,7 @@ var benchLLMCmd = &cobra.Command{
 
 		// Split dataset
 		var scores sync.Map
-		train, test := dataset.Split(0.2, 0)
+		train, test := dataset.SplitByUserTime(0.2)
 
 		table := tablewriter.NewWriter(os.Stdout)
 		table.Header([]string{"", "#interactions", "#positive", "#negative"})
@@ -106,7 +106,7 @@ var benchLLMCmd = &cobra.Command{
 
 		exportUserAUC, _ := cmd.Flags().GetBool("user-auc")
 		go EvaluateAFM(cfg, train, test, exportUserAUC, &scores)
-		EvaluateLLM(cfg, train, test, cfDataset.GetItems(), exportUserAUC, &scores)
+		EvaluateReranker(cfg, train, test, cfDataset.GetItems(), exportUserAUC, &scores)
 		data := [][]string{{"Ranker", "GAUC"}}
 		scores.Range(func(key, value any) bool {
 			data = append(data, []string{
@@ -206,7 +206,7 @@ func EvaluateAFM(cfg *config.Config, train, test *ctr.Dataset, exportUserAUC boo
 	scores.Store("AFM", score)
 }
 
-func EvaluateLLM(cfg *config.Config, train, test *ctr.Dataset, items []data.Item, exportUserAUC bool, scores *sync.Map) {
+func EvaluateReranker(cfg *config.Config, train, test *ctr.Dataset, items []data.Item, exportUserAUC bool, scores *sync.Map) {
 	chat, err := logics.NewChatReranker(
 		cfg.Recommend.Ranker.RerankerAPI,
 		cfg.Recommend.Ranker.QueryTemplate,
@@ -249,7 +249,7 @@ func EvaluateLLM(cfg *config.Config, train, test *ctr.Dataset, items []data.Item
 		var err error
 		csvFile, err = os.Create(fmt.Sprintf("%s.csv", cfg.Recommend.Ranker.RerankerAPI.Model))
 		if err != nil {
-			log.Logger().Error("failed to create LLM.csv", zap.Error(err))
+			log.Logger().Error("failed to create reranker csv", zap.Error(err))
 			exportUserAUC = false
 		} else {
 			defer csvFile.Close()
@@ -555,9 +555,9 @@ var benchEmbeddingCmd = &cobra.Command{
 func init() {
 	rootCmd.PersistentFlags().StringP("config", "c", "", "Path to configuration file")
 	rootCmd.PersistentFlags().IntP("jobs", "j", runtime.NumCPU(), "Number of jobs to run in parallel")
-	rootCmd.AddCommand(benchLLMCmd)
+	rootCmd.AddCommand(benchRerankerCmd)
 	rootCmd.AddCommand(benchEmbeddingCmd)
-	benchLLMCmd.PersistentFlags().Bool("user-auc", false, "Export user-level AUC scores to CSV file")
+	benchRerankerCmd.PersistentFlags().Bool("user-auc", false, "Export user-level AUC scores to CSV file")
 	benchEmbeddingCmd.PersistentFlags().IntP("top", "k", 10, "Number of top items to evaluate for each user")
 	benchEmbeddingCmd.PersistentFlags().IntP("shots", "s", math.MaxInt, "Number of shots for each user")
 	benchEmbeddingCmd.PersistentFlags().Int("embedding-dimensions", 0, "Embedding dimensions")

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -435,12 +435,8 @@ func (m *Master) LoadDataFromDatabase(
 		}
 	}
 
-	// create positive set
-	positiveSet := make([]mapset.Set[int32], dataSet.CountUsers())
-	positiveTimestamps := make([]map[int32]time.Time, dataSet.CountUsers())
-	for i := range positiveSet {
-		positiveSet[i] = mapset.NewSet[int32]()
-	}
+	// create positive feedback map
+	positiveFeedback := make([]sync.Map, dataSet.CountUsers())
 
 	// split item groups
 	sort.Slice(items, func(i, j int) bool {
@@ -528,15 +524,18 @@ func (m *Master) LoadDataFromDatabase(
 				if negativeSet != nil && negativeSet[userIndex].Contains(itemIndex) {
 					continue
 				}
-				// insert feedback to positive set
+				// insert feedback to positive map
+				for {
+					timestamp, loaded := positiveFeedback[userIndex].LoadOrStore(itemIndex, f.Timestamp)
+					if !loaded || !f.Timestamp.After(timestamp.(time.Time)) {
+						break
+					}
+					if positiveFeedback[userIndex].CompareAndSwap(itemIndex, timestamp, f.Timestamp) {
+						break
+					}
+				}
+
 				mu.Lock()
-				positiveSet[userIndex].Add(itemIndex)
-				if positiveTimestamps[userIndex] == nil {
-					positiveTimestamps[userIndex] = make(map[int32]time.Time)
-				}
-				if timestamp, ok := positiveTimestamps[userIndex][itemIndex]; !ok || f.Timestamp.After(timestamp) {
-					positiveTimestamps[userIndex][itemIndex] = f.Timestamp
-				}
 				posFeedbackCount++
 				// insert feedback to evaluator
 				evaluator.Add(f.FeedbackType, f.Value, userIndex, itemIndex, f.Timestamp)
@@ -623,7 +622,8 @@ func (m *Master) LoadDataFromDatabase(
 					continue
 				}
 				// skip if already in negative feedback set or positive set
-				if (negativeSet != nil && negativeSet[userIndex].Contains(itemIndex)) || positiveSet[userIndex].Contains(itemIndex) {
+				_, hasPositiveFeedback := positiveFeedback[userIndex].Load(itemIndex)
+				if (negativeSet != nil && negativeSet[userIndex].Contains(itemIndex)) || hasPositiveFeedback {
 					continue
 				}
 				mu.Lock()
@@ -685,7 +685,7 @@ func (m *Master) LoadDataFromDatabase(
 		}
 	}
 	ctrDataset.ItemEmbeddings = itemEmbeddings
-	for userIndex := range positiveSet {
+	for userIndex := range positiveFeedback {
 		// insert explicit negative feedback (highest priority)
 		if negativeSet != nil {
 			for _, itemIndex := range negativeSet[userIndex].ToSlice() {
@@ -697,13 +697,14 @@ func (m *Master) LoadDataFromDatabase(
 			}
 		}
 		// insert positive feedback
-		for _, itemIndex := range positiveSet[userIndex].ToSlice() {
+		positiveFeedback[userIndex].Range(func(itemIndex, timestamp any) bool {
 			ctrDataset.Users = append(ctrDataset.Users, int32(userIndex))
-			ctrDataset.Items = append(ctrDataset.Items, itemIndex)
+			ctrDataset.Items = append(ctrDataset.Items, itemIndex.(int32))
 			ctrDataset.Target = append(ctrDataset.Target, 1)
-			ctrDataset.Timestamps = append(ctrDataset.Timestamps, positiveTimestamps[userIndex][itemIndex])
+			ctrDataset.Timestamps = append(ctrDataset.Timestamps, timestamp.(time.Time))
 			ctrDataset.PositiveCount++
-		}
+			return true
+		})
 		// insert read feedback (implicit negative)
 		for _, itemIndex := range readSet[userIndex].ToSlice() {
 			ctrDataset.Users = append(ctrDataset.Users, int32(userIndex))
@@ -716,7 +717,6 @@ func (m *Master) LoadDataFromDatabase(
 		if negativeSet != nil {
 			negativeSet[userIndex] = nil
 		}
-		positiveSet[userIndex] = nil
 		readSet[userIndex] = nil
 	}
 	log.Logger().Debug("created ranking dataset",

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -426,8 +426,10 @@ func (m *Master) LoadDataFromDatabase(
 
 	// create negative feedback set (highest priority)
 	var negativeSet []mapset.Set[int32]
+	var negativeTimestamps []map[int32]time.Time
 	if len(negFeedbackTypes) > 0 {
 		negativeSet = make([]mapset.Set[int32], dataSet.CountUsers())
+		negativeTimestamps = make([]map[int32]time.Time, dataSet.CountUsers())
 		for i := range negativeSet {
 			negativeSet[i] = mapset.NewSet[int32]()
 		}
@@ -435,6 +437,7 @@ func (m *Master) LoadDataFromDatabase(
 
 	// create positive set
 	positiveSet := make([]mapset.Set[int32], dataSet.CountUsers())
+	positiveTimestamps := make([]map[int32]time.Time, dataSet.CountUsers())
 	for i := range positiveSet {
 		positiveSet[i] = mapset.NewSet[int32]()
 	}
@@ -468,8 +471,14 @@ func (m *Master) LoadDataFromDatabase(
 					if itemIndex == dataset.NotId {
 						continue
 					}
-					negativeSet[userIndex].Add(itemIndex)
 					mu.Lock()
+					negativeSet[userIndex].Add(itemIndex)
+					if negativeTimestamps[userIndex] == nil {
+						negativeTimestamps[userIndex] = make(map[int32]time.Time)
+					}
+					if timestamp, ok := negativeTimestamps[userIndex][itemIndex]; !ok || f.Timestamp.After(timestamp) {
+						negativeTimestamps[userIndex][itemIndex] = f.Timestamp
+					}
 					explicitNegativeFeedbackCount++
 					evaluator.Add(f.FeedbackType, f.Value, userIndex, itemIndex, f.Timestamp)
 					mu.Unlock()
@@ -520,9 +529,14 @@ func (m *Master) LoadDataFromDatabase(
 					continue
 				}
 				// insert feedback to positive set
-				positiveSet[userIndex].Add(itemIndex)
-
 				mu.Lock()
+				positiveSet[userIndex].Add(itemIndex)
+				if positiveTimestamps[userIndex] == nil {
+					positiveTimestamps[userIndex] = make(map[int32]time.Time)
+				}
+				if timestamp, ok := positiveTimestamps[userIndex][itemIndex]; !ok || f.Timestamp.After(timestamp) {
+					positiveTimestamps[userIndex][itemIndex] = f.Timestamp
+				}
 				posFeedbackCount++
 				// insert feedback to evaluator
 				evaluator.Add(f.FeedbackType, f.Value, userIndex, itemIndex, f.Timestamp)
@@ -583,6 +597,7 @@ func (m *Master) LoadDataFromDatabase(
 
 	// create read set (implicit negative feedback)
 	readSet := make([]mapset.Set[int32], dataSet.CountUsers())
+	readTimestamps := make([]map[int32]time.Time, dataSet.CountUsers())
 	for i := range readSet {
 		readSet[i] = mapset.NewSet[int32]()
 	}
@@ -611,8 +626,14 @@ func (m *Master) LoadDataFromDatabase(
 				if (negativeSet != nil && negativeSet[userIndex].Contains(itemIndex)) || positiveSet[userIndex].Contains(itemIndex) {
 					continue
 				}
-				readSet[userIndex].Add(itemIndex)
 				mu.Lock()
+				readSet[userIndex].Add(itemIndex)
+				if readTimestamps[userIndex] == nil {
+					readTimestamps[userIndex] = make(map[int32]time.Time)
+				}
+				if timestamp, ok := readTimestamps[userIndex][itemIndex]; !ok || f.Timestamp.After(timestamp) {
+					readTimestamps[userIndex][itemIndex] = f.Timestamp
+				}
 				readFeedbackCount++
 				evaluator.Add(f.FeedbackType, f.Value, userIndex, itemIndex, f.Timestamp)
 				mu.Unlock()
@@ -671,6 +692,7 @@ func (m *Master) LoadDataFromDatabase(
 				ctrDataset.Users = append(ctrDataset.Users, int32(userIndex))
 				ctrDataset.Items = append(ctrDataset.Items, itemIndex)
 				ctrDataset.Target = append(ctrDataset.Target, -1)
+				ctrDataset.Timestamps = append(ctrDataset.Timestamps, negativeTimestamps[userIndex][itemIndex])
 				ctrDataset.NegativeCount++
 			}
 		}
@@ -679,6 +701,7 @@ func (m *Master) LoadDataFromDatabase(
 			ctrDataset.Users = append(ctrDataset.Users, int32(userIndex))
 			ctrDataset.Items = append(ctrDataset.Items, itemIndex)
 			ctrDataset.Target = append(ctrDataset.Target, 1)
+			ctrDataset.Timestamps = append(ctrDataset.Timestamps, positiveTimestamps[userIndex][itemIndex])
 			ctrDataset.PositiveCount++
 		}
 		// insert read feedback (implicit negative)
@@ -686,6 +709,7 @@ func (m *Master) LoadDataFromDatabase(
 			ctrDataset.Users = append(ctrDataset.Users, int32(userIndex))
 			ctrDataset.Items = append(ctrDataset.Items, itemIndex)
 			ctrDataset.Target = append(ctrDataset.Target, -1)
+			ctrDataset.Timestamps = append(ctrDataset.Timestamps, readTimestamps[userIndex][itemIndex])
 			ctrDataset.NegativeCount++
 		}
 		// release sets

--- a/model/ctr/data.go
+++ b/model/ctr/data.go
@@ -368,9 +368,7 @@ func (dataset *Dataset) Split(ratio float32, seed int64) (*Dataset, *Dataset) {
 				testSet.ContextLabels = append(testSet.ContextLabels, dataset.ContextLabels[i])
 			}
 			testSet.Target = append(testSet.Target, dataset.Target[i])
-			if len(dataset.Timestamps) > 0 {
-				testSet.Timestamps = append(testSet.Timestamps, dataset.Timestamps[i])
-			}
+			testSet.Timestamps = append(testSet.Timestamps, dataset.Timestamps[i])
 			if dataset.Target[i] > 0 {
 				testSet.PositiveCount++
 			} else {
@@ -384,9 +382,7 @@ func (dataset *Dataset) Split(ratio float32, seed int64) (*Dataset, *Dataset) {
 				trainSet.ContextLabels = append(trainSet.ContextLabels, dataset.ContextLabels[i])
 			}
 			trainSet.Target = append(trainSet.Target, dataset.Target[i])
-			if len(dataset.Timestamps) > 0 {
-				trainSet.Timestamps = append(trainSet.Timestamps, dataset.Timestamps[i])
-			}
+			trainSet.Timestamps = append(trainSet.Timestamps, dataset.Timestamps[i])
 			if dataset.Target[i] > 0 {
 				trainSet.PositiveCount++
 			} else {
@@ -398,14 +394,9 @@ func (dataset *Dataset) Split(ratio float32, seed int64) (*Dataset, *Dataset) {
 }
 
 // SplitByUserTime splits the dataset within each user by timestamp. Earlier samples are used for
-// training and the latest samples are used for testing. Users whose test samples don't contain
-// both positive and negative samples are removed from both train and test. At least one sample is
-// kept in train for every user with two or more samples. If timestamps are unavailable, it falls
-// back to random split.
+// training and the latest samples are used for testing. At least one sample is kept in train for
+// every user with two or more samples.
 func (dataset *Dataset) SplitByUserTime(ratio float32) (*Dataset, *Dataset) {
-	if len(dataset.Timestamps) != dataset.Count() {
-		return dataset.Split(ratio, 0)
-	}
 	trainSet := &Dataset{
 		Index:                  dataset.Index,
 		UserLabels:             dataset.UserLabels,
@@ -442,17 +433,6 @@ func (dataset *Dataset) SplitByUserTime(ratio float32) (*Dataset, *Dataset) {
 			numTest = len(samples) - 1
 		}
 		splitIndex := len(samples) - numTest
-		var hasPositiveTestSample, hasNegativeTestSample bool
-		for _, sampleIndex := range samples[splitIndex:] {
-			if dataset.Target[sampleIndex] > 0 {
-				hasPositiveTestSample = true
-			} else {
-				hasNegativeTestSample = true
-			}
-		}
-		if !hasPositiveTestSample || !hasNegativeTestSample {
-			continue
-		}
 		for i, sampleIndex := range samples {
 			if i >= splitIndex {
 				dataset.appendSample(testSet, sampleIndex)
@@ -471,9 +451,7 @@ func (dataset *Dataset) appendSample(dst *Dataset, i int) {
 		dst.ContextLabels = append(dst.ContextLabels, dataset.ContextLabels[i])
 	}
 	dst.Target = append(dst.Target, dataset.Target[i])
-	if len(dataset.Timestamps) > 0 {
-		dst.Timestamps = append(dst.Timestamps, dataset.Timestamps[i])
-	}
+	dst.Timestamps = append(dst.Timestamps, dataset.Timestamps[i])
 	if dataset.Target[i] > 0 {
 		dst.PositiveCount++
 	} else {

--- a/model/ctr/data.go
+++ b/model/ctr/data.go
@@ -18,8 +18,10 @@ import (
 	"bufio"
 	"encoding/json"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/gorse-io/gorse/common/bfloats"
@@ -155,6 +157,7 @@ type Dataset struct {
 	Users                  []int32
 	Items                  []int32
 	Target                 []float32
+	Timestamps             []time.Time
 	ItemEmbeddings         [][][]uint16 // Index by row id, embedding id, embedding dimension; stored as BF16 bits
 	ItemEmbeddingDimension []int
 	ItemEmbeddingIndex     *dataset.Index
@@ -365,6 +368,9 @@ func (dataset *Dataset) Split(ratio float32, seed int64) (*Dataset, *Dataset) {
 				testSet.ContextLabels = append(testSet.ContextLabels, dataset.ContextLabels[i])
 			}
 			testSet.Target = append(testSet.Target, dataset.Target[i])
+			if len(dataset.Timestamps) > 0 {
+				testSet.Timestamps = append(testSet.Timestamps, dataset.Timestamps[i])
+			}
 			if dataset.Target[i] > 0 {
 				testSet.PositiveCount++
 			} else {
@@ -378,6 +384,9 @@ func (dataset *Dataset) Split(ratio float32, seed int64) (*Dataset, *Dataset) {
 				trainSet.ContextLabels = append(trainSet.ContextLabels, dataset.ContextLabels[i])
 			}
 			trainSet.Target = append(trainSet.Target, dataset.Target[i])
+			if len(dataset.Timestamps) > 0 {
+				trainSet.Timestamps = append(trainSet.Timestamps, dataset.Timestamps[i])
+			}
 			if dataset.Target[i] > 0 {
 				trainSet.PositiveCount++
 			} else {
@@ -386,6 +395,90 @@ func (dataset *Dataset) Split(ratio float32, seed int64) (*Dataset, *Dataset) {
 		}
 	}
 	return trainSet, testSet
+}
+
+// SplitByUserTime splits the dataset within each user by timestamp. Earlier samples are used for
+// training and the latest samples are used for testing. Users whose test samples don't contain
+// both positive and negative samples are removed from both train and test. At least one sample is
+// kept in train for every user with two or more samples. If timestamps are unavailable, it falls
+// back to random split.
+func (dataset *Dataset) SplitByUserTime(ratio float32) (*Dataset, *Dataset) {
+	if len(dataset.Timestamps) != dataset.Count() {
+		return dataset.Split(ratio, 0)
+	}
+	trainSet := &Dataset{
+		Index:                  dataset.Index,
+		UserLabels:             dataset.UserLabels,
+		ItemLabels:             dataset.ItemLabels,
+		ItemEmbeddings:         dataset.ItemEmbeddings,
+		ItemEmbeddingIndex:     dataset.ItemEmbeddingIndex,
+		ItemEmbeddingDimension: dataset.ItemEmbeddingDimension,
+	}
+	testSet := &Dataset{
+		Index:                  dataset.Index,
+		UserLabels:             dataset.UserLabels,
+		ItemLabels:             dataset.ItemLabels,
+		ItemEmbeddings:         dataset.ItemEmbeddings,
+		ItemEmbeddingIndex:     dataset.ItemEmbeddingIndex,
+		ItemEmbeddingDimension: dataset.ItemEmbeddingDimension,
+	}
+
+	userSamples := make([][]int, dataset.CountUsers())
+	for i, userIndex := range dataset.Users {
+		userSamples[int(userIndex)] = append(userSamples[int(userIndex)], i)
+	}
+	for _, samples := range userSamples {
+		if len(samples) == 0 {
+			continue
+		}
+		sort.Slice(samples, func(i, j int) bool {
+			return dataset.Timestamps[samples[i]].Before(dataset.Timestamps[samples[j]])
+		})
+		numTest := int(float32(len(samples)) * ratio)
+		if numTest == 0 && len(samples) > 1 {
+			numTest = 1
+		}
+		if numTest >= len(samples) {
+			numTest = len(samples) - 1
+		}
+		splitIndex := len(samples) - numTest
+		var hasPositiveTestSample, hasNegativeTestSample bool
+		for _, sampleIndex := range samples[splitIndex:] {
+			if dataset.Target[sampleIndex] > 0 {
+				hasPositiveTestSample = true
+			} else {
+				hasNegativeTestSample = true
+			}
+		}
+		if !hasPositiveTestSample || !hasNegativeTestSample {
+			continue
+		}
+		for i, sampleIndex := range samples {
+			if i >= splitIndex {
+				dataset.appendSample(testSet, sampleIndex)
+			} else {
+				dataset.appendSample(trainSet, sampleIndex)
+			}
+		}
+	}
+	return trainSet, testSet
+}
+
+func (dataset *Dataset) appendSample(dst *Dataset, i int) {
+	dst.Users = append(dst.Users, dataset.Users[i])
+	dst.Items = append(dst.Items, dataset.Items[i])
+	if dataset.ContextLabels != nil {
+		dst.ContextLabels = append(dst.ContextLabels, dataset.ContextLabels[i])
+	}
+	dst.Target = append(dst.Target, dataset.Target[i])
+	if len(dataset.Timestamps) > 0 {
+		dst.Timestamps = append(dst.Timestamps, dataset.Timestamps[i])
+	}
+	if dataset.Target[i] > 0 {
+		dst.PositiveCount++
+	} else {
+		dst.NegativeCount++
+	}
 }
 
 func (dataset *Dataset) GetItemEmbeddingDim() []int {

--- a/model/ctr/data_test.go
+++ b/model/ctr/data_test.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gorse-io/gorse/common/bfloats"
 	"github.com/gorse-io/gorse/dataset"
@@ -145,12 +146,14 @@ func TestDataset_Split(t *testing.T) {
 				dataSet.Items = append(dataSet.Items, int32(j))
 				dataSet.ContextLabels = append(dataSet.ContextLabels, []lo.Tuple2[int32, float32]{{A: int32(i * j), B: 0.5}})
 				dataSet.Target = append(dataSet.Target, 1)
+				dataSet.Timestamps = append(dataSet.Timestamps, time.Unix(int64(i*numItems+j), 0))
 				dataSet.PositiveCount++
 			} else {
 				dataSet.Users = append(dataSet.Users, int32(i))
 				dataSet.Items = append(dataSet.Items, int32(j))
 				dataSet.ContextLabels = append(dataSet.ContextLabels, []lo.Tuple2[int32, float32]{{A: int32(i * j), B: 0.5}})
 				dataSet.Target = append(dataSet.Target, -1)
+				dataSet.Timestamps = append(dataSet.Timestamps, time.Unix(int64(i*numItems+j), 0))
 				dataSet.NegativeCount++
 			}
 		}
@@ -190,4 +193,79 @@ func TestDataset_Split(t *testing.T) {
 	assert.Equal(t, 6, test.Count())
 	assert.Equal(t, 3, test.PositiveCount)
 	assert.Equal(t, 3, test.NegativeCount)
+}
+
+func TestDataset_SplitByUserTime(t *testing.T) {
+	unifiedIndex := dataset.NewUnifiedMapIndexBuilder()
+	for i := range 3 {
+		unifiedIndex.AddUser(fmt.Sprintf("user%v", i))
+	}
+	for i := range 6 {
+		unifiedIndex.AddItem(fmt.Sprintf("item%v", i))
+	}
+
+	dataSet := &Dataset{
+		Index: unifiedIndex.Build(),
+		Users: []int32{
+			0, 0, 0,
+			1, 1,
+			2,
+		},
+		Items: []int32{
+			0, 1, 2,
+			3, 4,
+			5,
+		},
+		Target: []float32{
+			1, -1, 1,
+			-1, 1,
+			-1,
+		},
+		Timestamps: []time.Time{
+			time.Unix(30, 0), time.Unix(10, 0), time.Unix(20, 0),
+			time.Unix(40, 0), time.Unix(50, 0),
+			time.Unix(60, 0),
+		},
+		PositiveCount: 3,
+		NegativeCount: 3,
+	}
+
+	train, test := dataSet.SplitByUserTime(0.5)
+
+	type sample struct {
+		User      int32
+		Item      int32
+		Target    float32
+		Timestamp int64
+	}
+	collect := func(dataSet *Dataset) []sample {
+		samples := make([]sample, 0, dataSet.Count())
+		for i := range dataSet.Count() {
+			samples = append(samples, sample{
+				User:      dataSet.Users[i],
+				Item:      dataSet.Items[i],
+				Target:    dataSet.Target[i],
+				Timestamp: dataSet.Timestamps[i].Unix(),
+			})
+		}
+		return samples
+	}
+
+	assert.Equal(t, 4, train.Count())
+	assert.Equal(t, 1, train.PositiveCount)
+	assert.Equal(t, 3, train.NegativeCount)
+	assert.ElementsMatch(t, []sample{
+		{User: 0, Item: 1, Target: -1, Timestamp: 10},
+		{User: 0, Item: 2, Target: 1, Timestamp: 20},
+		{User: 1, Item: 3, Target: -1, Timestamp: 40},
+		{User: 2, Item: 5, Target: -1, Timestamp: 60},
+	}, collect(train))
+
+	assert.Equal(t, 2, test.Count())
+	assert.Equal(t, 2, test.PositiveCount)
+	assert.Equal(t, 0, test.NegativeCount)
+	assert.ElementsMatch(t, []sample{
+		{User: 0, Item: 0, Target: 1, Timestamp: 30},
+		{User: 1, Item: 4, Target: 1, Timestamp: 50},
+	}, collect(test))
 }


### PR DESCRIPTION
## Summary
- rename `gorse-bench llm` to `gorse-bench reranker`
- add CTR sample timestamps and user-level time-based splitting
- use the latest 20% samples per user for reranker evaluation, dropping users whose test set lacks both positive and negative samples

## Tests
- `/usr/local/go/bin/go test ./model/ctr ./cmd/gorse-bench ./master`
