### PR TITLE
Skip local blob server for cloud stores

### DIFF
--- a/master/master.go
+++ b/master/master.go
@@ -152,7 +152,9 @@ func NewMaster(cfg *config.Config, cacheFolder string, standalone bool, configPa
 func (m *Master) Serve() {
 	// connect blob store
 	var err error
-	m.blobServer = newMasterBlobServer(m.Config.Blob.URI)
+	if !strings.Contains(m.Config.Blob.URI, "://") {
+		m.blobServer = blob.NewMasterStoreServer(m.Config.Blob.URI)
+	}
 	m.blobStore, err = blob.NewStore(m.Config.Blob, nil)
 	if err != nil {
 		log.Logger().Fatal("failed to create blob store", zap.Error(err))
@@ -289,13 +291,6 @@ func (m *Master) Serve() {
 
 	// start http server
 	m.StartHttpServer()
-}
-
-func newMasterBlobServer(uri string) *blob.MasterStoreServer {
-	if strings.Contains(uri, "://") {
-		return nil
-	}
-	return blob.NewMasterStoreServer(uri)
 }
 
 func (m *Master) Shutdown() {

--- a/master/master.go
+++ b/master/master.go
@@ -21,6 +21,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -151,7 +152,7 @@ func NewMaster(cfg *config.Config, cacheFolder string, standalone bool, configPa
 func (m *Master) Serve() {
 	// connect blob store
 	var err error
-	m.blobServer = blob.NewMasterStoreServer(m.Config.Blob.URI)
+	m.blobServer = newMasterBlobServer(m.Config.Blob.URI)
 	m.blobStore, err = blob.NewStore(m.Config.Blob, nil)
 	if err != nil {
 		log.Logger().Fatal("failed to create blob store", zap.Error(err))
@@ -260,7 +261,9 @@ func (m *Master) Serve() {
 		protocol.RegisterMasterServer(m.grpcServer, m)
 		protocol.RegisterCacheStoreServer(m.grpcServer, cache.NewProxyServer(m.CacheClient))
 		protocol.RegisterDataStoreServer(m.grpcServer, data.NewProxyServer(m.DataClient))
-		protocol.RegisterBlobStoreServer(m.grpcServer, m.blobServer)
+		if m.blobServer != nil {
+			protocol.RegisterBlobStoreServer(m.grpcServer, m.blobServer)
+		}
 		if err = m.grpcServer.Serve(lis); err != nil {
 			log.Logger().Fatal("failed to start rpc server", zap.Error(err))
 		}
@@ -286,6 +289,13 @@ func (m *Master) Serve() {
 
 	// start http server
 	m.StartHttpServer()
+}
+
+func newMasterBlobServer(uri string) *blob.MasterStoreServer {
+	if strings.Contains(uri, "://") {
+		return nil
+	}
+	return blob.NewMasterStoreServer(uri)
 }
 
 func (m *Master) Shutdown() {

--- a/master/master_test.go
+++ b/master/master_test.go
@@ -75,8 +75,12 @@ func TestNewMasterBlobServer(t *testing.T) {
 		if server != nil {
 			t.Fatal("expected no local blob server for cloud URI")
 		}
-		if _, err := os.Stat(filepath.Join(dir, "s3:")); !os.IsNotExist(err) {
-			t.Fatalf("expected no s3: directory, got %v", err)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(entries) != 0 {
+			t.Fatalf("expected no local directories, got %v", entries)
 		}
 	})
 }

--- a/master/master_test.go
+++ b/master/master_test.go
@@ -15,6 +15,8 @@ package master
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gorse-io/gorse/common/monitor"
@@ -52,4 +54,29 @@ func (s *MasterTestSuite) TearDownTest() {
 
 func TestMaster(t *testing.T) {
 	suite.Run(t, new(MasterTestSuite))
+}
+
+func TestNewMasterBlobServer(t *testing.T) {
+	t.Run("local URI", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "blob")
+		server := newMasterBlobServer(dir)
+		if server == nil {
+			t.Fatal("expected local blob server")
+		}
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("cloud URI", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Chdir(dir)
+		server := newMasterBlobServer("s3://bucket/path")
+		if server != nil {
+			t.Fatal("expected no local blob server for cloud URI")
+		}
+		if _, err := os.Stat(filepath.Join(dir, "s3:")); !os.IsNotExist(err) {
+			t.Fatalf("expected no s3: directory, got %v", err)
+		}
+	})
 }

--- a/master/master_test.go
+++ b/master/master_test.go
@@ -15,8 +15,6 @@ package master
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/gorse-io/gorse/common/monitor"
@@ -54,33 +52,4 @@ func (s *MasterTestSuite) TearDownTest() {
 
 func TestMaster(t *testing.T) {
 	suite.Run(t, new(MasterTestSuite))
-}
-
-func TestNewMasterBlobServer(t *testing.T) {
-	t.Run("local URI", func(t *testing.T) {
-		dir := filepath.Join(t.TempDir(), "blob")
-		server := newMasterBlobServer(dir)
-		if server == nil {
-			t.Fatal("expected local blob server")
-		}
-		if _, err := os.Stat(dir); err != nil {
-			t.Fatal(err)
-		}
-	})
-
-	t.Run("cloud URI", func(t *testing.T) {
-		dir := t.TempDir()
-		t.Chdir(dir)
-		server := newMasterBlobServer("s3://bucket/path")
-		if server != nil {
-			t.Fatal("expected no local blob server for cloud URI")
-		}
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(entries) != 0 {
-			t.Fatalf("expected no local directories, got %v", entries)
-		}
-	})
 }


### PR DESCRIPTION
## Summary
- skip the legacy local blob gRPC server when [blob].uri uses a cloud URI scheme
- avoid registering a nil blob server in that case
- add coverage that cloud URIs do not create a local s3: directory while local paths still create a blob server

Fixes #1283

## Test Plan
- /usr/local/go/bin/go test ./master -run TestNewMasterBlobServer -count=1
- /usr/local/go/bin/go test ./master -run TestMaster -count=1
- /usr/local/go/bin/go test ./... -run '^$'
- git diff --check