### PR TITLE
feat: proxy OpenAI chat completions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/gomlx/gomlx v0.27.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/securecookie v1.1.2
-	github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb
+	github.com/gorse-io/dashboard v0.0.0-20260614030520-940c6f9c303b
 	github.com/gorse-io/gorse-go v0.5.0-alpha.3
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jaswdr/faker v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pw
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorse-io/clickhouse v0.3.3-0.20260331225025-ab309f55941d h1:ehE+4aaZ1kU2x6fB/OtsgAfZ8UOnB6bFygI4URyolVs=
 github.com/gorse-io/clickhouse v0.3.3-0.20260331225025-ab309f55941d/go.mod h1:6aZpl8cJgPkqNVeZiEgQJ+yLCC0NyDfv7gF/3/pJywU=
-github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb h1:ES79cPTUrtVSrJNg+Cseyj0vJ9Gvv28Q9AuHgENkdqU=
-github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb/go.mod h1:qz7Y16kcH61Qxr6uQtq7a1FbSujErfr020SZH1SVX3g=
+github.com/gorse-io/dashboard v0.0.0-20260614030520-940c6f9c303b h1:PoauwfuuZH3X+STWxjAZ6imImdhgt6jHtTyMfl0/M1Y=
+github.com/gorse-io/dashboard v0.0.0-20260614030520-940c6f9c303b/go.mod h1:qz7Y16kcH61Qxr6uQtq7a1FbSujErfr020SZH1SVX3g=
 github.com/gorse-io/gorse-go v0.5.0-alpha.3 h1:GR/OWzq016VyFyTTxgQWeayGahRVzB1cGFIW/AaShC4=
 github.com/gorse-io/gorse-go v0.5.0-alpha.3/go.mod h1:ZxmVHzZPKm5pmEIlqaRDwK0rkfTRHlfziO033XZ+RW0=
 github.com/gorse-io/sqlite v1.3.3-0.20260331224015-eb865ec4453d h1:cZeyKO0Z7tnpQBCrGOGJrUmZHkpDK/0DgNr2+8cXoOM=

--- a/master/rest.go
+++ b/master/rest.go
@@ -277,7 +277,7 @@ func (m *Master) StartHttpServer() {
 	container.Handle("/api/bulk/feedback", http.HandlerFunc(m.importExportFeedback))
 	container.Handle("/api/dump", http.HandlerFunc(m.dump))
 	container.Handle("/api/restore", http.HandlerFunc(m.restore))
-	container.Handle("/api/chat", http.HandlerFunc(m.chat))
+	container.Handle("/api/chat/completions", http.HandlerFunc(m.chatCompletions))
 	m.RestServer.StartHttpServer(container)
 }
 
@@ -2027,49 +2027,81 @@ func (m *Master) handleOAuth2Callback(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (m *Master) chat(response http.ResponseWriter, request *http.Request) {
+func (m *Master) chatCompletions(response http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodPost {
+		writeError(response, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
 	if !m.checkAdmin(request) {
 		writeError(response, http.StatusUnauthorized, "unauthorized")
 		return
 	}
-	content, err := io.ReadAll(request.Body)
-	if err != nil {
-		writeError(response, http.StatusInternalServerError, err.Error())
+
+	var chatRequest openai.ChatCompletionRequest
+	if err := json.NewDecoder(request.Body).Decode(&chatRequest); err != nil {
+		writeError(response, http.StatusBadRequest, err.Error())
 		return
 	}
+	if chatRequest.Model == "" {
+		chatRequest.Model = m.Config.OpenAI.ChatCompletionModel
+	}
+	if chatRequest.Model == "" {
+		writeError(response, http.StatusBadRequest, "missing chat completion model")
+		return
+	}
+
+	if !chatRequest.Stream {
+		chatResponse, err := m.openAIClient.CreateChatCompletion(request.Context(), chatRequest)
+		if err != nil {
+			writeError(response, http.StatusInternalServerError, err.Error())
+			return
+		}
+		response.Header().Set("Content-Type", restful.MIME_JSON)
+		if err := json.NewEncoder(response).Encode(chatResponse); err != nil {
+			log.Logger().Error("failed to write response", zap.Error(err))
+		}
+		return
+	}
+
 	stream, err := m.openAIClient.CreateChatCompletionStream(
 		request.Context(),
-		openai.ChatCompletionRequest{
-			Model: m.Config.OpenAI.ChatCompletionModel,
-			Messages: []openai.ChatCompletionMessage{
-				{
-					Role:    openai.ChatMessageRoleUser,
-					Content: string(content),
-				},
-			},
-			Stream: true,
-		},
+		chatRequest,
 	)
 	if err != nil {
 		writeError(response, http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	response.Header().Set("Content-Type", "text/event-stream")
+	response.Header().Set("Cache-Control", "no-cache")
+	response.Header().Set("Connection", "keep-alive")
+	response.Header().Set("X-Accel-Buffering", "no")
+
 	// read response
 	defer stream.Close()
 	for {
 		var resp openai.ChatCompletionStreamResponse
 		resp, err = stream.Recv()
 		if errors.Is(err, io.EOF) {
+			_, _ = response.Write([]byte("data: [DONE]\n\n"))
+			if f, ok := response.(http.Flusher); ok {
+				f.Flush()
+			}
 			return
 		}
 		if err != nil {
 			writeError(response, http.StatusInternalServerError, err.Error())
 			return
 		}
-		if len(resp.Choices) == 0 {
-			continue
+		if _, err = response.Write([]byte("data: ")); err != nil {
+			log.Logger().Error("failed to write response", zap.Error(err))
+			return
 		}
-		if _, err = response.Write([]byte(resp.Choices[0].Delta.Content)); err != nil {
+		if err = json.NewEncoder(response).Encode(resp); err != nil {
+			log.Logger().Error("failed to write response", zap.Error(err))
+			return
+		}
+		if _, err = response.Write([]byte("\n")); err != nil {
 			log.Logger().Error("failed to write response", zap.Error(err))
 			return
 		}

--- a/master/rest.go
+++ b/master/rest.go
@@ -2073,7 +2073,7 @@ func (m *Master) chatCompletions(response http.ResponseWriter, request *http.Req
 	}
 
 	response.Header().Set("Content-Type", "text/event-stream")
-	response.Header().Set("Cache-Control", "no-cache")
+	response.Header().Set("Cache-Control", "no-cache, no-transform")
 	response.Header().Set("Connection", "keep-alive")
 	response.Header().Set("X-Accel-Buffering", "no")
 

--- a/master/rest_test.go
+++ b/master/rest_test.go
@@ -1177,17 +1177,62 @@ func (suite *MasterAPITestSuite) TestExportAndImport() {
 	}
 }
 
-func (suite *MasterAPITestSuite) TestChat() {
+func (suite *MasterAPITestSuite) TestChatCompletions() {
 	content := "In my younger and more vulnerable years my father gave me some advice that I've been turning over in" +
 		" my mind ever since. \"Whenever you feel like criticizing any one,\" he told me, \" just remember that all " +
 		"the people in this world haven't had the advantages that you've had.\""
-	buf := strings.NewReader(content)
-	req := httptest.NewRequest("POST", "https://example.com/", buf)
+	buf := bytes.NewBuffer(nil)
+	suite.NoError(json.NewEncoder(buf).Encode(openai.ChatCompletionRequest{
+		Model: "gpt-test",
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: content},
+		},
+	}))
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/api/chat/completions", buf)
 	req.Header.Set("Cookie", suite.cookie)
 	w := httptest.NewRecorder()
-	suite.chat(w, req)
+	suite.chatCompletions(w, req)
 	suite.Equal(http.StatusOK, w.Code, w.Body.String())
-	suite.Equal(content, w.Body.String())
+
+	var chatResponse openai.ChatCompletionResponse
+	suite.NoError(json.NewDecoder(w.Body).Decode(&chatResponse))
+	if suite.Len(chatResponse.Choices, 1) {
+		suite.Equal(content, chatResponse.Choices[0].Message.Content)
+	}
+}
+
+func (suite *MasterAPITestSuite) TestChatCompletionsStream() {
+	content := "streaming chat completion proxy"
+	buf := bytes.NewBuffer(nil)
+	suite.NoError(json.NewEncoder(buf).Encode(openai.ChatCompletionRequest{
+		Model:  "gpt-test",
+		Stream: true,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleUser, Content: content},
+		},
+	}))
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/api/chat/completions", buf)
+	req.Header.Set("Cookie", suite.cookie)
+	w := httptest.NewRecorder()
+	suite.chatCompletions(w, req)
+	suite.Equal(http.StatusOK, w.Code, w.Body.String())
+	suite.Equal("text/event-stream", w.Header().Get("Content-Type"))
+	suite.Contains(w.Body.String(), "data: ")
+	suite.Contains(w.Body.String(), "data: [DONE]")
+
+	var got strings.Builder
+	for _, event := range strings.Split(w.Body.String(), "\n\n") {
+		event = strings.TrimSpace(event)
+		if event == "" || event == "data: [DONE]" {
+			continue
+		}
+		var streamResponse openai.ChatCompletionStreamResponse
+		suite.NoError(json.Unmarshal([]byte(strings.TrimPrefix(event, "data: ")), &streamResponse))
+		if len(streamResponse.Choices) > 0 {
+			got.WriteString(streamResponse.Choices[0].Delta.Content)
+		}
+	}
+	suite.Equal(content, got.String())
 }
 
 func TestMasterAPI(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the legacy raw-text /api/chat handler with an OpenAI-compatible /api/chat/completions proxy
- support both normal and streaming chat completion responses
- add focused master API coverage for non-streaming and SSE streaming proxy behavior

## Test Plan
- /usr/local/go/bin/go test ./master -run 'TestMasterAPI/TestChatCompletions' -count=1
- /usr/local/go/bin/go test ./master -run TestMasterAPI -count=1
- git diff --check