### PR TITLE
fix(model): keep zero-score search results

### DIFF
--- a/model/cf/optimize.go
+++ b/model/cf/optimize.go
@@ -69,7 +69,7 @@ func (ms *ModelSearch) Objective(trial goptuna.Trial) (float64, error) {
 	m := ms.modelCreators[modelType]()
 	m.SetParams(m.SuggestParams(trial))
 	score := m.Fit(ms.ctx, ms.trainSet, ms.valSet, ms.config)
-	if score.NDCG > ms.result.Score.NDCG {
+	if ms.result.Type == "" || score.NDCG > ms.result.Score.NDCG {
 		ms.result.Type = modelType
 		ms.result.Params = m.GetParams()
 		ms.result.Score = score

--- a/model/cf/optimize_test.go
+++ b/model/cf/optimize_test.go
@@ -98,6 +98,14 @@ func (m *mockMatrixFactorizationForSearch) SuggestParams(trial goptuna.Trial) mo
 	}
 }
 
+type zeroScoreMatrixFactorizationForSearch struct {
+	mockMatrixFactorizationForSearch
+}
+
+func (m *zeroScoreMatrixFactorizationForSearch) Fit(_ context.Context, _, _ dataset.CFSplit, _ *FitConfig) Score {
+	return Score{}
+}
+
 func TestTPE(t *testing.T) {
 	search := NewModelSearch(map[string]ModelCreator{
 		"mock": func() MatrixFactorization {
@@ -120,4 +128,21 @@ func TestTPE(t *testing.T) {
 		model.InitStdDev: float64(4),
 	}, result.Params)
 	assert.Equal(t, Score{NDCG: 12}, result.Score)
+}
+
+func TestModelSearchKeepsZeroScoreResult(t *testing.T) {
+	search := NewModelSearch(map[string]ModelCreator{
+		"mock": func() MatrixFactorization {
+			return &zeroScoreMatrixFactorizationForSearch{}
+		},
+	}, nil, nil, nil)
+	study, err := goptuna.CreateStudy("TestModelSearchKeepsZeroScoreResult",
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMaximize),
+		goptuna.StudyOptionSampler(tpe.NewSampler()))
+	assert.NoError(t, err)
+	err = study.Optimize(search.Objective, 1)
+	assert.NoError(t, err)
+	result := search.Result()
+	assert.Equal(t, "mock", result.Type)
+	assert.Equal(t, Score{}, result.Score)
 }

--- a/model/ctr/optimize.go
+++ b/model/ctr/optimize.go
@@ -69,7 +69,7 @@ func (ms *ModelSearch) Objective(trial goptuna.Trial) (float64, error) {
 	m := ms.modelCreators[modelType]()
 	m.SetParams(m.SuggestParams(trial))
 	score := m.Fit(ms.ctx, ms.trainSet, ms.testSet, ms.config)
-	if score.AUC > ms.result.Score.AUC {
+	if ms.result.Type == "" || score.AUC > ms.result.Score.AUC {
 		ms.result = meta.Model[Score]{
 			Type:   modelType,
 			Params: m.GetParams(),

--- a/model/ctr/optimize_test.go
+++ b/model/ctr/optimize_test.go
@@ -89,6 +89,14 @@ func (m *mockFactorizationMachineForSearch) SuggestParams(trial goptuna.Trial) m
 	}
 }
 
+type zeroScoreFactorizationMachineForSearch struct {
+	mockFactorizationMachineForSearch
+}
+
+func (m *zeroScoreFactorizationMachineForSearch) Fit(_ context.Context, _, _ dataset.CTRSplit, _ *FitConfig) Score {
+	return Score{}
+}
+
 func TestTPE(t *testing.T) {
 	search := NewModelSearch(map[string]ModelCreator{
 		"mock": func() FactorizationMachines {
@@ -111,4 +119,21 @@ func TestTPE(t *testing.T) {
 		model.InitStdDev: float64(4),
 	}, result.Params)
 	assert.Equal(t, Score{AUC: 12}, result.Score)
+}
+
+func TestModelSearchKeepsZeroScoreResult(t *testing.T) {
+	search := NewModelSearch(map[string]ModelCreator{
+		"mock": func() FactorizationMachines {
+			return &zeroScoreFactorizationMachineForSearch{}
+		},
+	}, nil, nil, nil)
+	study, err := goptuna.CreateStudy("TestModelSearchKeepsZeroScoreResult",
+		goptuna.StudyOptionDirection(goptuna.StudyDirectionMaximize),
+		goptuna.StudyOptionSampler(tpe.NewSampler()))
+	assert.NoError(t, err)
+	err = study.Optimize(search.Objective, 1)
+	assert.NoError(t, err)
+	result := search.Result()
+	assert.Equal(t, "mock", result.Type)
+	assert.Equal(t, Score{}, result.Score)
 }


### PR DESCRIPTION
﻿## Summary

- keep the first completed CF/CTR model-search trial even when its score is zero
- add regression coverage for zero-score CF and CTR searches

## Why

With very small datasets, every optimization trial can legitimately score `0`. The previous comparison only saved a result when the score was strictly greater than the zero-value score, leaving the selected model empty after optimization.

## To verify

- `go test ./model/cf ./model/ctr`
- `git diff --check`
