### PR TITLE
fix(dataset): guard concurrent feedback writes

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/chewxy/math32"
@@ -88,6 +89,7 @@ type Dataset struct {
 	userDict     *FreqDict
 	itemDict     *FreqDict
 	numFeedback  int
+	feedbackMu   sync.Mutex
 	categories   map[string]int
 }
 
@@ -112,6 +114,8 @@ func (d *Dataset) GetTimestamp() time.Time {
 }
 
 func (d *Dataset) CountFeedback() int {
+	d.feedbackMu.Lock()
+	defer d.feedbackMu.Unlock()
 	return d.numFeedback
 }
 
@@ -235,12 +239,18 @@ func (d *Dataset) AddItem(item data.Item) {
 func (d *Dataset) AddFeedback(userId, itemId string, timestamp time.Time) {
 	userIndex := d.userDict.Add(userId)
 	itemIndex := d.itemDict.Add(itemId)
+
+	d.itemDict.Lock(itemIndex)
 	d.itemFeedback[itemIndex] = append(d.itemFeedback[itemIndex], userIndex)
+	d.itemDict.Unlock(itemIndex)
+
 	d.userDict.Lock(userIndex)
 	defer d.userDict.Unlock(userIndex)
 	d.userFeedback[userIndex] = append(d.userFeedback[userIndex], itemIndex)
 	d.timestamps[userIndex] = append(d.timestamps[userIndex], timestamp)
+	d.feedbackMu.Lock()
 	d.numFeedback++
+	d.feedbackMu.Unlock()
 }
 
 func (d *Dataset) SampleUserNegatives(excludeSet CFSplit, numCandidates int) [][]int32 {

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -192,6 +193,38 @@ func TestDataset_AddFeedback(t *testing.T) {
 		assert.Len(t, dataSet.timestamps[i], 10-i)
 		assert.InDelta(t, math32.Log(float32(10)/float32(10-i)), userIDF[i], 1e-2)
 		assert.InDelta(t, math32.Log(float32(10)/float32(i+1)), itemIDF[i], 1e-2)
+	}
+}
+
+func TestDataset_AddFeedbackConcurrent(t *testing.T) {
+	const numUsers, numItems = 16, 32
+	dataSet := NewDataset(time.Now(), numUsers, numItems)
+	for i := range numUsers {
+		dataSet.AddUser(data.User{UserId: fmt.Sprintf("user%d", i)})
+	}
+	for j := range numItems {
+		dataSet.AddItem(data.Item{ItemId: fmt.Sprintf("item%d", j)})
+	}
+
+	var wg sync.WaitGroup
+	timestamp := time.Unix(1700000000, 0)
+	for i := range numUsers {
+		wg.Add(1)
+		go func(userIndex int) {
+			defer wg.Done()
+			for j := range numItems {
+				dataSet.AddFeedback(fmt.Sprintf("user%d", userIndex), fmt.Sprintf("item%d", j), timestamp)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Equal(t, numUsers*numItems, dataSet.CountFeedback())
+	for i := range numUsers {
+		assert.Len(t, dataSet.GetUserFeedback()[i], numItems)
+	}
+	for j := range numItems {
+		assert.Len(t, dataSet.GetItemFeedback()[j], numUsers)
 	}
 }
 

--- a/dataset/dict.go
+++ b/dataset/dict.go
@@ -20,19 +20,25 @@ type FreqDict struct {
 	si  map[string]int32
 	is  []string
 	cnt []int32
-	mu  []sync.Mutex
+	mu  []*sync.Mutex
+	rw  sync.RWMutex
 }
 
 func NewFreqDict() (d *FreqDict) {
-	d = &FreqDict{map[string]int32{}, []string{}, []int32{}, []sync.Mutex{}}
+	d = &FreqDict{si: map[string]int32{}}
 	return
 }
 
 func (d *FreqDict) Count() int32 {
+	d.rw.RLock()
+	defer d.rw.RUnlock()
 	return int32(len(d.is))
 }
 
 func (d *FreqDict) Add(s string) (y int32) {
+	d.rw.Lock()
+	defer d.rw.Unlock()
+
 	if y, ok := d.si[s]; ok {
 		d.cnt[y]++
 		return y
@@ -42,11 +48,14 @@ func (d *FreqDict) Add(s string) (y int32) {
 	d.si[s] = y
 	d.is = append(d.is, s)
 	d.cnt = append(d.cnt, 1)
-	d.mu = append(d.mu, sync.Mutex{})
+	d.mu = append(d.mu, &sync.Mutex{})
 	return
 }
 
 func (d *FreqDict) AddNoCount(s string) (y int32) {
+	d.rw.Lock()
+	defer d.rw.Unlock()
+
 	if y, ok := d.si[s]; ok {
 		return y
 	}
@@ -55,11 +64,14 @@ func (d *FreqDict) AddNoCount(s string) (y int32) {
 	d.si[s] = y
 	d.is = append(d.is, s)
 	d.cnt = append(d.cnt, 0)
-	d.mu = append(d.mu, sync.Mutex{})
+	d.mu = append(d.mu, &sync.Mutex{})
 	return
 }
 
 func (d *FreqDict) Id(s string) int32 {
+	d.rw.RLock()
+	defer d.rw.RUnlock()
+
 	if y, ok := d.si[s]; ok {
 		return y
 	}
@@ -67,6 +79,9 @@ func (d *FreqDict) Id(s string) int32 {
 }
 
 func (d *FreqDict) String(id int32) (s string, ok bool) {
+	d.rw.RLock()
+	defer d.rw.RUnlock()
+
 	if id >= int32(len(d.is)) {
 		return "", false
 	}
@@ -74,6 +89,9 @@ func (d *FreqDict) String(id int32) (s string, ok bool) {
 }
 
 func (d *FreqDict) Freq(id int32) int32 {
+	d.rw.RLock()
+	defer d.rw.RUnlock()
+
 	if id >= int32(len(d.cnt)) {
 		return 0
 	}
@@ -81,11 +99,17 @@ func (d *FreqDict) Freq(id int32) int32 {
 }
 
 func (d *FreqDict) Lock(index int32) {
-	d.mu[index].Lock()
+	d.rw.RLock()
+	mu := d.mu[index]
+	d.rw.RUnlock()
+	mu.Lock()
 }
 
 func (d *FreqDict) Unlock(index int32) {
-	d.mu[index].Unlock()
+	d.rw.RLock()
+	mu := d.mu[index]
+	d.rw.RUnlock()
+	mu.Unlock()
 }
 
 func (d *FreqDict) ToIndex() *Index {


### PR DESCRIPTION
Fixes #1239.

`Dataset.AddFeedback` currently protects the per-user feedback append, but two shared writes still happen without synchronization:

- `itemFeedback[itemIndex]` can be appended by several goroutines when different users add feedback for the same item.
- `numFeedback` can lose increments because different user locks do not protect the shared counter.

This patch keeps the existing per-user locking, adds the matching per-item lock for `itemFeedback`, and protects `numFeedback` reads/writes. It also makes `FreqDict.Add` safe for concurrent callers and stores per-key locks as pointers so the lock slice can grow without copying live mutex values.

The regression test adds feedback from multiple goroutines across shared items and verifies the total count plus both user/item feedback indexes.

To verify:

```bash
go test -race -run TestDataset_AddFeedbackConcurrent -count=5 ./dataset
go test -race ./dataset
go test ./dataset
git diff --check
```
