### PR TITLE
Index item comments in ml-100k config

### DIFF
--- a/client/config.toml
+++ b/client/config.toml
@@ -86,7 +86,7 @@ active_user_ttl = 0
 [recommend.search]
 
 # Item fields to index for search. Values use expr syntax.
-columns = []
+columns = ["item.Comment"]
 
 [recommend.data_source]
 


### PR DESCRIPTION
## Summary
- Enable item search for the client playground config by indexing item.Comment
- Match the default config's recommend.search.columns setting

## Test Plan
- git diff --check
- /usr/local/go/bin/go test ./client