### PR TITLE
fix(master): protect maintenance endpoints with login

### DIFF
--- a/master/rest.go
+++ b/master/rest.go
@@ -1669,16 +1669,6 @@ func writeError(response http.ResponseWriter, httpStatus int, message string) {
 	}
 }
 
-func (m *Master) checkAdmin(request *http.Request) bool {
-	if m.Config.Master.AdminAPIKey == "" {
-		return true
-	}
-	if request.Header.Get("X-API-Key") == m.Config.Master.AdminAPIKey {
-		return true
-	}
-	return false
-}
-
 const (
 	EOF            = int64(0)
 	UserStream     = int64(-1)
@@ -1723,7 +1713,7 @@ func readDump[T proto.Message](r io.Reader, data T) (int64, error) {
 }
 
 func (m *Master) dump(response http.ResponseWriter, request *http.Request) {
-	if !m.checkAdmin(request) {
+	if !m.checkLogin(request) {
 		writeError(response, http.StatusUnauthorized, "unauthorized")
 		return
 	}
@@ -1953,7 +1943,7 @@ func (m *Master) Restore(r io.ReadCloser, delta *time.Duration) (stats DumpStats
 }
 
 func (m *Master) restore(response http.ResponseWriter, request *http.Request) {
-	if !m.checkAdmin(request) {
+	if !m.checkLogin(request) {
 		writeError(response, http.StatusUnauthorized, "unauthorized")
 		return
 	}
@@ -2028,7 +2018,7 @@ func (m *Master) handleOAuth2Callback(w http.ResponseWriter, r *http.Request) {
 }
 
 func (m *Master) chat(response http.ResponseWriter, request *http.Request) {
-	if !m.checkAdmin(request) {
+	if !m.checkLogin(request) {
 		writeError(response, http.StatusUnauthorized, "unauthorized")
 		return
 	}


### PR DESCRIPTION
## Summary
- backport #1293 to release-0.5
- remove the admin-only auth helper that allowed requests when admin_api_key was empty
- protect dump, restore, and chat endpoints with the existing login check
- preserve admin_api_key access through checkLogin

Fixes #1292

## Test Plan
- /usr/local/go/bin/go test ./master -run 'TestMasterAPI/Test(DumpAndRestore|Chat)$' -count=1