### PR TITLE
feat: add labels to feedback

### DIFF
--- a/cmd/gorse-cli/main_test.go
+++ b/cmd/gorse-cli/main_test.go
@@ -344,8 +344,8 @@ func (s *CLITestSuite) TestGetFeedback() {
 
 		lines := strings.Split(strings.TrimSpace(out), "\n")
 		s.Require().Len(lines, 2)
-		s.Require().Regexp(`^FEEDBACK-TYPE\s+USER-ID\s+ITEM-ID\s+VALUE\s+TIMESTAMP\s+COMMENT\s+UPDATED$`, lines[0])
-		s.Require().Regexp(`^click\s+alice\s+item-1\s+0\s+2026-01-01T03:00:00Z\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$`, lines[1])
+		s.Require().Regexp(`^FEEDBACK-TYPE\s+USER-ID\s+ITEM-ID\s+VALUE\s+TIMESTAMP\s+COMMENT\s+UPDATED\s+LABELS$`, lines[0])
+		s.Require().Regexp(`^click\s+alice\s+item-1\s+0\s+2026-01-01T03:00:00Z\s+\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*$`, lines[1])
 		s.Require().NotContains(out, "Cursor")
 		s.Require().NotContains(out, "┌")
 		s.Require().NotContains(out, "│")

--- a/master/rest.go
+++ b/master/rest.go
@@ -1801,12 +1801,18 @@ func (m *Master) dump(response http.ResponseWriter, request *http.Request) {
 	feedbackStream, errChan := m.DataClient.GetFeedbackStream(context.Background(), batchSize, data.WithEndTime(*m.Config.Now()))
 	for feedbacks := range feedbackStream {
 		for _, feedback := range feedbacks {
+			labels, err := json.Marshal(feedback.Labels)
+			if err != nil {
+				writeError(response, http.StatusInternalServerError, err.Error())
+				return
+			}
 			if err := writeDump(response, &protocol.Feedback{
 				FeedbackType: feedback.FeedbackType,
 				UserId:       feedback.UserId,
 				ItemId:       feedback.ItemId,
 				Value:        feedback.Value,
 				Timestamp:    timestamppb.New(feedback.Timestamp),
+				Labels:       labels,
 				Comment:      feedback.Comment,
 			}); err != nil {
 				writeError(response, http.StatusInternalServerError, err.Error())
@@ -1921,6 +1927,12 @@ func (m *Master) Restore(r io.ReadCloser, delta *time.Duration) (stats DumpStats
 				if delta != nil {
 					timestamp = timestamp.Add(*delta)
 				}
+				var labels any
+				if len(feedback.Labels) > 0 {
+					if err = json.Unmarshal(feedback.Labels, &labels); err != nil {
+						return
+					}
+				}
 				feedbacks = append(feedbacks, data.Feedback{
 					FeedbackKey: data.FeedbackKey{
 						FeedbackType: feedback.FeedbackType,
@@ -1929,6 +1941,7 @@ func (m *Master) Restore(r io.ReadCloser, delta *time.Duration) (stats DumpStats
 					},
 					Value:     feedback.Value,
 					Timestamp: timestamp,
+					Labels:    labels,
 					Comment:   feedback.Comment,
 				})
 				stats.Feedback++

--- a/protocol/protocol.pb.go
+++ b/protocol/protocol.pb.go
@@ -255,6 +255,7 @@ type Feedback struct {
 	Timestamp     *timestamppb.Timestamp `protobuf:"bytes,6,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
 	Comment       string                 `protobuf:"bytes,7,opt,name=comment,proto3" json:"comment,omitempty"`
 	Updated       *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=updated,proto3" json:"updated,omitempty"`
+	Labels        []byte                 `protobuf:"bytes,9,opt,name=labels,proto3" json:"labels,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -341,6 +342,13 @@ func (x *Feedback) GetComment() string {
 func (x *Feedback) GetUpdated() *timestamppb.Timestamp {
 	if x != nil {
 		return x.Updated
+	}
+	return nil
+}
+
+func (x *Feedback) GetLabels() []byte {
+	if x != nil {
+		return x.Labels
 	}
 	return nil
 }
@@ -1156,7 +1164,7 @@ const file_protocol_proto_rawDesc = "" +
 	"categories\x128\n" +
 	"\ttimestamp\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x16\n" +
 	"\x06labels\x18\x06 \x01(\fR\x06labels\x12\x18\n" +
-	"\acomment\x18\a \x01(\tR\acomment\"\x9f\x02\n" +
+	"\acomment\x18\a \x01(\tR\acomment\"\xb7\x02\n" +
 	"\bFeedback\x12\x1c\n" +
 	"\tnamespace\x18\x01 \x01(\tR\tnamespace\x12#\n" +
 	"\rfeedback_type\x18\x02 \x01(\tR\ffeedbackType\x12\x17\n" +
@@ -1165,7 +1173,8 @@ const file_protocol_proto_rawDesc = "" +
 	"\x05value\x18\x05 \x01(\x01R\x05value\x128\n" +
 	"\ttimestamp\x18\x06 \x01(\v2\x1a.google.protobuf.TimestampR\ttimestamp\x12\x18\n" +
 	"\acomment\x18\a \x01(\tR\acomment\x124\n" +
-	"\aupdated\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\aupdated\"\xe9\x01\n" +
+	"\aupdated\x18\b \x01(\v2\x1a.google.protobuf.TimestampR\aupdated\x12\x16\n" +
+	"\x06labels\x18\t \x01(\fR\x06labels\"\xe9\x01\n" +
 	"\x04Meta\x12\x16\n" +
 	"\x06config\x18\x01 \x01(\tR\x06config\x12G\n" +
 	" collaborative_filtering_model_id\x18\x03 \x01(\x03R\x1dcollaborativeFilteringModelId\x12<\n" +

--- a/protocol/protocol.proto
+++ b/protocol/protocol.proto
@@ -46,6 +46,7 @@ message Feedback {
   google.protobuf.Timestamp timestamp = 6;
   string comment = 7;
   google.protobuf.Timestamp updated = 8;
+  bytes labels = 9;
 }
 
 enum NodeType {

--- a/server/rest.go
+++ b/server/rest.go
@@ -1548,6 +1548,7 @@ type Feedback struct {
 	data.FeedbackKey
 	Value     float64
 	Timestamp string
+	Labels    any
 	Comment   string
 }
 
@@ -1555,6 +1556,7 @@ func (f Feedback) ToDataFeedback() (data.Feedback, error) {
 	var feedback data.Feedback
 	feedback.FeedbackKey = f.FeedbackKey
 	feedback.Value = f.Value
+	feedback.Labels = f.Labels
 	feedback.Comment = f.Comment
 	if f.Timestamp != "" {
 		var err error

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -722,7 +722,7 @@ func (suite *ServerTestSuite) TestFeedback() {
 		Header("X-API-Key", apiKey).
 		Expect(t).
 		Status(http.StatusOK).
-		Body(`[{"FeedbackType":"click", "UserId": "2", "ItemId": "4", "Timestamp":"0001-01-01T00:00:00Z", "Updated":"0001-01-01T00:00:00Z", "Comment":"", "Value":1}]`).
+		Body(`[{"FeedbackType":"click", "UserId": "2", "ItemId": "4", "Timestamp":"0001-01-01T00:00:00Z", "Updated":"0001-01-01T00:00:00Z", "Labels": null, "Comment":"", "Value":1}]`).
 		End()
 	apitest.New().
 		Handler(suite.handler).
@@ -730,7 +730,7 @@ func (suite *ServerTestSuite) TestFeedback() {
 		Header("X-API-Key", apiKey).
 		Expect(t).
 		Status(http.StatusOK).
-		Body(`[{"FeedbackType":"click", "UserId": "2", "ItemId": "4", "Timestamp":"0001-01-01T00:00:00Z", "Updated":"0001-01-01T00:00:00Z", "Comment":"", "Value":1}]`).
+		Body(`[{"FeedbackType":"click", "UserId": "2", "ItemId": "4", "Timestamp":"0001-01-01T00:00:00Z", "Updated":"0001-01-01T00:00:00Z", "Labels": null, "Comment":"", "Value":1}]`).
 		End()
 	// test overwrite
 	apitest.New().

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -633,8 +633,8 @@ func (suite *ServerTestSuite) TestFeedback() {
 	// Insert ret
 	feedback := []data.Feedback{
 		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "0", ItemId: "0"}, Value: 1.0},
-		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "1", ItemId: "2"}, Value: 1.0},
-		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "2", ItemId: "4"}, Value: 1.0},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "1", ItemId: "2"}, Value: 1.0, Labels: []any{"positive", "mobile"}},
+		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "2", ItemId: "4"}, Value: 1.0, Labels: map[string]any{"source": "rest", "rank": json.Number("2")}},
 		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "3", ItemId: "6"}, Value: 1.0},
 		{FeedbackKey: data.FeedbackKey{FeedbackType: "click", UserId: "4", ItemId: "8"}, Value: 1.0},
 	}
@@ -722,7 +722,7 @@ func (suite *ServerTestSuite) TestFeedback() {
 		Header("X-API-Key", apiKey).
 		Expect(t).
 		Status(http.StatusOK).
-		Body(`[{"FeedbackType":"click", "UserId": "2", "ItemId": "4", "Timestamp":"0001-01-01T00:00:00Z", "Updated":"0001-01-01T00:00:00Z", "Labels": null, "Comment":"", "Value":1}]`).
+		Body(suite.marshal([]data.Feedback{feedback[2]})).
 		End()
 	apitest.New().
 		Handler(suite.handler).
@@ -730,7 +730,7 @@ func (suite *ServerTestSuite) TestFeedback() {
 		Header("X-API-Key", apiKey).
 		Expect(t).
 		Status(http.StatusOK).
-		Body(`[{"FeedbackType":"click", "UserId": "2", "ItemId": "4", "Timestamp":"0001-01-01T00:00:00Z", "Updated":"0001-01-01T00:00:00Z", "Labels": null, "Comment":"", "Value":1}]`).
+		Body(suite.marshal([]data.Feedback{feedback[2]})).
 		End()
 	// test overwrite
 	apitest.New().

--- a/storage/data/database.go
+++ b/storage/data/database.go
@@ -44,10 +44,6 @@ func ValidateLabels(o any) error {
 		return nil
 	}
 	switch labels := o.(type) {
-	case []string:
-		return nil
-	case []float64:
-		return nil
 	case []any: // must be []string or []float64
 		if len(labels) == 0 {
 			return nil
@@ -59,11 +55,9 @@ func ValidateLabels(o any) error {
 					return errors.Errorf("unsupported labels: %v", jsonutil.MustMarshal(labels))
 				}
 			}
-		case json.Number, float64:
+		case json.Number:
 			for _, val := range labels {
-				switch val.(type) {
-				case json.Number, float64:
-				default:
+				if _, ok := val.(json.Number); !ok {
 					return errors.Errorf("unsupported labels: %v", jsonutil.MustMarshal(labels))
 				}
 			}

--- a/storage/data/database.go
+++ b/storage/data/database.go
@@ -44,6 +44,10 @@ func ValidateLabels(o any) error {
 		return nil
 	}
 	switch labels := o.(type) {
+	case []string:
+		return nil
+	case []float64:
+		return nil
 	case []any: // must be []string or []float64
 		if len(labels) == 0 {
 			return nil
@@ -55,9 +59,11 @@ func ValidateLabels(o any) error {
 					return errors.Errorf("unsupported labels: %v", jsonutil.MustMarshal(labels))
 				}
 			}
-		case json.Number:
+		case json.Number, float64:
 			for _, val := range labels {
-				if _, ok := val.(json.Number); !ok {
+				switch val.(type) {
+				case json.Number, float64:
+				default:
 					return errors.Errorf("unsupported labels: %v", jsonutil.MustMarshal(labels))
 				}
 			}
@@ -130,6 +136,7 @@ type Feedback struct {
 	Value       float64   `gorm:"column:value" mapstructure:"value"`
 	Timestamp   time.Time `gorm:"column:time_stamp" mapstructure:"timestamp"`
 	Updated     time.Time `gorm:"column:updated" mapstructure:"updated"`
+	Labels      any       `gorm:"serializer:json" mapstructure:"labels"`
 	Comment     string    `gorm:"column:comment" mapstructure:"comment"`
 }
 

--- a/storage/data/database_test.go
+++ b/storage/data/database_test.go
@@ -256,7 +256,7 @@ func (suite *baseTestSuite) TestFeedback() {
 	// insert feedbacks
 	timestamp := time.Date(1996, 3, 15, 0, 0, 0, 0, time.UTC)
 	feedback := []Feedback{
-		{FeedbackKey: FeedbackKey{positiveFeedbackType1, "0", "8"}, Value: 1, Timestamp: timestamp, Comment: "comment"},
+		{FeedbackKey: FeedbackKey{positiveFeedbackType1, "0", "8"}, Value: 1, Timestamp: timestamp, Labels: []string{"positive"}, Comment: "comment"},
 		{FeedbackKey: FeedbackKey{positiveFeedbackType1, "1", "6"}, Value: 1, Timestamp: timestamp, Comment: "comment"},
 		{FeedbackKey: FeedbackKey{positiveFeedbackType2, "2", "4"}, Value: 1, Timestamp: timestamp, Comment: "comment"},
 		{FeedbackKey: FeedbackKey{positiveFeedbackType2, "3", "2"}, Value: 1, Timestamp: timestamp, Comment: "comment"},
@@ -268,6 +268,7 @@ func (suite *baseTestSuite) TestFeedback() {
 	for i := range feedback {
 		feedback[i].Updated = feedback[i].Timestamp
 	}
+	feedback[0].Labels = []any{"positive"}
 	// other type
 	err = suite.Database.BatchInsertFeedback(ctx, []Feedback{{FeedbackKey: FeedbackKey{negativeFeedbackType, "0", "2"}}}, true, true, true)
 	suite.NoError(err)
@@ -387,6 +388,7 @@ func (suite *baseTestSuite) TestFeedback() {
 		FeedbackKey: FeedbackKey{positiveFeedbackType, "0", "8"},
 		Value:       100,
 		Timestamp:   time.Date(1996, 4, 8, 0, 0, 0, 0, time.UTC),
+		Labels:      []string{"override"},
 		Comment:     "override",
 	}}, true, true, true)
 	suite.NoError(err)
@@ -403,12 +405,14 @@ func (suite *baseTestSuite) TestFeedback() {
 	suite.Equal(1, len(ret))
 	suite.Equal(float64(100), ret[0].Value)
 	suite.Equal(time.Date(1996, 4, 8, 0, 0, 0, 0, time.UTC), ret[0].Timestamp)
+	suite.Equal([]any{"override"}, ret[0].Labels)
 	suite.Equal("override", ret[0].Comment)
 	// test not overwrite
 	err = suite.Database.BatchInsertFeedback(ctx, []Feedback{{
 		FeedbackKey: FeedbackKey{positiveFeedbackType, "0", "8"},
 		Value:       80,
 		Timestamp:   time.Date(1996, 3, 15, 0, 0, 0, 0, time.UTC),
+		Labels:      []string{"not_override"},
 		Comment:     "not_override",
 	}}, true, true, false)
 	suite.NoError(err)
@@ -419,6 +423,7 @@ func (suite *baseTestSuite) TestFeedback() {
 	suite.Equal(1, len(ret))
 	suite.Equal(float64(180), ret[0].Value)
 	suite.Equal(time.Date(1996, 3, 15, 0, 0, 0, 0, time.UTC), ret[0].Timestamp)
+	suite.Equal([]any{"not_override"}, ret[0].Labels)
 	suite.Equal("not_override", ret[0].Comment)
 
 	// insert no feedback

--- a/storage/data/mongodb.go
+++ b/storage/data/mongodb.go
@@ -776,9 +776,6 @@ func (db *MongoDB) BatchInsertFeedback(ctx context.Context, feedback []Feedback,
 	users := mapset.NewSet[string]()
 	items := mapset.NewSet[string]()
 	for _, v := range feedback {
-		if err := ValidateLabels(v.Labels); err != nil {
-			return errors.Trace(err)
-		}
 		users.Add(v.UserId)
 		items.Add(v.ItemId)
 	}

--- a/storage/data/mongodb.go
+++ b/storage/data/mongodb.go
@@ -593,6 +593,7 @@ func (db *MongoDB) GetItemFeedback(ctx context.Context, itemId string, feedbackT
 		if err = r.Decode(&feedback); err != nil {
 			return nil, err
 		}
+		feedback.Labels = unpack(feedback.Labels)
 		feedbacks = append(feedbacks, feedback)
 	}
 	return feedbacks, nil
@@ -759,6 +760,7 @@ func (db *MongoDB) GetUserFeedback(ctx context.Context, userId string, endTime *
 		if err = r.Decode(&feedback); err != nil {
 			return nil, err
 		}
+		feedback.Labels = unpack(feedback.Labels)
 		feedbacks = append(feedbacks, feedback)
 	}
 	return feedbacks, nil
@@ -774,6 +776,9 @@ func (db *MongoDB) BatchInsertFeedback(ctx context.Context, feedback []Feedback,
 	users := mapset.NewSet[string]()
 	items := mapset.NewSet[string]()
 	for _, v := range feedback {
+		if err := ValidateLabels(v.Labels); err != nil {
+			return errors.Trace(err)
+		}
 		users.Add(v.UserId)
 		items.Add(v.ItemId)
 	}
@@ -859,6 +864,7 @@ func (db *MongoDB) BatchInsertFeedback(ctx context.Context, feedback []Feedback,
 						"updated": f.Updated,
 					},
 					"$set": bson.M{
+						"labels":  f.Labels,
 						"comment": f.Comment,
 					},
 				})
@@ -922,6 +928,7 @@ func (db *MongoDB) GetFeedback(ctx context.Context, cursor string, n int, beginT
 		if err = r.Decode(&feedback); err != nil {
 			return "", nil, err
 		}
+		feedback.Labels = unpack(feedback.Labels)
 		feedbacks = append(feedbacks, feedback)
 	}
 	if len(feedbacks) == n {
@@ -1005,6 +1012,7 @@ func (db *MongoDB) GetFeedbackStream(ctx context.Context, batchSize int, scanOpt
 				errChan <- errors.Trace(err)
 				return
 			}
+			feedback.Labels = unpack(feedback.Labels)
 			feedbacks = append(feedbacks, feedback)
 			if len(feedbacks) == batchSize {
 				feedbackChan <- feedbacks
@@ -1046,6 +1054,7 @@ func (db *MongoDB) GetUserItemFeedback(ctx context.Context, userId, itemId strin
 		if err = r.Decode(&feedback); err != nil {
 			return nil, err
 		}
+		feedback.Labels = unpack(feedback.Labels)
 		feedbacks = append(feedbacks, feedback)
 	}
 	return feedbacks, nil

--- a/storage/data/proxy.go
+++ b/storage/data/proxy.go
@@ -53,6 +53,52 @@ func (p *ProxyServer) Ping(_ context.Context, _ *protocol.PingRequest) (*protoco
 	return &protocol.PingResponse{}, p.database.Ping()
 }
 
+func feedbackToPB(feedback []Feedback) ([]*protocol.Feedback, error) {
+	pbFeedback := make([]*protocol.Feedback, len(feedback))
+	for i, f := range feedback {
+		labels, err := json.Marshal(f.Labels)
+		if err != nil {
+			return nil, err
+		}
+		pbFeedback[i] = &protocol.Feedback{
+			FeedbackType: f.FeedbackType,
+			UserId:       f.UserId,
+			ItemId:       f.ItemId,
+			Value:        f.Value,
+			Timestamp:    timestamppb.New(f.Timestamp),
+			Updated:      timestamppb.New(f.Updated),
+			Labels:       labels,
+			Comment:      f.Comment,
+		}
+	}
+	return pbFeedback, nil
+}
+
+func feedbackFromPB(pbFeedback []*protocol.Feedback) ([]Feedback, error) {
+	feedback := make([]Feedback, len(pbFeedback))
+	for i, f := range pbFeedback {
+		var labels any
+		if len(f.Labels) > 0 {
+			if err := json.Unmarshal(f.Labels, &labels); err != nil {
+				return nil, err
+			}
+		}
+		feedback[i] = Feedback{
+			FeedbackKey: FeedbackKey{
+				FeedbackType: f.FeedbackType,
+				UserId:       f.UserId,
+				ItemId:       f.ItemId,
+			},
+			Value:     f.Value,
+			Timestamp: f.Timestamp.AsTime(),
+			Updated:   f.Updated.AsTime(),
+			Labels:    labels,
+			Comment:   f.Comment,
+		}
+	}
+	return feedback, nil
+}
+
 func (p *ProxyServer) Reconcile(_ context.Context, in *protocol.ReconcileRequest) (*protocol.ReconcileResponse, error) {
 	err := p.database.Reconcile(config.SearchConfig{Columns: in.SearchColumns})
 	return &protocol.ReconcileResponse{}, err
@@ -225,17 +271,9 @@ func (p *ProxyServer) GetItemFeedback(ctx context.Context, in *protocol.GetItemF
 	if err != nil {
 		return nil, err
 	}
-	pbFeedback := make([]*protocol.Feedback, len(feedback))
-	for i, f := range feedback {
-		pbFeedback[i] = &protocol.Feedback{
-			FeedbackType: f.FeedbackType,
-			UserId:       f.UserId,
-			ItemId:       f.ItemId,
-			Value:        f.Value,
-			Timestamp:    timestamppb.New(f.Timestamp),
-			Updated:      timestamppb.New(f.Updated),
-			Comment:      f.Comment,
-		}
+	pbFeedback, err := feedbackToPB(feedback)
+	if err != nil {
+		return nil, err
 	}
 	return &protocol.GetFeedbackResponse{Feedback: pbFeedback}, nil
 }
@@ -332,17 +370,9 @@ func (p *ProxyServer) GetUserFeedback(ctx context.Context, in *protocol.GetUserF
 	if err != nil {
 		return nil, err
 	}
-	pbFeedback := make([]*protocol.Feedback, len(feedback))
-	for i, f := range feedback {
-		pbFeedback[i] = &protocol.Feedback{
-			FeedbackType: f.FeedbackType,
-			UserId:       f.UserId,
-			ItemId:       f.ItemId,
-			Value:        f.Value,
-			Timestamp:    timestamppb.New(f.Timestamp),
-			Updated:      timestamppb.New(f.Updated),
-			Comment:      f.Comment,
-		}
+	pbFeedback, err := feedbackToPB(feedback)
+	if err != nil {
+		return nil, err
 	}
 	return &protocol.GetFeedbackResponse{Feedback: pbFeedback}, nil
 }
@@ -356,17 +386,9 @@ func (p *ProxyServer) GetUserItemFeedback(ctx context.Context, in *protocol.GetU
 	if err != nil {
 		return nil, err
 	}
-	pbFeedback := make([]*protocol.Feedback, len(feedback))
-	for i, f := range feedback {
-		pbFeedback[i] = &protocol.Feedback{
-			FeedbackType: f.FeedbackType,
-			UserId:       f.UserId,
-			ItemId:       f.ItemId,
-			Value:        f.Value,
-			Timestamp:    timestamppb.New(f.Timestamp),
-			Updated:      timestamppb.New(f.Updated),
-			Comment:      f.Comment,
-		}
+	pbFeedback, err := feedbackToPB(feedback)
+	if err != nil {
+		return nil, err
 	}
 	return &protocol.GetFeedbackResponse{Feedback: pbFeedback}, nil
 }
@@ -377,20 +399,11 @@ func (p *ProxyServer) DeleteUserItemFeedback(ctx context.Context, in *protocol.D
 }
 
 func (p *ProxyServer) BatchInsertFeedback(ctx context.Context, in *protocol.BatchInsertFeedbackRequest) (*protocol.BatchInsertFeedbackResponse, error) {
-	feedback := make([]Feedback, len(in.Feedback))
-	for i, f := range in.Feedback {
-		feedback[i] = Feedback{
-			FeedbackKey: FeedbackKey{
-				FeedbackType: f.FeedbackType,
-				UserId:       f.UserId,
-				ItemId:       f.ItemId,
-			},
-			Value:     f.Value,
-			Timestamp: f.Timestamp.AsTime(),
-			Comment:   f.Comment,
-		}
+	feedback, err := feedbackFromPB(in.Feedback)
+	if err != nil {
+		return nil, err
 	}
-	err := p.database.BatchInsertFeedback(ctx, feedback, in.InsertUser, in.InsertItem, in.Overwrite)
+	err = p.database.BatchInsertFeedback(ctx, feedback, in.InsertUser, in.InsertItem, in.Overwrite)
 	return &protocol.BatchInsertFeedbackResponse{}, err
 }
 
@@ -410,17 +423,9 @@ func (p *ProxyServer) GetFeedback(ctx context.Context, in *protocol.GetFeedbackR
 	if err != nil {
 		return nil, err
 	}
-	pbFeedback := make([]*protocol.Feedback, len(feedback))
-	for i, f := range feedback {
-		pbFeedback[i] = &protocol.Feedback{
-			FeedbackType: f.FeedbackType,
-			UserId:       f.UserId,
-			ItemId:       f.ItemId,
-			Value:        f.Value,
-			Timestamp:    timestamppb.New(f.Timestamp),
-			Updated:      timestamppb.New(f.Updated),
-			Comment:      f.Comment,
-		}
+	pbFeedback, err := feedbackToPB(feedback)
+	if err != nil {
+		return nil, err
 	}
 	return &protocol.GetFeedbackResponse{Cursor: cursor, Feedback: pbFeedback}, nil
 }
@@ -510,19 +515,11 @@ func (p *ProxyServer) GetFeedbackStream(in *protocol.GetFeedbackStreamRequest, s
 	}
 	feedbackChan, errChan := p.database.GetFeedbackStream(stream.Context(), int(in.BatchSize), opts...)
 	for feedback := range feedbackChan {
-		pbFeedback := make([]*protocol.Feedback, len(feedback))
-		for i, f := range feedback {
-			pbFeedback[i] = &protocol.Feedback{
-				FeedbackType: f.FeedbackType,
-				UserId:       f.UserId,
-				ItemId:       f.ItemId,
-				Value:        f.Value,
-				Timestamp:    timestamppb.New(f.Timestamp),
-				Updated:      timestamppb.New(f.Updated),
-				Comment:      f.Comment,
-			}
+		pbFeedback, err := feedbackToPB(feedback)
+		if err != nil {
+			return err
 		}
-		err := stream.Send(&protocol.GetFeedbackStreamResponse{Feedback: pbFeedback})
+		err = stream.Send(&protocol.GetFeedbackStreamResponse{Feedback: pbFeedback})
 		if err != nil {
 			return err
 		}
@@ -811,19 +808,9 @@ func (p ProxyClient) GetItemFeedback(ctx context.Context, itemId string, feedbac
 	if err != nil {
 		return nil, err
 	}
-	feedback := make([]Feedback, len(resp.Feedback))
-	for i, f := range resp.Feedback {
-		feedback[i] = Feedback{
-			FeedbackKey: FeedbackKey{
-				FeedbackType: f.FeedbackType,
-				UserId:       f.UserId,
-				ItemId:       f.ItemId,
-			},
-			Value:     f.Value,
-			Timestamp: f.Timestamp.AsTime(),
-			Updated:   f.Updated.AsTime(),
-			Comment:   f.Comment,
-		}
+	feedback, err := feedbackFromPB(resp.Feedback)
+	if err != nil {
+		return nil, err
 	}
 	return feedback, nil
 }
@@ -925,19 +912,9 @@ func (p ProxyClient) GetUserFeedback(ctx context.Context, userId string, endTime
 	if err != nil {
 		return nil, err
 	}
-	feedback := make([]Feedback, len(resp.Feedback))
-	for i, f := range resp.Feedback {
-		feedback[i] = Feedback{
-			FeedbackKey: FeedbackKey{
-				FeedbackType: f.FeedbackType,
-				UserId:       f.UserId,
-				ItemId:       f.ItemId,
-			},
-			Value:     f.Value,
-			Timestamp: f.Timestamp.AsTime(),
-			Updated:   f.Updated.AsTime(),
-			Comment:   f.Comment,
-		}
+	feedback, err := feedbackFromPB(resp.Feedback)
+	if err != nil {
+		return nil, err
 	}
 	return feedback, nil
 }
@@ -955,19 +932,9 @@ func (p ProxyClient) GetUserItemFeedback(ctx context.Context, userId, itemId str
 	if err != nil {
 		return nil, err
 	}
-	feedback := make([]Feedback, len(resp.Feedback))
-	for i, f := range resp.Feedback {
-		feedback[i] = Feedback{
-			FeedbackKey: FeedbackKey{
-				FeedbackType: f.FeedbackType,
-				UserId:       f.UserId,
-				ItemId:       f.ItemId,
-			},
-			Value:     f.Value,
-			Timestamp: f.Timestamp.AsTime(),
-			Updated:   f.Updated.AsTime(),
-			Comment:   f.Comment,
-		}
+	feedback, err := feedbackFromPB(resp.Feedback)
+	if err != nil {
+		return nil, err
 	}
 	return feedback, nil
 }
@@ -985,18 +952,11 @@ func (p ProxyClient) DeleteUserItemFeedback(ctx context.Context, userId, itemId 
 }
 
 func (p ProxyClient) BatchInsertFeedback(ctx context.Context, feedback []Feedback, insertUser, insertItem, overwrite bool) error {
-	reqFeedback := make([]*protocol.Feedback, len(feedback))
-	for i, f := range feedback {
-		reqFeedback[i] = &protocol.Feedback{
-			FeedbackType: f.FeedbackType,
-			UserId:       f.UserId,
-			ItemId:       f.ItemId,
-			Value:        f.Value,
-			Timestamp:    timestamppb.New(f.Timestamp),
-			Comment:      f.Comment,
-		}
+	reqFeedback, err := feedbackToPB(feedback)
+	if err != nil {
+		return err
 	}
-	_, err := p.DataStoreClient.BatchInsertFeedback(ctx, &protocol.BatchInsertFeedbackRequest{
+	_, err = p.DataStoreClient.BatchInsertFeedback(ctx, &protocol.BatchInsertFeedbackRequest{
 		Feedback:   reqFeedback,
 		InsertUser: insertUser,
 		InsertItem: insertItem,
@@ -1027,19 +987,9 @@ func (p ProxyClient) GetFeedback(ctx context.Context, cursor string, n int, begi
 	if err != nil {
 		return "", nil, err
 	}
-	feedback := make([]Feedback, len(resp.Feedback))
-	for i, f := range resp.Feedback {
-		feedback[i] = Feedback{
-			FeedbackKey: FeedbackKey{
-				FeedbackType: f.FeedbackType,
-				UserId:       f.UserId,
-				ItemId:       f.ItemId,
-			},
-			Value:     f.Value,
-			Timestamp: f.Timestamp.AsTime(),
-			Updated:   f.Updated.AsTime(),
-			Comment:   f.Comment,
-		}
+	feedback, err := feedbackFromPB(resp.Feedback)
+	if err != nil {
+		return "", nil, err
 	}
 	return resp.Cursor, feedback, nil
 }
@@ -1173,19 +1123,10 @@ func (p ProxyClient) GetFeedbackStream(ctx context.Context, batchSize int, optio
 				errChan <- err
 				return
 			}
-			feedback := make([]Feedback, len(resp.Feedback))
-			for i, f := range resp.Feedback {
-				feedback[i] = Feedback{
-					FeedbackKey: FeedbackKey{
-						FeedbackType: f.FeedbackType,
-						UserId:       f.UserId,
-						ItemId:       f.ItemId,
-					},
-					Value:     f.Value,
-					Timestamp: f.Timestamp.AsTime(),
-					Updated:   f.Updated.AsTime(),
-					Comment:   f.Comment,
-				}
+			feedback, err := feedbackFromPB(resp.Feedback)
+			if err != nil {
+				errChan <- err
+				return
 			}
 			feedbackChan <- feedback
 		}

--- a/storage/data/sql.go
+++ b/storage/data/sql.go
@@ -1182,7 +1182,7 @@ func (d *SQLDatabase) GetItemFeedback(ctx context.Context, itemId string, feedba
 			Group("user_id, item_id, feedback_type")
 	} else {
 		tx = tx.Table(d.FeedbackTable()).
-			Select("user_id, item_id, feedback_type, value, time_stamp, updated, comment")
+			Select("user_id, item_id, feedback_type, value, time_stamp, updated, labels, comment")
 	}
 	switch d.driver {
 	case SQLite:

--- a/storage/data/sql.go
+++ b/storage/data/sql.go
@@ -299,6 +299,7 @@ func (d *SQLDatabase) Init() error {
 			Value        float64   `gorm:"column:value;type:float;not null;default:0"`
 			Timestamp    time.Time `gorm:"column:time_stamp;type:datetime;not null"`
 			Updated      time.Time `gorm:"column:updated;type:datetime;not null;default:'2000-01-01 00:00:00'"`
+			Labels       []string  `gorm:"column:labels;type:json"`
 			Comment      string    `gorm:"column:comment;type:text;not null"`
 		}
 		err := d.gormDB.Set("gorm:table_options", "ENGINE=InnoDB").AutoMigrate(Users{}, Items{}, Feedback{})
@@ -327,6 +328,7 @@ func (d *SQLDatabase) Init() error {
 			Value        float64   `gorm:"column:value;type:float8;not null;default:0"`
 			Timestamp    time.Time `gorm:"column:time_stamp;type:timestamptz;not null"`
 			Updated      time.Time `gorm:"column:updated;type:timestamptz;not null;default:'2000-01-01 00:00:00'"`
+			Labels       string    `gorm:"column:labels;type:json"`
 			Comment      string    `gorm:"column:comment;type:text;not null;default:''"`
 		}
 		err := d.gormDB.AutoMigrate(Users{}, Items{}, Feedback{})
@@ -355,6 +357,7 @@ func (d *SQLDatabase) Init() error {
 			Value        float64 `gorm:"column:value;type:real;not null;default:0"`
 			Timestamp    string  `gorm:"column:time_stamp;type:datetime;not null;default:'0001-01-01'"`
 			Updated      string  `gorm:"column:updated;type:datetime;not null;default:'0001-01-01'"`
+			Labels       string  `gorm:"column:labels;type:json"`
 			Comment      string  `gorm:"column:comment;type:text;not null;default:''"`
 		}
 		err := d.gormDB.AutoMigrate(Users{}, Items{}, Feedback{})
@@ -393,6 +396,7 @@ func (d *SQLDatabase) Init() error {
 			Value        float64   `gorm:"column:value;type:Float64;default:0"`
 			Timestamp    time.Time `gorm:"column:time_stamp;type:DateTime64(9,'UTC')"`
 			Updated      time.Time `gorm:"column:updated;type:DateTime64(9,'UTC')"`
+			Labels       string    `gorm:"column:labels;type:String"`
 			Comment      string    `gorm:"column:comment;type:String"`
 		}
 		err = d.gormDB.Set("gorm:table_options", "ENGINE = MergeTree ORDER BY (feedback_type, user_id, item_id)").AutoMigrate(Feedback{})
@@ -407,6 +411,7 @@ func (d *SQLDatabase) Init() error {
 			Value        float64   `gorm:"column:value;type:SimpleAggregateFunction(sum, Float64)"`
 			Timestamp    time.Time `gorm:"column:time_stamp;type:SimpleAggregateFunction(min, DateTime64(9,'UTC'))"`
 			Updated      time.Time `gorm:"column:updated;type:SimpleAggregateFunction(max, DateTime64(9,'UTC'))"`
+			Labels       string    `gorm:"column:labels;type:SimpleAggregateFunction(anyLast, String)"`
 			Comment      string    `gorm:"column:comment;type:SimpleAggregateFunction(anyLast, String)"`
 		}
 		err = d.gormDB.Set("gorm:table_options", "ENGINE = AggregatingMergeTree() ORDER BY (user_id, item_id, feedback_type)").AutoMigrate(AggregatingFeedback{})
@@ -414,7 +419,7 @@ func (d *SQLDatabase) Init() error {
 			return errors.Trace(err)
 		}
 		err = d.gormDB.Exec(fmt.Sprintf("CREATE MATERIALIZED VIEW IF NOT EXISTS %s_mv TO %s AS "+
-			"SELECT feedback_type, user_id, item_id, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(comment) AS comment "+
+			"SELECT feedback_type, user_id, item_id, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(labels) AS labels, anyLast(comment) AS comment "+
 			"FROM %s GROUP BY feedback_type, user_id, item_id",
 			d.AggregatingFeedbackTable(), d.AggregatingFeedbackTable(), d.FeedbackTable())).Error
 		if err != nil {
@@ -426,7 +431,7 @@ func (d *SQLDatabase) Init() error {
 			return errors.Trace(err)
 		}
 		err = d.gormDB.Exec(fmt.Sprintf("CREATE MATERIALIZED VIEW IF NOT EXISTS %s_mv TO %s AS "+
-			"SELECT feedback_type, user_id, item_id, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(comment) AS comment "+
+			"SELECT feedback_type, user_id, item_id, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(labels) AS labels, anyLast(comment) AS comment "+
 			"FROM %s GROUP BY feedback_type, user_id, item_id",
 			d.UserFeedbackTable(), d.UserFeedbackTable(), d.FeedbackTable())).Error
 		if err != nil {
@@ -438,7 +443,7 @@ func (d *SQLDatabase) Init() error {
 			return errors.Trace(err)
 		}
 		err = d.gormDB.Exec(fmt.Sprintf("CREATE MATERIALIZED VIEW IF NOT EXISTS %s_mv TO %s AS "+
-			"SELECT feedback_type, user_id, item_id, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(comment) AS comment "+
+			"SELECT feedback_type, user_id, item_id, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(labels) AS labels, anyLast(comment) AS comment "+
 			"FROM %s GROUP BY feedback_type, user_id, item_id",
 			d.ItemFeedbackTable(), d.ItemFeedbackTable(), d.FeedbackTable())).Error
 		if err != nil {
@@ -1173,7 +1178,7 @@ func (d *SQLDatabase) GetItemFeedback(ctx context.Context, itemId string, feedba
 	tx := d.gormDB.WithContext(ctx)
 	if d.driver == ClickHouse {
 		tx = tx.Table(d.ItemFeedbackTable()).
-			Select("user_id, item_id, feedback_type, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(comment) AS comment").
+			Select("user_id, item_id, feedback_type, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(labels) AS labels, anyLast(comment) AS comment").
 			Group("user_id, item_id, feedback_type")
 	} else {
 		tx = tx.Table(d.FeedbackTable()).
@@ -1380,13 +1385,13 @@ func (d *SQLDatabase) GetUserFeedback(ctx context.Context, userId string, endTim
 		tx = tx.Table(d.FeedbackTable())
 	}
 	if d.driver == ClickHouse {
-		tx.Select("feedback_type, user_id, item_id, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(comment) AS comment").
+		tx.Select("feedback_type, user_id, item_id, sum(value) AS value, min(time_stamp) AS time_stamp, max(updated) AS updated, anyLast(labels) AS labels, anyLast(comment) AS comment").
 			Group("feedback_type, user_id, item_id")
 		if endTime != nil {
 			tx.Having("time_stamp <= ?", d.convertTimeZone(endTime))
 		}
 	} else {
-		tx.Select("feedback_type, user_id, item_id, value, time_stamp, updated, comment")
+		tx.Select("feedback_type, user_id, item_id, value, time_stamp, updated, labels, comment")
 		if endTime != nil {
 			tx.Where("time_stamp <= ?", d.convertTimeZone(endTime))
 		}
@@ -1432,6 +1437,9 @@ func (d *SQLDatabase) BatchInsertFeedback(ctx context.Context, feedback []Feedba
 	users := mapset.NewSet[string]()
 	items := mapset.NewSet[string]()
 	for _, v := range feedback {
+		if err := ValidateLabels(v.Labels); err != nil {
+			return errors.Trace(err)
+		}
 		users.Add(v.UserId)
 		items.Add(v.ItemId)
 	}
@@ -1558,7 +1566,7 @@ func (d *SQLDatabase) BatchInsertFeedback(ctx context.Context, feedback []Feedba
 		}
 		var updates clause.Set
 		if overwrite {
-			updates = clause.AssignmentColumns([]string{"time_stamp", "updated", "comment", "value"})
+			updates = clause.AssignmentColumns([]string{"time_stamp", "updated", "labels", "comment", "value"})
 		} else {
 			values := make(map[string]any)
 			switch d.driver {
@@ -1566,16 +1574,19 @@ func (d *SQLDatabase) BatchInsertFeedback(ctx context.Context, feedback []Feedba
 				values["value"] = clause.Column{Raw: true, Name: "value + VALUES(value)"}
 				values["time_stamp"] = clause.Column{Raw: true, Name: "LEAST(time_stamp, VALUES(time_stamp))"}
 				values["updated"] = clause.Column{Raw: true, Name: "GREATEST(updated, VALUES(updated))"}
+				values["labels"] = clause.Column{Raw: true, Name: "VALUES(labels)"}
 				values["comment"] = clause.Column{Raw: true, Name: "VALUES(comment)"}
 			case Postgres:
 				values["value"] = clause.Column{Raw: true, Name: fmt.Sprintf("%s.value + EXCLUDED.value", d.FeedbackTable())}
 				values["time_stamp"] = clause.Column{Raw: true, Name: fmt.Sprintf("LEAST(%s.time_stamp, EXCLUDED.time_stamp)", d.FeedbackTable())}
 				values["updated"] = clause.Column{Raw: true, Name: fmt.Sprintf("GREATEST(%s.updated, EXCLUDED.updated)", d.FeedbackTable())}
+				values["labels"] = clause.Column{Raw: true, Name: "EXCLUDED.labels"}
 				values["comment"] = clause.Column{Raw: true, Name: "EXCLUDED.comment"}
 			case SQLite:
 				values["value"] = clause.Column{Raw: true, Name: "value + excluded.value"}
 				values["time_stamp"] = clause.Column{Raw: true, Name: "MIN(time_stamp, excluded.time_stamp)"}
 				values["updated"] = clause.Column{Raw: true, Name: "MAX(updated, excluded.updated)"}
+				values["labels"] = clause.Column{Raw: true, Name: "excluded.labels"}
 				values["comment"] = clause.Column{Raw: true, Name: "excluded.comment"}
 			}
 			updates = clause.Assignments(values)
@@ -1594,7 +1605,7 @@ func (d *SQLDatabase) GetFeedback(ctx context.Context, cursor string, n int, beg
 	if err != nil {
 		return "", nil, errors.Trace(err)
 	}
-	tx := d.gormDB.WithContext(ctx).Table(d.FeedbackTable()).Select("feedback_type, user_id, item_id, value, time_stamp, updated, comment")
+	tx := d.gormDB.WithContext(ctx).Table(d.FeedbackTable()).Select("feedback_type, user_id, item_id, value, time_stamp, updated, labels, comment")
 	if len(buf) > 0 {
 		var cursorKey FeedbackKey
 		if err := jsonutil.Unmarshal(buf, &cursorKey); err != nil {
@@ -1651,7 +1662,7 @@ func (d *SQLDatabase) GetFeedbackStream(ctx context.Context, batchSize int, scan
 		// send query
 		tx := d.gormDB.WithContext(ctx).
 			Table(d.FeedbackTable()).
-			Select("feedback_type, user_id, item_id, value, time_stamp, updated, comment")
+			Select("feedback_type, user_id, item_id, value, time_stamp, updated, labels, comment")
 		if len(scan.FeedbackTypes) > 0 {
 			db := d.gormDB
 			for _, feedbackType := range scan.FeedbackTypes {
@@ -1715,11 +1726,11 @@ func (d *SQLDatabase) GetUserItemFeedback(ctx context.Context, userId, itemId st
 	tx := d.gormDB.WithContext(ctx)
 	if d.driver == ClickHouse {
 		tx = tx.Table(d.UserFeedbackTable()).
-			Select("feedback_type, user_id, item_id, sum(value) AS value, any(time_stamp) AS time_stamp, max(updated) AS updated, any(comment) AS comment").
+			Select("feedback_type, user_id, item_id, sum(value) AS value, any(time_stamp) AS time_stamp, max(updated) AS updated, any(labels) AS labels, any(comment) AS comment").
 			Group("feedback_type, user_id, item_id")
 	} else {
 		tx = tx.Table(d.FeedbackTable()).
-			Select("feedback_type, user_id, item_id, value, time_stamp, updated, comment")
+			Select("feedback_type, user_id, item_id, value, time_stamp, updated, labels, comment")
 	}
 	tx.Where("user_id = ? AND item_id = ?", userId, itemId)
 	if len(feedbackTypes) > 0 {

--- a/storage/data/sql.go
+++ b/storage/data/sql.go
@@ -1437,9 +1437,6 @@ func (d *SQLDatabase) BatchInsertFeedback(ctx context.Context, feedback []Feedba
 	users := mapset.NewSet[string]()
 	items := mapset.NewSet[string]()
 	for _, v := range feedback {
-		if err := ValidateLabels(v.Labels); err != nil {
-			return errors.Trace(err)
-		}
 		users.Add(v.UserId)
 		items.Add(v.ItemId)
 	}


### PR DESCRIPTION
## Summary
- add labels support to feedback data model and SQL/Mongo storage
- preserve feedback labels through proxy/protobuf, REST insert, and dump/restore paths
- add feedback labels persistence coverage and align label validation with documented supported types

## Test Plan
- /usr/local/go/bin/go test ./storage/data -run '^TestSQLite$/^TestFeedback$' -count=1 -v
- /usr/local/go/bin/go test ./storage/data -run '^TestProxy$' -count=1 -v
- /usr/local/go/bin/go test ./storage/data -run '^TestMySQL$/^TestFeedback$' -count=1 -v
- /usr/local/go/bin/go test ./storage/data -run '^TestPostgres$/^TestFeedback$' -count=1 -v
- /usr/local/go/bin/go test ./storage/data -run '^TestClickHouse$/^TestFeedback$' -count=1 -v
- /usr/local/go/bin/go test ./storage/data -run '^TestMongo$/^TestFeedback$' -count=1 -v
- /usr/local/go/bin/go test ./server ./master -run '^$' -count=1
- git diff --check