### PR TITLE
feat(cli): search items by query

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -240,9 +240,9 @@ func (suite *GorseClientTestSuite) TestRecommend() {
 	suite.NoError(err)
 	suite.Len(recommendations, 3)
 	if suite.Len(recommendations, 3) {
-		suite.Equal("315", recommendations[0])
-		suite.Equal("1432", recommendations[1])
-		suite.Equal("918", recommendations[2])
+		suite.Equal("315", recommendations[0].Id)
+		suite.Equal("1432", recommendations[1].Id)
+		suite.Equal("918", recommendations[2].Id)
 	}
 }
 

--- a/cmd/gorse-cli/main.go
+++ b/cmd/gorse-cli/main.go
@@ -390,14 +390,24 @@ var getUsersCmd = &cobra.Command{
 }
 
 var getItemsCmd = &cobra.Command{
-	Use:   "items",
-	Short: "Get items",
+	Use:   "items [query...]",
+	Short: "Get or search items",
+	Args:  cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		n := lo.Must(cmd.Flags().GetInt("n"))
 		if n == 0 {
 			n = 10
 		}
-		items, err := newGorseClient(cmd).GetItems(cmd.Context(), n, "")
+		client := newGorseClient(cmd)
+		var (
+			items gorse.ItemIterator
+			err   error
+		)
+		if len(args) > 0 {
+			items, err = client.SearchItems(cmd.Context(), strings.Join(args, " "), n)
+		} else {
+			items, err = client.GetItems(cmd.Context(), n, "")
+		}
 		if err != nil {
 			log.Logger().Fatal("API request failed", zap.Error(err))
 		}

--- a/cmd/gorse-cli/main_test.go
+++ b/cmd/gorse-cli/main_test.go
@@ -93,6 +93,8 @@ func (s *CLITestSuite) SetupTest() {
 		{ItemId: "recommend-1", Categories: []string{"news"}, Timestamp: time.Date(2026, 1, 4, 0, 0, 0, 0, time.UTC)},
 		{ItemId: "similar-1", Categories: []string{"news"}, Timestamp: time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)},
 	}))
+	s.Require().NoError(s.m.DataClient.Reconcile(config.SearchConfig{Columns: []string{"item.Comment"}}))
+	s.Require().NoError(s.m.DataClient.Optimize())
 	s.Require().NoError(s.m.DataClient.BatchInsertFeedback(ctx, []data.Feedback{{
 		FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "alice", ItemId: "item-1"},
 		Timestamp:   time.Date(2026, 1, 1, 3, 0, 0, 0, time.UTC),
@@ -375,6 +377,20 @@ func (s *CLITestSuite) TestGetItems() {
 	s.Require().NotContains(out, "└")
 }
 
+func (s *CLITestSuite) TestSearchItems() {
+	out, err := s.execute("get", "items", "raw", "item", "-n", "10")
+	s.Require().NoError(err)
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	s.Require().Len(lines, 2)
+	s.Require().Regexp(`^ITEM-ID\s+COMMENT\s+CATEGORIES\s+IS-HIDDEN\s+TIMESTAMP\s+LABELS$`, lines[0])
+	s.Require().Regexp(`^item-1\s+raw item\s+\["news"\]\s+false\s+2026-01-01T01:00:00Z\s+\{"embedding":"\[0\.1, 0\.2, 0\.3, \.\.\.\] \(10 values\)"\}$`, lines[1])
+	s.Require().NotContains(out, "listed item")
+	s.Require().NotContains(out, "┌")
+	s.Require().NotContains(out, "│")
+	s.Require().NotContains(out, "└")
+}
+
 func (s *CLITestSuite) TestPipelineGetCmd() {
 	out, err := s.execute("pipeline", "get")
 	s.Require().NoError(err)
@@ -480,6 +496,7 @@ func newTestMaster(t *testing.T) (*master.Master, string) {
 	cfg.Master.AdminAPIKey = testAPIKey
 	cfg.Master.DashboardUserName = "admin"
 	cfg.Master.DashboardPassword = "pass"
+	cfg.Recommend.Search.Columns = []string{"item.Comment"}
 	cfg.OpenAI.AuthToken = "test"
 
 	m := master.NewMaster(cfg, tempDir, true, "")

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb
-	github.com/gorse-io/gorse-go v0.5.0-alpha.3
+	github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jaswdr/faker v1.19.1
 	github.com/jellydator/ttlcache/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -365,8 +365,8 @@ github.com/gorse-io/clickhouse v0.3.3-0.20260331225025-ab309f55941d h1:ehE+4aaZ1
 github.com/gorse-io/clickhouse v0.3.3-0.20260331225025-ab309f55941d/go.mod h1:6aZpl8cJgPkqNVeZiEgQJ+yLCC0NyDfv7gF/3/pJywU=
 github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb h1:ES79cPTUrtVSrJNg+Cseyj0vJ9Gvv28Q9AuHgENkdqU=
 github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb/go.mod h1:qz7Y16kcH61Qxr6uQtq7a1FbSujErfr020SZH1SVX3g=
-github.com/gorse-io/gorse-go v0.5.0-alpha.3 h1:GR/OWzq016VyFyTTxgQWeayGahRVzB1cGFIW/AaShC4=
-github.com/gorse-io/gorse-go v0.5.0-alpha.3/go.mod h1:ZxmVHzZPKm5pmEIlqaRDwK0rkfTRHlfziO033XZ+RW0=
+github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2 h1:tx7eKfedcqWXNGzO6T5CG8asT5UnwHBkdYKKbZS4z7E=
+github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2/go.mod h1:ZxmVHzZPKm5pmEIlqaRDwK0rkfTRHlfziO033XZ+RW0=
 github.com/gorse-io/sqlite v1.3.3-0.20260331224015-eb865ec4453d h1:cZeyKO0Z7tnpQBCrGOGJrUmZHkpDK/0DgNr2+8cXoOM=
 github.com/gorse-io/sqlite v1.3.3-0.20260331224015-eb865ec4453d/go.mod h1:toTKzjPuIMlZytqN+tB/B486xp/m/RMNemkJ5ZQ9NpQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=


### PR DESCRIPTION
## Summary
- Update gorse-go SDK dependency to include SearchItems
- Let `gorse-cli get items <query...>` search items by joining positional query words with spaces
- Keep `gorse-cli get items` listing behavior unchanged
- Add CLI coverage for multi-word item search via `item.Comment`

## Test Plan
- `/usr/local/go/bin/go test ./cmd/gorse-cli -run 'TestCLI/TestGetItems|TestCLI/TestSearchItems' -count=1`
- `/usr/local/go/bin/go test ./cmd/gorse-cli -run TestCLI -count=1`
- `git diff --check`
