### PR TITLE
ci: replace gox with GoReleaser

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -8,74 +8,27 @@ jobs:
   binaries:
     name: binaries
     runs-on: macos-latest
+    permissions:
+      contents: write
     steps:
       - name: Pull source
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: ./go.mod
 
-      - name: Install gox
-        run: go install github.com/mitchellh/gox@master
-
-      - name: Build release (windows and linux)
-        run: >
-          gox -output="{{.OS}}/{{.Arch}}/{{.Dir}}" \
-            -osarch='windows/arm64 windows/amd64 linux/arm64 linux/amd64 linux/riscv64' -ldflags="
-            -X 'github.com/gorse-io/gorse/cmd/version.Version=$(git describe --tags $(git rev-parse HEAD))'
-            -X 'github.com/gorse-io/gorse/cmd/version.GitCommit=$(git rev-parse HEAD)'
-            -X 'github.com/gorse-io/gorse/cmd/version.BuildTime=$(date)'" ./...
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
         env:
-          CGO_ENABLED: 0
-
-      - name: Build release (darwin)
-        run: >
-          gox -output="{{.OS}}/{{.Arch}}/{{.Dir}}" \
-            -osarch='darwin/arm64' -ldflags="
-            -X 'github.com/gorse-io/gorse/cmd/version.Version=$(git describe --tags $(git rev-parse HEAD))'
-            -X 'github.com/gorse-io/gorse/cmd/version.GitCommit=$(git rev-parse HEAD)'
-            -X 'github.com/gorse-io/gorse/cmd/version.BuildTime=$(date)'" ./...
-
-      - name: Install zip
-        run: brew install zip
-
-      - name: Zip binaries
-        run: |
-          zip -j gorse_linux_amd64.zip linux/amd64/gorse-*
-          zip -j gorse_linux_arm64.zip linux/arm64/gorse-*
-          zip -j gorse_linux_riscv64.zip linux/riscv64/gorse-*
-          zip -j gorse_windows_amd64.zip windows/amd64/gorse-*
-          zip -j gorse_windows_arm64.zip windows/arm64/gorse-*
-          zip -j gorse_darwin_arm64.zip darwin/arm64/gorse-*
-
-      - name: Prepare standalone CLI binaries
-        run: |
-          cp linux/amd64/gorse-cli gorse-cli_linux_amd64
-          cp linux/arm64/gorse-cli gorse-cli_linux_arm64
-          cp linux/riscv64/gorse-cli gorse-cli_linux_riscv64
-          cp windows/amd64/gorse-cli.exe gorse-cli_windows_amd64.exe
-          cp windows/arm64/gorse-cli.exe gorse-cli_windows_arm64.exe
-          cp darwin/arm64/gorse-cli gorse-cli_darwin_arm64
-
-      - name: Upload release
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: gorse_*_*.zip
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true
-
-      - name: Upload standalone CLI binaries
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: gorse-cli_*
-          tag: ${{ github.ref }}
-          overwrite: true
-          file_glob: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker_images:
     name: docker images

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -5,9 +5,9 @@ on:
     types: [published]
 
 jobs:
-  binaries:
-    name: binaries
-    runs-on: macos-latest
+  binaries_linux_windows:
+    name: binaries (linux/windows)
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
@@ -29,6 +29,58 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  binaries_darwin:
+    name: binaries (darwin)
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Pull source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Install gox
+        run: go install github.com/mitchellh/gox@master
+
+      - name: Build release (darwin)
+        run: >
+          gox -output="{{.OS}}/{{.Arch}}/{{.Dir}}" \
+            -osarch='darwin/arm64' -ldflags="
+            -X 'github.com/gorse-io/gorse/cmd/version.Version=$(git describe --tags $(git rev-parse HEAD))'
+            -X 'github.com/gorse-io/gorse/cmd/version.GitCommit=$(git rev-parse HEAD)'
+            -X 'github.com/gorse-io/gorse/cmd/version.BuildTime=$(date)'" ./...
+
+      - name: Install zip
+        run: brew install zip
+
+      - name: Zip binaries
+        run: zip -j gorse_darwin_arm64.zip darwin/arm64/gorse-*
+
+      - name: Prepare standalone CLI binary
+        run: cp darwin/arm64/gorse-cli gorse-cli_darwin_arm64
+
+      - name: Upload release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: gorse_darwin_arm64.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+
+      - name: Upload standalone CLI binary
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: gorse-cli_darwin_arm64
+          tag: ${{ github.ref }}
+          overwrite: true
 
   docker_images:
     name: docker images

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,23 +20,12 @@ builds:
         -X 'github.com/gorse-io/gorse/cmd/version.Version={{ .Version }}'
         -X 'github.com/gorse-io/gorse/cmd/version.GitCommit={{ .Commit }}'
         -X 'github.com/gorse-io/gorse/cmd/version.BuildTime={{ .Date }}'
-  - id: gorse-bench-darwin
-    main: ./cmd/gorse-bench
-    binary: gorse-bench
-    targets: &darwin_targets
-      - darwin_arm64
-    ldflags: *ldflags
   - id: gorse-cli
     main: ./cmd/gorse-cli
     binary: gorse-cli
     env:
       - CGO_ENABLED=0
     targets: *linux_windows_targets
-    ldflags: *ldflags
-  - id: gorse-cli-darwin
-    main: ./cmd/gorse-cli
-    binary: gorse-cli
-    targets: *darwin_targets
     ldflags: *ldflags
   - id: gorse-in-one
     main: ./cmd/gorse-in-one
@@ -45,22 +34,12 @@ builds:
       - CGO_ENABLED=0
     targets: *linux_windows_targets
     ldflags: *ldflags
-  - id: gorse-in-one-darwin
-    main: ./cmd/gorse-in-one
-    binary: gorse-in-one
-    targets: *darwin_targets
-    ldflags: *ldflags
   - id: gorse-master
     main: ./cmd/gorse-master
     binary: gorse-master
     env:
       - CGO_ENABLED=0
     targets: *linux_windows_targets
-    ldflags: *ldflags
-  - id: gorse-master-darwin
-    main: ./cmd/gorse-master
-    binary: gorse-master
-    targets: *darwin_targets
     ldflags: *ldflags
   - id: gorse-server
     main: ./cmd/gorse-server
@@ -69,11 +48,6 @@ builds:
       - CGO_ENABLED=0
     targets: *linux_windows_targets
     ldflags: *ldflags
-  - id: gorse-server-darwin
-    main: ./cmd/gorse-server
-    binary: gorse-server
-    targets: *darwin_targets
-    ldflags: *ldflags
   - id: gorse-worker
     main: ./cmd/gorse-worker
     binary: gorse-worker
@@ -81,27 +55,16 @@ builds:
       - CGO_ENABLED=0
     targets: *linux_windows_targets
     ldflags: *ldflags
-  - id: gorse-worker-darwin
-    main: ./cmd/gorse-worker
-    binary: gorse-worker
-    targets: *darwin_targets
-    ldflags: *ldflags
 
 archives:
   - id: gorse
     ids: &all_builds
       - gorse-bench
-      - gorse-bench-darwin
       - gorse-cli
-      - gorse-cli-darwin
       - gorse-in-one
-      - gorse-in-one-darwin
       - gorse-master
-      - gorse-master-darwin
       - gorse-server
-      - gorse-server-darwin
       - gorse-worker
-      - gorse-worker-darwin
     formats:
       - zip
     name_template: "gorse_{{ .Os }}_{{ .Arch }}"
@@ -110,7 +73,6 @@ archives:
   - id: gorse-cli
     ids:
       - gorse-cli
-      - gorse-cli-darwin
     formats:
       - binary
     name_template: "gorse-cli_{{ .Os }}_{{ .Arch }}"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,6 +11,7 @@ builds:
     targets: &linux_windows_targets
       - linux_amd64
       - linux_arm64
+      - linux_loong64
       - linux_riscv64
       - windows_amd64
       - windows_arm64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,122 @@
+version: 2
+
+project_name: gorse
+
+builds:
+  - id: gorse-bench
+    main: ./cmd/gorse-bench
+    binary: gorse-bench
+    env:
+      - CGO_ENABLED=0
+    targets: &linux_windows_targets
+      - linux_amd64
+      - linux_arm64
+      - linux_riscv64
+      - windows_amd64
+      - windows_arm64
+    ldflags: &ldflags
+      - >-
+        -X 'github.com/gorse-io/gorse/cmd/version.Version={{ .Version }}'
+        -X 'github.com/gorse-io/gorse/cmd/version.GitCommit={{ .Commit }}'
+        -X 'github.com/gorse-io/gorse/cmd/version.BuildTime={{ .Date }}'
+  - id: gorse-bench-darwin
+    main: ./cmd/gorse-bench
+    binary: gorse-bench
+    targets: &darwin_targets
+      - darwin_arm64
+    ldflags: *ldflags
+  - id: gorse-cli
+    main: ./cmd/gorse-cli
+    binary: gorse-cli
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-cli-darwin
+    main: ./cmd/gorse-cli
+    binary: gorse-cli
+    targets: *darwin_targets
+    ldflags: *ldflags
+  - id: gorse-in-one
+    main: ./cmd/gorse-in-one
+    binary: gorse-in-one
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-in-one-darwin
+    main: ./cmd/gorse-in-one
+    binary: gorse-in-one
+    targets: *darwin_targets
+    ldflags: *ldflags
+  - id: gorse-master
+    main: ./cmd/gorse-master
+    binary: gorse-master
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-master-darwin
+    main: ./cmd/gorse-master
+    binary: gorse-master
+    targets: *darwin_targets
+    ldflags: *ldflags
+  - id: gorse-server
+    main: ./cmd/gorse-server
+    binary: gorse-server
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-server-darwin
+    main: ./cmd/gorse-server
+    binary: gorse-server
+    targets: *darwin_targets
+    ldflags: *ldflags
+  - id: gorse-worker
+    main: ./cmd/gorse-worker
+    binary: gorse-worker
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-worker-darwin
+    main: ./cmd/gorse-worker
+    binary: gorse-worker
+    targets: *darwin_targets
+    ldflags: *ldflags
+
+archives:
+  - id: gorse
+    ids: &all_builds
+      - gorse-bench
+      - gorse-bench-darwin
+      - gorse-cli
+      - gorse-cli-darwin
+      - gorse-in-one
+      - gorse-in-one-darwin
+      - gorse-master
+      - gorse-master-darwin
+      - gorse-server
+      - gorse-server-darwin
+      - gorse-worker
+      - gorse-worker-darwin
+    formats:
+      - zip
+    name_template: "gorse_{{ .Os }}_{{ .Arch }}"
+    files:
+      - none*
+  - id: gorse-cli
+    ids:
+      - gorse-cli
+      - gorse-cli-darwin
+    formats:
+      - binary
+    name_template: "gorse-cli_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  disable: true
+
+release:
+  replace_existing_artifacts: true
+  mode: keep-existing


### PR DESCRIPTION
## Summary
- replace the Linux/Windows release binaries flow's gox/zip/upload-release-action steps with goreleaser/goreleaser-action on Ubuntu
- add .goreleaser.yaml for Linux/Windows release targets and artifacts, including linux/loong64
- split Darwin into its own macOS job and keep the original gox/zip/upload workflow for darwin/arm64
- keep Docker release jobs unchanged

## Checks
- YAML parse check
- goreleaser check
- git diff --check
- PATH=/usr/local/go/bin:$PATH GOCACHE=/mnt/openclaw/tmp/gocache GOTMPDIR=/mnt/openclaw/tmp/gotmp goreleaser build --snapshot --clean --single-target --parallelism 1
- PATH=/usr/local/go/bin:$PATH GOCACHE=/mnt/openclaw/tmp/gocache GOTMPDIR=/mnt/openclaw/tmp/gotmp GOOS=linux GOARCH=loong64 goreleaser build --snapshot --clean --single-target --parallelism 1

Note: Darwin remains on the original macOS workflow as requested.