### PR TITLE
support search items on dashboard

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -155,7 +155,7 @@ active_user_ttl = 0
 [recommend.search]
 
 # Item fields to index for search. Values use expr syntax.
-columns = []
+columns = ["item.Comment"]
 
 [recommend.data_source]
 

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/gomlx/gomlx v0.27.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/securecookie v1.1.2
-	github.com/gorse-io/dashboard v0.0.0-20260223101641-33715448ded8
+	github.com/gorse-io/dashboard v0.0.0-20260608133319-c82bb34447e6
 	github.com/gorse-io/gorse-go v0.5.0-alpha.3
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jaswdr/faker v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,9 @@ github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pw
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorse-io/clickhouse v0.3.3-0.20260331225025-ab309f55941d h1:ehE+4aaZ1kU2x6fB/OtsgAfZ8UOnB6bFygI4URyolVs=
 github.com/gorse-io/clickhouse v0.3.3-0.20260331225025-ab309f55941d/go.mod h1:6aZpl8cJgPkqNVeZiEgQJ+yLCC0NyDfv7gF/3/pJywU=
-github.com/gorse-io/dashboard v0.0.0-20260223101641-33715448ded8 h1:IjZK+VF93JvEAZEFsOa8qwVKBfb4dXuCF+m7Qb2Yr5c=
 github.com/gorse-io/dashboard v0.0.0-20260223101641-33715448ded8/go.mod h1:Ako5pxQlNyCiJpLpcJAwYWMF5nXdYP0mgpGcEOaw0vQ=
+github.com/gorse-io/dashboard v0.0.0-20260608133319-c82bb34447e6 h1:RJd9yDeb2Yzi25sTFspquYJ00UIvYiQz8G9YJyf/kpk=
+github.com/gorse-io/dashboard v0.0.0-20260608133319-c82bb34447e6/go.mod h1:qz7Y16kcH61Qxr6uQtq7a1FbSujErfr020SZH1SVX3g=
 github.com/gorse-io/gorse-go v0.5.0-alpha.3 h1:GR/OWzq016VyFyTTxgQWeayGahRVzB1cGFIW/AaShC4=
 github.com/gorse-io/gorse-go v0.5.0-alpha.3/go.mod h1:ZxmVHzZPKm5pmEIlqaRDwK0rkfTRHlfziO033XZ+RW0=
 github.com/gorse-io/sqlite v1.3.3-0.20260331224015-eb865ec4453d h1:cZeyKO0Z7tnpQBCrGOGJrUmZHkpDK/0DgNr2+8cXoOM=

--- a/master/master.go
+++ b/master/master.go
@@ -96,12 +96,10 @@ type Master struct {
 	tokenCache   *ttlcache.Cache[string, UserInfo]
 
 	// events
-	ticker    *time.Ticker
-	scheduled chan struct{}
-	cancel    context.CancelFunc
-
-	// data store maintenance
-	reconcileRunning atomic.Bool
+	ticker      *time.Ticker
+	scheduled   chan struct{}
+	cancel      context.CancelFunc
+	reconciling atomic.Bool
 }
 
 // NewMaster creates a master node.

--- a/master/master.go
+++ b/master/master.go
@@ -22,6 +22,7 @@ import (
 	"math/rand"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -98,6 +99,9 @@ type Master struct {
 	ticker    *time.Ticker
 	scheduled chan struct{}
 	cancel    context.CancelFunc
+
+	// data store maintenance
+	reconcileRunning atomic.Bool
 }
 
 // NewMaster creates a master node.

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -54,11 +54,11 @@ func (m *Master) loadDataset(parent context.Context) (datasets Datasets, err err
 
 	searchConfig := config.SearchConfig{Columns: append([]string(nil), m.Config.Recommend.Search.Columns...)}
 	go func() {
-		if !m.reconcileRunning.CompareAndSwap(false, true) {
+		if !m.reconciling.CompareAndSwap(false, true) {
 			log.Logger().Info("skip reconciling data store since previous reconciliation is still running")
 			return
 		}
-		defer m.reconcileRunning.Store(false)
+		defer m.reconciling.Store(false)
 		if err := m.DataClient.Reconcile(searchConfig); err != nil {
 			log.Logger().Error("failed to reconcile data store", zap.Error(err))
 		}

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -52,6 +52,13 @@ func (m *Master) loadDataset(parent context.Context) (datasets Datasets, err err
 	ctx, span := m.tracer.Start(parent, "Load Dataset", 1)
 	defer span.End()
 
+	searchConfig := config.SearchConfig{Columns: append([]string(nil), m.Config.Recommend.Search.Columns...)}
+	go func() {
+		if err := m.DataClient.Reconcile(searchConfig); err != nil {
+			log.Logger().Error("failed to reconcile data store", zap.Error(err))
+		}
+	}()
+
 	// Build non-personalized recommenders
 	initialStartTime := time.Now()
 	nonPersonalizedRecommenders := make([]*logics.NonPersonalized, 0, len(m.Config.Recommend.NonPersonalized))

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -54,6 +54,11 @@ func (m *Master) loadDataset(parent context.Context) (datasets Datasets, err err
 
 	searchConfig := config.SearchConfig{Columns: append([]string(nil), m.Config.Recommend.Search.Columns...)}
 	go func() {
+		if !m.reconcileRunning.CompareAndSwap(false, true) {
+			log.Logger().Info("skip reconciling data store since previous reconciliation is still running")
+			return
+		}
+		defer m.reconcileRunning.Store(false)
 		if err := m.DataClient.Reconcile(searchConfig); err != nil {
 			log.Logger().Error("failed to reconcile data store", zap.Error(err))
 		}

--- a/server/rest.go
+++ b/server/rest.go
@@ -286,6 +286,7 @@ func (s *RestServer) CreateWebService() {
 		Param(ws.HeaderParameter("X-API-Key", "API key").DataType("string")).
 		Param(ws.QueryParameter("n", "Number of returned items").DataType("integer")).
 		Param(ws.QueryParameter("cursor", "Cursor for the next page").DataType("string")).
+		Param(ws.QueryParameter("q", "Search query. Requires [recommend.search].columns to be configured.").DataType("string")).
 		Returns(http.StatusOK, "OK", ItemIterator{}).
 		Writes(ItemIterator{}))
 	// Get item
@@ -1408,12 +1409,26 @@ func (s *RestServer) getItems(request *restful.Request, response *restful.Respon
 	if request != nil && request.Request != nil {
 		ctx = request.Request.Context()
 	}
-	cursor := request.QueryParameter("cursor")
 	n, err := ParseInt(request, "n", s.Config.Server.DefaultN)
 	if err != nil {
 		BadRequest(response, err)
 		return
 	}
+	query := request.QueryParameter("q")
+	if query != "" {
+		if len(s.Config.Recommend.Search.Columns) == 0 {
+			BadRequest(response, errors.New("item search is not supported because [recommend.search].columns is empty"))
+			return
+		}
+		items, err := s.DataClient.SearchItems(ctx, query, n)
+		if err != nil {
+			InternalServerError(response, err)
+			return
+		}
+		Ok(response, ItemIterator{Items: items})
+		return
+	}
+	cursor := request.QueryParameter("cursor")
 	cursor, items, err := s.DataClient.GetItems(ctx, cursor, n, nil)
 	if err != nil {
 		InternalServerError(response, err)

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -570,6 +570,63 @@ func (suite *ServerTestSuite) TestItems() {
 		End()
 }
 
+func (suite *ServerTestSuite) TestSearchItems() {
+	t := suite.T()
+
+	apitest.New().
+		Handler(suite.handler).
+		Get("/api/items").
+		Header("X-API-Key", apiKey).
+		QueryParams(map[string]string{
+			"q": "running",
+			"n": "10",
+		}).
+		Expect(t).
+		Status(http.StatusBadRequest).
+		Body("item search is not supported because [recommend.search].columns is empty").
+		End()
+
+	suite.Config.Recommend.Search.Columns = []string{"item.ItemId", "item.Categories", "item.Labels.brand", "item.Comment"}
+	err := suite.DataClient.Reconcile(suite.Config.Recommend.Search)
+	suite.NoError(err)
+
+	items := []data.Item{
+		{
+			ItemId:     "running-shoes",
+			Categories: []string{"sports", "shoes"},
+			Labels: map[string]any{
+				"brand": "acme",
+			},
+			Comment: "Lightweight running shoes for marathon training",
+		},
+		{
+			ItemId:     "coffee-grinder",
+			Categories: []string{"kitchen"},
+			Labels: map[string]any{
+				"brand": "acme",
+			},
+			Comment: "Burr grinder for espresso and pour over coffee",
+		},
+	}
+	err = suite.DataClient.BatchInsertItems(t.Context(), items)
+	suite.NoError(err)
+	err = suite.DataClient.Optimize()
+	suite.NoError(err)
+
+	apitest.New().
+		Handler(suite.handler).
+		Get("/api/items").
+		Header("X-API-Key", apiKey).
+		QueryParams(map[string]string{
+			"q": "espresso",
+			"n": "10",
+		}).
+		Expect(t).
+		Status(http.StatusOK).
+		Body(suite.marshal(ItemIterator{Items: []data.Item{items[1]}})).
+		End()
+}
+
 func (suite *ServerTestSuite) TestFeedback() {
 	ctx := suite.T().Context()
 	t := suite.T()

--- a/storage/data/database_test.go
+++ b/storage/data/database_test.go
@@ -1000,6 +1000,14 @@ func (suite *baseTestSuite) TestSearch() {
 			},
 			Comment: "Ergonomic chair with lumbar support",
 		},
+		{
+			ItemId:     "gorse-io:gorse",
+			Categories: []string{"repository"},
+			Labels: map[string]any{
+				"brand": "gorse",
+			},
+			Comment: "Open source recommender system",
+		},
 	}
 	err = suite.Database.BatchInsertItems(ctx, items)
 	suite.NoError(err)
@@ -1014,6 +1022,7 @@ func (suite *baseTestSuite) TestSearch() {
 		})
 	}
 
+	suite.ElementsMatch([]string{"gorse-io:gorse"}, searchItemIDs("gorse-io:gorse", 10))
 	suite.ElementsMatch([]string{"running-shoes", "trail-watch"}, searchItemIDs("running", 10))
 	suite.ElementsMatch([]string{"coffee-grinder"}, searchItemIDs("coffee", 10))
 	suite.ElementsMatch([]string{"trail-watch"}, searchItemIDs("electronics", 10))

--- a/storage/data/sql.go
+++ b/storage/data/sql.go
@@ -770,6 +770,18 @@ func sqliteSearchColumn(column, qualifier string) (string, bool) {
 	return "", false
 }
 
+func sqlitePlainTextSearchQuery(query string) string {
+	terms := strings.Fields(query)
+	if len(terms) == 0 {
+		return `""`
+	}
+	quotedTerms := make([]string, len(terms))
+	for i, term := range terms {
+		quotedTerms[i] = `"` + strings.ReplaceAll(term, `"`, `""`) + `"`
+	}
+	return strings.Join(quotedTerms, " ")
+}
+
 func (d *SQLDatabase) dropMySQLIndexIfExists(tableName, indexName string) error {
 	var count int64
 	if err := d.gormDB.Raw("SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?", tableName, indexName).Scan(&count).Error; err != nil {
@@ -972,6 +984,7 @@ func (d *SQLDatabase) SearchItems(ctx context.Context, query string, n int) ([]I
 			Order(clause.Expr{SQL: fmt.Sprintf("MATCH(%s) AGAINST (? IN NATURAL LANGUAGE MODE) DESC", mysqlSearchDocumentColumn), Vars: []any{query}}).
 			Limit(n)
 	case SQLite:
+		query = sqlitePlainTextSearchQuery(query)
 		tx = d.gormDB.WithContext(ctx).
 			Table(fmt.Sprintf("%s AS items", d.ItemsTable())).
 			Select("items.item_id, items.is_hidden, items.categories, items.time_stamp, items.labels, items.comment").


### PR DESCRIPTION
## Summary
- Add `q` query parameter to `GET /api/items` to search items via the configured data-store search index
- Return `400 Bad Request` when `q` is used while `[recommend.search].columns` is empty
- Add REST API coverage for unsupported search and successful indexed item search

## Test Plan
- `/usr/local/go/bin/go test ./server -run 'TestServer/TestSearchItems' -count=1`
- `/usr/local/go/bin/go test ./server -run 'TestServer/TestItems' -count=1`
- `/usr/local/go/bin/go test ./server -run TestServer -count=1`
- `git diff --check`
