### PR TITLE
fix(dataset): make feedback count safe during concurrent loading

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/chewxy/math32"
@@ -87,7 +88,7 @@ type Dataset struct {
 	negatives    [][]int32
 	userDict     *FreqDict
 	itemDict     *FreqDict
-	numFeedback  int
+	numFeedback  atomic.Int64
 	categories   map[string]int
 }
 
@@ -112,7 +113,7 @@ func (d *Dataset) GetTimestamp() time.Time {
 }
 
 func (d *Dataset) CountFeedback() int {
-	return d.numFeedback
+	return int(d.numFeedback.Load())
 }
 
 func (d *Dataset) GetUsers() []data.User {
@@ -240,7 +241,7 @@ func (d *Dataset) AddFeedback(userId, itemId string, timestamp time.Time) {
 	defer d.userDict.Unlock(userIndex)
 	d.userFeedback[userIndex] = append(d.userFeedback[userIndex], itemIndex)
 	d.timestamps[userIndex] = append(d.timestamps[userIndex], timestamp)
-	d.numFeedback++
+	d.numFeedback.Add(1)
 }
 
 func (d *Dataset) SampleUserNegatives(excludeSet CFSplit, numCandidates int) [][]int32 {
@@ -276,13 +277,13 @@ func (d *Dataset) SplitCF(numTestUsers int, seed int64) (CFSplit, CFSplit) {
 				testSet.userFeedback[userIndex] = append(testSet.userFeedback[userIndex], d.userFeedback[userIndex][k])
 				testSet.itemFeedback[d.userFeedback[userIndex][k]] = append(testSet.itemFeedback[d.userFeedback[userIndex][k]], userIndex)
 				testSet.timestamps[userIndex] = append(testSet.timestamps[userIndex], d.timestamps[userIndex][k])
-				testSet.numFeedback++
+				testSet.numFeedback.Add(1)
 				for i, itemIndex := range d.userFeedback[userIndex] {
 					if i != k {
 						trainSet.userFeedback[userIndex] = append(trainSet.userFeedback[userIndex], itemIndex)
 						trainSet.itemFeedback[itemIndex] = append(trainSet.itemFeedback[itemIndex], userIndex)
 						trainSet.timestamps[userIndex] = append(trainSet.timestamps[userIndex], d.timestamps[userIndex][i])
-						trainSet.numFeedback++
+						trainSet.numFeedback.Add(1)
 					}
 				}
 			}
@@ -295,13 +296,13 @@ func (d *Dataset) SplitCF(numTestUsers int, seed int64) (CFSplit, CFSplit) {
 				testSet.userFeedback[userIndex] = append(testSet.userFeedback[userIndex], d.userFeedback[userIndex][k])
 				testSet.itemFeedback[d.userFeedback[userIndex][k]] = append(testSet.itemFeedback[d.userFeedback[userIndex][k]], userIndex)
 				testSet.timestamps[userIndex] = append(testSet.timestamps[userIndex], d.timestamps[userIndex][k])
-				testSet.numFeedback++
+				testSet.numFeedback.Add(1)
 				for i, itemIndex := range d.userFeedback[userIndex] {
 					if i != k {
 						trainSet.userFeedback[userIndex] = append(trainSet.userFeedback[userIndex], itemIndex)
 						trainSet.itemFeedback[itemIndex] = append(trainSet.itemFeedback[itemIndex], userIndex)
 						trainSet.timestamps[userIndex] = append(trainSet.timestamps[userIndex], d.timestamps[userIndex][i])
-						trainSet.numFeedback++
+						trainSet.numFeedback.Add(1)
 					}
 				}
 			}
@@ -313,7 +314,7 @@ func (d *Dataset) SplitCF(numTestUsers int, seed int64) (CFSplit, CFSplit) {
 					trainSet.userFeedback[userIndex] = append(trainSet.userFeedback[userIndex], itemIndex)
 					trainSet.itemFeedback[itemIndex] = append(trainSet.itemFeedback[itemIndex], userIndex)
 					trainSet.timestamps[userIndex] = append(trainSet.timestamps[userIndex], d.timestamps[userIndex][idx])
-					trainSet.numFeedback++
+					trainSet.numFeedback.Add(1)
 				}
 			}
 		}
@@ -342,13 +343,13 @@ func (d *Dataset) SplitLatest(shots int) (CFSplit, CFSplit) {
 		testSet.timestamps[userIndex] = append(testSet.timestamps[userIndex], d.timestamps[userIndex][idxs[0]])
 		testSet.itemFeedback[d.userFeedback[userIndex][idxs[0]]] = append(testSet.itemFeedback[d.userFeedback[userIndex][idxs[0]]], userIndex)
 		testSet.userFeedback[userIndex] = append(testSet.userFeedback[userIndex], d.userFeedback[userIndex][idxs[0]])
-		testSet.numFeedback++
+		testSet.numFeedback.Add(1)
 		for i := 1; i < len(d.userFeedback[userIndex]) && i <= shots; i++ {
 			itemIndex := d.userFeedback[userIndex][idxs[i]]
 			trainSet.userFeedback[userIndex] = append(trainSet.userFeedback[userIndex], itemIndex)
 			trainSet.itemFeedback[itemIndex] = append(trainSet.itemFeedback[itemIndex], userIndex)
 			trainSet.timestamps[userIndex] = append(trainSet.timestamps[userIndex], d.timestamps[userIndex][idxs[i]])
-			trainSet.numFeedback++
+			trainSet.numFeedback.Add(1)
 		}
 	}
 	return trainSet, testSet

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -192,6 +193,46 @@ func TestDataset_AddFeedback(t *testing.T) {
 		assert.Len(t, dataSet.timestamps[i], 10-i)
 		assert.InDelta(t, math32.Log(float32(10)/float32(10-i)), userIDF[i], 1e-2)
 		assert.InDelta(t, math32.Log(float32(10)/float32(i+1)), itemIDF[i], 1e-2)
+	}
+}
+
+func TestAddFeedbackRace(t *testing.T) {
+	const numUsers, numItems = 16, 32
+	const numWorkers = 4
+	dataSet := NewDataset(time.Now(), numUsers, numItems)
+	for i := range numUsers {
+		dataSet.AddUser(data.User{UserId: fmt.Sprintf("user%d", i)})
+	}
+	for i := range numItems {
+		dataSet.AddItem(data.Item{ItemId: fmt.Sprintf("item%d", i)})
+	}
+
+	var wg sync.WaitGroup
+	timestamp := time.Unix(1700000000, 0)
+	for workerIndex := range numWorkers {
+		wg.Add(1)
+		go func(workerIndex int) {
+			defer wg.Done()
+			for itemIndex := workerIndex; itemIndex < numItems; itemIndex += numWorkers {
+				for userIndex := range numUsers {
+					dataSet.AddFeedback(
+						fmt.Sprintf("user%d", userIndex),
+						fmt.Sprintf("item%d", itemIndex),
+						timestamp,
+					)
+				}
+			}
+		}(workerIndex)
+	}
+	wg.Wait()
+
+	assert.Equal(t, numUsers*numItems, dataSet.CountFeedback())
+	for itemIndex := range numItems {
+		assert.Len(t, dataSet.GetItemFeedback()[itemIndex], numUsers)
+		assert.Equal(t, int32(numUsers), dataSet.GetItemDict().Freq(int32(itemIndex)))
+	}
+	for userIndex := range numUsers {
+		assert.Len(t, dataSet.GetUserFeedback()[userIndex], numItems)
 	}
 }
 


### PR DESCRIPTION
Fixes #1239.

## What changed

This PR makes the feedback counter in `Dataset` safe during concurrent feedback loading.

`Dataset.AddFeedback` can be called from parallel loading jobs. Feedbacks under the same item are added in series, but multiple jobs can still update the global feedback counter concurrently. The previous `numFeedback++` could lose increments under concurrent updates.

This PR:

- replaces `numFeedback` with `atomic.Int64`
- preserves the existing `CountFeedback() int` API
- adds a regression test for concurrent feedback loading across disjoint item groups

## Why

`numFeedback++` is not atomic. Under concurrent loading, two goroutines can read the same value and write back the same incremented result, causing `CountFeedback()` to undercount loaded feedback.

The regression test verifies:

- total feedback count is correct
- each item receives the expected feedback entries
- each user receives the expected feedback entries
- item frequency counts remain correct

## Tests

```powershell
$env:GOCACHE='C:\tmp\go-build-cache'
go test -run TestAddFeedbackRace -count=100 ./dataset/...
go test ./dataset ./config