### PR TITLE
Update README to include MariaDB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more information：
 
 ## Architecture
 
-Gorse is a single-node training and distributed prediction recommender system. Gorse stores data in MySQL, MongoDB, Postgres, or ClickHouse, with intermediate results cached in Redis, MySQL, MongoDB and Postgres.
+Gorse is a single-node training and distributed prediction recommender system. Gorse stores data in MySQL, MariaDB, MongoDB, Postgres, or ClickHouse, with intermediate results cached in Redis, MySQL, MariaDB, MongoDB and Postgres.
 
 1. The cluster consists of a master node, multiple worker nodes, and server nodes.
 1. The master node is responsible for model training, non-personalized recommendation, configuration management, and membership management.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more information：
 
 ## Architecture
 
-Gorse is a single-node training and distributed prediction recommender system. Gorse stores data in MySQL, MariaDB, MongoDB, Postgres, or ClickHouse, with intermediate results cached in Redis, MySQL, MariaDB, MongoDB and Postgres.
+Gorse is a single-node training and distributed prediction recommender system. Gorse stores data in MySQL (MariaDB), MongoDB, Postgres, or ClickHouse, with intermediate results cached in Redis, MySQL (MariaDB), MongoDB and Postgres.
 
 1. The cluster consists of a master node, multiple worker nodes, and server nodes.
 1. The master node is responsible for model training, non-personalized recommendation, configuration management, and membership management.


### PR DESCRIPTION
Updated database references to include MariaDB in the README. CI runs compatibility tests against MariaDB 10.2 (compat_test in .github/workflows/build_test.yml), and the cache SQL backend detects MariaDB at runtime. Users connect with the same mysql:// URIs as for MySQL.