### PR TITLE
Require vector store configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,9 +71,9 @@ type Config struct {
 
 // DatabaseConfig is the configuration for the database.
 type DatabaseConfig struct {
-	DataStore         string       `mapstructure:"data_store" validate:"required,data_store"`      // database for data store
-	CacheStore        string       `mapstructure:"cache_store" validate:"required,cache_store"`    // database for cache store
-	VectorStore       string       `mapstructure:"vector_store" validate:"omitempty,vector_store"` // database for vector indices
+	DataStore         string       `mapstructure:"data_store" validate:"required,data_store"`     // database for data store
+	CacheStore        string       `mapstructure:"cache_store" validate:"required,cache_store"`   // database for cache store
+	VectorStore       string       `mapstructure:"vector_store" validate:"required,vector_store"` // database for vector indices
 	TablePrefix       string       `mapstructure:"table_prefix"`
 	DataTablePrefix   string       `mapstructure:"data_table_prefix"`
 	CacheTablePrefix  string       `mapstructure:"cache_table_prefix"`
@@ -466,6 +466,7 @@ func GetDefaultConfig() *Config {
 		Database: DatabaseConfig{
 			DataStore:       "sqlite://" + filepath.Join(MkDir(), "data.sqlite"),
 			CacheStore:      "sqlite://" + filepath.Join(MkDir(), "cache.sqlite"),
+			VectorStore:     "sqlite://" + filepath.Join(MkDir(), "vector.sqlite"),
 			CacheClientName: "gorse_cache_client",
 			MySQL: MySQLConfig{
 				IsolationLevel:  "READ-UNCOMMITTED",
@@ -612,6 +613,11 @@ func setDefault() {
 	// [database]
 	viper.SetDefault("database.data_store", defaultConfig.Database.DataStore)
 	viper.SetDefault("database.cache_store", defaultConfig.Database.CacheStore)
+	viper.SetDefault("database.vector_store", defaultConfig.Database.VectorStore)
+	viper.SetDefault("database.table_prefix", defaultConfig.Database.TablePrefix)
+	viper.SetDefault("database.data_table_prefix", defaultConfig.Database.DataTablePrefix)
+	viper.SetDefault("database.cache_table_prefix", defaultConfig.Database.CacheTablePrefix)
+	viper.SetDefault("database.vector_table_prefix", defaultConfig.Database.VectorTablePrefix)
 	viper.SetDefault("database.cache_client_name", defaultConfig.Database.CacheClientName)
 	// [database.mysql]
 	viper.SetDefault("database.mysql.isolation_level", defaultConfig.Database.MySQL.IsolationLevel)

--- a/config/config.toml
+++ b/config/config.toml
@@ -25,6 +25,14 @@ cache_store = "redis://localhost:6379/0"
 #   sqlite://<path>
 data_store = "mysql://gorse:gorse_pass@tcp(localhost:3306)/gorse"
 
+# The database for vector indices, support SQLite, Qdrant, Weaviate and Milvus:
+#   sqlite://<path>
+#   qdrant://<host>:<port>
+#   weaviate://<host>:<port>
+#   weaviates://<host>:<port>
+#   milvus://<host>:<port>
+vector_store = "sqlite://vector.db"
+
 # The naming prefix for tables (collections, keys) in databases. The default value is empty.
 table_prefix = ""
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -68,6 +68,7 @@ func TestUnmarshal(t *testing.T) {
 			// [database]
 			assert.Equal(t, "redis://localhost:6379/0", config.Database.CacheStore)
 			assert.Equal(t, "mysql://gorse:gorse_pass@tcp(localhost:3306)/gorse", config.Database.DataStore)
+			assert.Equal(t, "sqlite://vector.db", config.Database.VectorStore)
 			assert.Equal(t, "gorse_", config.Database.TablePrefix)
 			assert.Equal(t, "gorse_cache_", config.Database.CacheTablePrefix)
 			assert.Equal(t, "gorse_cache_client", config.Database.CacheClientName)
@@ -525,8 +526,10 @@ func (s *ValidateTestSuite) TestCacheStore() {
 }
 
 func (s *ValidateTestSuite) TestVectorStore() {
+	s.Database.VectorStore = ""
+	s.Error(s.Validate())
+
 	for _, vectorStore := range []string{
-		"",
 		"sqlite://:memory:",
 		"qdrant://localhost:6334",
 		"weaviate://localhost:8080",

--- a/master/master.go
+++ b/master/master.go
@@ -136,12 +136,13 @@ func NewMaster(cfg *config.Config, cacheFolder string, standalone bool, configPa
 		tracer:       monitor.NewTracer("master"),
 		openAIClient: openai.NewClientWithConfig(clientConfig),
 		RestServer: server.RestServer{
-			Config:      cfg,
-			CacheClient: cache.NoDatabase{},
-			DataClient:  data.NoDatabase{},
-			HttpHost:    cfg.Master.HttpHost,
-			HttpPort:    cfg.Master.HttpPort,
-			WebService:  new(restful.WebService),
+			Config:       cfg,
+			CacheClient:  cache.NoDatabase{},
+			DataClient:   data.NoDatabase{},
+			VectorClient: vectors.NoDatabase{},
+			HttpHost:     cfg.Master.HttpHost,
+			HttpPort:     cfg.Master.HttpPort,
+			WebService:   new(restful.WebService),
 		},
 		ticker:    time.NewTicker(duration),
 		scheduled: make(chan struct{}, 1),
@@ -194,18 +195,16 @@ func (m *Master) Serve() {
 	}
 
 	// open vector store
-	if m.Config.Database.VectorStore != "" {
-		log.Logger().Info("opening vector store", zap.String("path", m.Config.Database.VectorStore))
-		m.VectorClient, err = vectors.Open(m.Config.Database.VectorStore, m.Config.Database.VectorTablePrefix)
-		if err != nil {
-			log.Logger().Fatal("failed to connect vector store", zap.Error(err))
-		}
-		if err = m.VectorClient.Init(); err != nil {
-			log.Logger().Fatal("failed to init vector store", zap.Error(err))
-		}
-		if err = m.initCollaborativeFilteringVectorCollection(context.Background()); err != nil {
-			log.Logger().Fatal("failed to init collaborative filtering vector collection", zap.Error(err))
-		}
+	log.Logger().Info("opening vector store", zap.String("path", m.Config.Database.VectorStore))
+	m.VectorClient, err = vectors.Open(m.Config.Database.VectorStore, m.Config.Database.VectorTablePrefix)
+	if err != nil {
+		log.Logger().Fatal("failed to connect vector store", zap.Error(err))
+	}
+	if err = m.VectorClient.Init(); err != nil {
+		log.Logger().Fatal("failed to init vector store", zap.Error(err))
+	}
+	if err = m.initCollaborativeFilteringVectorCollection(context.Background()); err != nil {
+		log.Logger().Fatal("failed to init collaborative filtering vector collection", zap.Error(err))
 	}
 
 	// load recommend config


### PR DESCRIPTION
## Summary
- require database.vector_store in config validation
- add default SQLite vector store and sample config entry
- always initialize the master vector store and collaborative filtering collection

## Tests
- PATH=/home/openclaw/.local/go1.26/bin:/home/openclaw/go1.26/bin:/home/openclaw/.local/bin:/home/openclaw/go1.26/bin:/home/openclaw/.local/bin:/home/openclaw/.hermes/hermes-agent/venv/bin:/home/openclaw/.hermes/hermes-agent/node_modules/.bin:/usr/bin:/home/openclaw/.local/bin:/home/openclaw/go/bin:/home/openclaw/.npm-global/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/sbin:/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/snap/bin:/home/openclaw/go/bin:/home/openclaw/go/bin GOMODCACHE=/home/openclaw/.cache/gomod go test ./config ./master ./server ./worker -count=1