### PR TITLE
fix: support loong64 in CLI installer

### DIFF
--- a/cmd/gorse-cli/install.sh
+++ b/cmd/gorse-cli/install.sh
@@ -45,6 +45,9 @@ normalize_arch() {
     riscv64)
       printf 'riscv64'
       ;;
+    loong64 | loongarch64)
+      printf 'loong64'
+      ;;
     *)
       fail "unsupported architecture: $(uname -m)"
       ;;
@@ -85,7 +88,7 @@ main() {
   arch="$(normalize_arch)"
 
   case "${os}_${arch}" in
-    linux_amd64 | linux_arm64 | linux_riscv64 | darwin_arm64)
+    linux_amd64 | linux_arm64 | linux_loong64 | linux_riscv64 | darwin_arm64)
       ;;
     darwin_amd64)
       fail "unsupported platform: darwin_amd64. Release builds currently include darwin_arm64 only."


### PR DESCRIPTION
Add loong64 support to cmd/gorse-cli/install.sh.

Changes:
- Map `uname -m` values `loong64` and `loongarch64` to Go arch `loong64`
- Allow the `linux_loong64` platform in the installer

GoReleaser already builds the `gorse-cli_linux_loong64` standalone asset.

Tests:
- `bash -n cmd/gorse-cli/install.sh`
- Simulated `Linux` + `loongarch64` uname and verified the installer downloads `gorse-cli_linux_loong64`