### PR TITLE
ci: replace gox with GoReleaser

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -5,12 +5,41 @@ on:
     types: [published]
 
 jobs:
-  binaries:
-    name: binaries
-    runs-on: macos-latest
+  binaries_linux_windows:
+    name: binaries (linux/windows)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Pull source
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  binaries_darwin:
+    name: binaries (darwin)
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Pull source
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -19,16 +48,6 @@ jobs:
 
       - name: Install gox
         run: go install github.com/mitchellh/gox@master
-
-      - name: Build release (windows and linux)
-        run: >
-          gox -output="{{.OS}}/{{.Arch}}/{{.Dir}}" \
-            -osarch='windows/arm64 windows/amd64 linux/arm64 linux/amd64 linux/riscv64' -ldflags="
-            -X 'github.com/gorse-io/gorse/cmd/version.Version=$(git describe --tags $(git rev-parse HEAD))'
-            -X 'github.com/gorse-io/gorse/cmd/version.GitCommit=$(git rev-parse HEAD)'
-            -X 'github.com/gorse-io/gorse/cmd/version.BuildTime=$(date)'" ./...
-        env:
-          CGO_ENABLED: 0
 
       - name: Build release (darwin)
         run: >
@@ -42,40 +61,26 @@ jobs:
         run: brew install zip
 
       - name: Zip binaries
-        run: |
-          zip -j gorse_linux_amd64.zip linux/amd64/gorse-*
-          zip -j gorse_linux_arm64.zip linux/arm64/gorse-*
-          zip -j gorse_linux_riscv64.zip linux/riscv64/gorse-*
-          zip -j gorse_windows_amd64.zip windows/amd64/gorse-*
-          zip -j gorse_windows_arm64.zip windows/arm64/gorse-*
-          zip -j gorse_darwin_arm64.zip darwin/arm64/gorse-*
+        run: zip -j gorse_darwin_arm64.zip darwin/arm64/gorse-*
 
-      - name: Prepare standalone CLI binaries
-        run: |
-          cp linux/amd64/gorse-cli gorse-cli_linux_amd64
-          cp linux/arm64/gorse-cli gorse-cli_linux_arm64
-          cp linux/riscv64/gorse-cli gorse-cli_linux_riscv64
-          cp windows/amd64/gorse-cli.exe gorse-cli_windows_amd64.exe
-          cp windows/arm64/gorse-cli.exe gorse-cli_windows_arm64.exe
-          cp darwin/arm64/gorse-cli gorse-cli_darwin_arm64
+      - name: Prepare standalone CLI binary
+        run: cp darwin/arm64/gorse-cli gorse-cli_darwin_arm64
 
       - name: Upload release
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: gorse_*_*.zip
+          file: gorse_darwin_arm64.zip
           tag: ${{ github.ref }}
           overwrite: true
-          file_glob: true
 
-      - name: Upload standalone CLI binaries
+      - name: Upload standalone CLI binary
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: gorse-cli_*
+          file: gorse-cli_darwin_arm64
           tag: ${{ github.ref }}
           overwrite: true
-          file_glob: true
 
   docker_images:
     name: docker images

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,85 @@
+version: 2
+
+project_name: gorse
+
+builds:
+  - id: gorse-bench
+    main: ./cmd/gorse-bench
+    binary: gorse-bench
+    env:
+      - CGO_ENABLED=0
+    targets: &linux_windows_targets
+      - linux_amd64
+      - linux_arm64
+      - linux_loong64
+      - linux_riscv64
+      - windows_amd64
+      - windows_arm64
+    ldflags: &ldflags
+      - >-
+        -X 'github.com/gorse-io/gorse/cmd/version.Version={{ .Version }}'
+        -X 'github.com/gorse-io/gorse/cmd/version.GitCommit={{ .Commit }}'
+        -X 'github.com/gorse-io/gorse/cmd/version.BuildTime={{ .Date }}'
+  - id: gorse-cli
+    main: ./cmd/gorse-cli
+    binary: gorse-cli
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-in-one
+    main: ./cmd/gorse-in-one
+    binary: gorse-in-one
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-master
+    main: ./cmd/gorse-master
+    binary: gorse-master
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-server
+    main: ./cmd/gorse-server
+    binary: gorse-server
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+  - id: gorse-worker
+    main: ./cmd/gorse-worker
+    binary: gorse-worker
+    env:
+      - CGO_ENABLED=0
+    targets: *linux_windows_targets
+    ldflags: *ldflags
+
+archives:
+  - id: gorse
+    ids: &all_builds
+      - gorse-bench
+      - gorse-cli
+      - gorse-in-one
+      - gorse-master
+      - gorse-server
+      - gorse-worker
+    formats:
+      - zip
+    name_template: "gorse_{{ .Os }}_{{ .Arch }}"
+    files:
+      - none*
+  - id: gorse-cli
+    ids:
+      - gorse-cli
+    formats:
+      - binary
+    name_template: "gorse-cli_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  disable: true
+
+release:
+  replace_existing_artifacts: true
+  mode: keep-existing


### PR DESCRIPTION
Cherry-pick 9eed567c35072fa5f0590abb5a4079c27abb24aa onto release-0.5.\n\nValidation:\n- YAML parsed successfully for .github/workflows/build_release.yml and .goreleaser.yaml\n- goreleaser check passed