### PR TITLE
Add Redis cache client name configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,7 @@ type DatabaseConfig struct {
 	TablePrefix      string      `mapstructure:"table_prefix"`
 	DataTablePrefix  string      `mapstructure:"data_table_prefix"`
 	CacheTablePrefix string      `mapstructure:"cache_table_prefix"`
+	CacheClientName  string      `mapstructure:"cache_client_name"`
 	MySQL            MySQLConfig `mapstructure:"mysql"`
 	Postgres         SQLConfig   `mapstructure:"postgres"`
 	Redis            RedisConfig `mapstructure:"redis"`
@@ -118,6 +119,7 @@ func (db *DatabaseConfig) StorageOptions(path string) []storage.Option {
 		strings.HasPrefix(path, storage.RedisClusterPrefix) || strings.HasPrefix(path, storage.RedissClusterPrefix) {
 		return []storage.Option{
 			storage.WithMaxSearchResults(db.Redis.MaxSearchResults),
+			storage.WithRedisClientName(db.CacheClientName),
 		}
 	}
 	return nil
@@ -450,8 +452,9 @@ type AzureBlobConfig struct {
 func GetDefaultConfig() *Config {
 	return &Config{
 		Database: DatabaseConfig{
-			DataStore:  "sqlite://" + filepath.Join(MkDir(), "data.sqlite"),
-			CacheStore: "sqlite://" + filepath.Join(MkDir(), "cache.sqlite"),
+			DataStore:       "sqlite://" + filepath.Join(MkDir(), "data.sqlite"),
+			CacheStore:      "sqlite://" + filepath.Join(MkDir(), "cache.sqlite"),
+			CacheClientName: "gorse_cache_client",
 			MySQL: MySQLConfig{
 				IsolationLevel:  "READ-UNCOMMITTED",
 				MaxOpenConns:    0,
@@ -594,6 +597,7 @@ func setDefault() {
 	// [database]
 	viper.SetDefault("database.data_store", defaultConfig.Database.DataStore)
 	viper.SetDefault("database.cache_store", defaultConfig.Database.CacheStore)
+	viper.SetDefault("database.cache_client_name", defaultConfig.Database.CacheClientName)
 	// [database.mysql]
 	viper.SetDefault("database.mysql.isolation_level", defaultConfig.Database.MySQL.IsolationLevel)
 	viper.SetDefault("database.mysql.max_open_conns", defaultConfig.Database.MySQL.MaxOpenConns)
@@ -662,6 +666,7 @@ var bindings = []configBinding{
 	{"database.data_store", "GORSE_DATA_STORE"},
 	{"database.table_prefix", "GORSE_TABLE_PREFIX"},
 	{"database.cache_table_prefix", "GORSE_CACHE_TABLE_PREFIX"},
+	{"database.cache_client_name", "GORSE_CACHE_CLIENT_NAME"},
 	{"database.data_table_prefix", "GORSE_DATA_TABLE_PREFIX"},
 	{"master.port", "GORSE_MASTER_PORT"},
 	{"master.host", "GORSE_MASTER_HOST"},

--- a/config/config.toml
+++ b/config/config.toml
@@ -31,6 +31,9 @@ table_prefix = ""
 # The naming prefix for tables (collections, keys) in cache storage databases. The default value is `table_prefix`.
 cache_table_prefix = ""
 
+# Name shown by Redis/Valkey CLIENT LIST for cache connections.
+cache_client_name = "gorse_cache_client"
+
 # The naming prefix for tables (collections, keys) in data storage databases. The default value is `table_prefix`.
 data_table_prefix = ""
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,6 +70,7 @@ func TestUnmarshal(t *testing.T) {
 			assert.Equal(t, "mysql://gorse:gorse_pass@tcp(localhost:3306)/gorse", config.Database.DataStore)
 			assert.Equal(t, "gorse_", config.Database.TablePrefix)
 			assert.Equal(t, "gorse_cache_", config.Database.CacheTablePrefix)
+			assert.Equal(t, "gorse_cache_client", config.Database.CacheClientName)
 			assert.Equal(t, "gorse_data_", config.Database.DataTablePrefix)
 			assert.Equal(t, "READ-UNCOMMITTED", config.Database.MySQL.IsolationLevel)
 			assert.Equal(t, 0, config.Database.MySQL.MaxOpenConns)
@@ -196,6 +197,7 @@ func TestBindEnv(t *testing.T) {
 		{"GORSE_TABLE_PREFIX", "gorse_"},
 		{"GORSE_DATA_TABLE_PREFIX", "gorse_data_"},
 		{"GORSE_CACHE_TABLE_PREFIX", "gorse_cache_"},
+		{"GORSE_CACHE_CLIENT_NAME", "gorse_cache_client_from_env"},
 		{"GORSE_MASTER_PORT", "123"},
 		{"GORSE_MASTER_HOST", "<master_host>"},
 		{"GORSE_MASTER_SSL_MODE", "true"},
@@ -242,6 +244,7 @@ func TestBindEnv(t *testing.T) {
 	assert.Equal(t, "mysql://<data_store>", config.Database.DataStore)
 	assert.Equal(t, "gorse_", config.Database.TablePrefix)
 	assert.Equal(t, "gorse_cache_", config.Database.CacheTablePrefix)
+	assert.Equal(t, "gorse_cache_client_from_env", config.Database.CacheClientName)
 	assert.Equal(t, "gorse_data_", config.Database.DataTablePrefix)
 	assert.Equal(t, 123, config.Master.Port)
 	assert.Equal(t, "<master_host>", config.Master.Host)

--- a/storage/cache/redis.go
+++ b/storage/cache/redis.go
@@ -41,10 +41,14 @@ func init() {
 			return nil, err
 		}
 		opt.Protocol = 2
+		option := storage.NewOptions(opts...)
+		if option.RedisClientName != "" {
+			opt.ClientName = option.RedisClientName
+		}
 		database := new(Redis)
 		database.client = redis.NewClient(opt)
 		database.TablePrefix = storage.TablePrefix(tablePrefix)
-		database.maxSearchResults = storage.NewOptions(opts...).MaxSearchResults
+		database.maxSearchResults = option.MaxSearchResults
 		if err = redisotel.InstrumentTracing(database.client, redisotel.WithAttributes(semconv.DBSystemRedis)); err != nil {
 			log.Logger().Error("failed to add tracing for redis", zap.Error(err))
 			return nil, errors.Trace(err)
@@ -63,10 +67,14 @@ func init() {
 			return nil, err
 		}
 		opt.Protocol = 2
+		option := storage.NewOptions(opts...)
+		if option.RedisClientName != "" {
+			opt.ClientName = option.RedisClientName
+		}
 		database := new(Redis)
 		database.client = redis.NewClusterClient(opt)
 		database.TablePrefix = storage.TablePrefix(tablePrefix)
-		database.maxSearchResults = storage.NewOptions(opts...).MaxSearchResults
+		database.maxSearchResults = option.MaxSearchResults
 		if err = redisotel.InstrumentTracing(database.client, redisotel.WithAttributes(semconv.DBSystemRedis)); err != nil {
 			log.Logger().Error("failed to add tracing for redis", zap.Error(err))
 			return nil, errors.Trace(err)

--- a/storage/options.go
+++ b/storage/options.go
@@ -11,6 +11,7 @@ type Options struct {
 	MaxIdleConns     int
 	ConnMaxLifetime  time.Duration
 	MaxSearchResults int
+	RedisClientName  string
 }
 
 type Option func(*Options)
@@ -42,6 +43,12 @@ func WithConnMaxLifetime(connMaxLifetime time.Duration) Option {
 func WithMaxSearchResults(limit int) Option {
 	return func(o *Options) {
 		o.MaxSearchResults = limit
+	}
+}
+
+func WithRedisClientName(clientName string) Option {
+	return func(o *Options) {
+		o.RedisClientName = clientName
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Allow specifying a name for Redis cache clients so connections appear with a friendly name in Redis tools and for easier identification/monitoring.

### Description

- Added `CacheClientName` to `DatabaseConfig` and exposed it in defaults via `GetDefaultConfig()` and `config.toml` as `cache_client_name` with a default of `gorse_cache_client`.
- Plumbed `CacheClientName` into viper defaults and environment bindings as `database.cache_client_name` / `GORSE_CACHE_CLIENT_NAME` so it can be set from config files or env vars.
- Extended storage options with `RedisClientName` and `WithRedisClientName` and used `storage.NewOptions(opts...)` in Redis constructors to set `opt.ClientName` when provided for both standalone and cluster Redis clients.
- Updated tests in `config_test.go` to assert the new `CacheClientName` behavior when loading from files and environment variables.

### Testing

- Ran unit tests for configuration parsing and environment binding including `TestUnmarshal`, `TestSetDefault`, and `TestBindEnv`, and they all succeeded. 
- Executed `go test ./...` on the modified packages and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16672d99e4832dbc3f112f66c1841b)