### PR TITLE
test: redirect logs to t.Log

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -121,7 +121,7 @@ jobs:
       working-directory: ${{ runner.temp }}
 
     - name: Test
-      run: go test -timeout 30m -v ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...
+      run: go test -timeout 30m ./... -coverprofile=coverage.txt -covermode=atomic -coverpkg=./...
       env:
         # MySQL
         MYSQL_URI: mysql://root:password@tcp(localhost:${{ job.services.mysql.ports[3306] }})/
@@ -181,7 +181,7 @@ jobs:
         go-version-file: ./go.mod
 
     - name: Test
-      run: go test -timeout 20m -v ./... -skip "TestPostgres|TestMySQL|TestMongo|TestRedis|TestClickHouse|TestMilvus|TestQdrant|TestWeaviate"
+      run: go test -timeout 20m ./... -skip "TestPostgres|TestMySQL|TestMongo|TestRedis|TestClickHouse|TestMilvus|TestQdrant|TestWeaviate"
 
   unit_test_windows:
     strategy:
@@ -215,7 +215,7 @@ jobs:
         go-version-file: ./go.mod
 
     - name: Test
-      run: go test -timeout 20m -v ./... -skip "TestPostgres|TestMySQL|TestMongo|TestRedis|TestClickHouse|TestMilvus|TestQdrant|TestWeaviate"
+      run: go test -timeout 20m ./... -skip "TestPostgres|TestMySQL|TestMongo|TestRedis|TestClickHouse|TestMilvus|TestQdrant|TestWeaviate"
 
   integrate_test:
     name: integrate tests

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	client "github.com/gorse-io/gorse-go"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -38,7 +39,12 @@ type GorseClientTestSuite struct {
 	client *client.GorseClient
 }
 
+func (suite *GorseClientTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
+}
+
 func (suite *GorseClientTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	if serverEndpoint == "" || dashboardEndpoint == "" {
 		suite.T().Skip("GORSE_SERVER_ENDPOINT or GORSE_DASHBOARD_ENDPOINT is not set")
 	}

--- a/cmd/gorse-cli/main_test.go
+++ b/cmd/gorse-cli/main_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/master"
@@ -66,7 +67,12 @@ type CLITestSuite struct {
 	endpoint string
 }
 
+func (s *CLITestSuite) SetupSuite() {
+	log.SetTestLogger(s.T())
+}
+
 func (s *CLITestSuite) SetupTest() {
+	log.SetTestLogger(s.T())
 	s.m, s.endpoint = newTestMaster(s.T())
 
 	ctx := s.T().Context()

--- a/common/floats/floats_test.go
+++ b/common/floats/floats_test.go
@@ -17,6 +17,7 @@ package floats
 import (
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -38,7 +39,6 @@ func TestZero(t *testing.T) {
 	Zero(a)
 	assert.Equal(t, []float32{0, 0, 0, 0, 0, 0}, a)
 }
-
 
 func TestAdd(t *testing.T) {
 	a := []float32{1, 2, 3, 4}
@@ -180,6 +180,14 @@ func TestEuclidean(t *testing.T) {
 
 type NativeTestSuite struct {
 	suite.Suite
+}
+
+func (suite *NativeTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
+}
+
+func (suite *NativeTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 }
 
 func (suite *NativeTestSuite) TestDot() {

--- a/common/log/log.go
+++ b/common/log/log.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -89,6 +90,25 @@ func CloseLogger() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+// SetTestLogger redirects Gorse logs to t.Log until the test finishes.
+func SetTestLogger(t testing.TB) {
+	t.Helper()
+	oldLogger := logger
+	oldOpenAILogger := openaiLogger
+	oldAccessLogger := accessLogger
+
+	testLogger := zaptest.NewLogger(t, zaptest.Level(zap.DebugLevel))
+	logger = testLogger
+	openaiLogger = testLogger
+	accessLogger = testLogger
+
+	t.Cleanup(func() {
+		logger = oldLogger
+		openaiLogger = oldOpenAILogger
+		accessLogger = oldAccessLogger
+	})
 }
 
 func AddFlags(flagSet *pflag.FlagSet) {

--- a/common/log/log_test.go
+++ b/common/log/log_test.go
@@ -60,6 +60,27 @@ func TestSetProductionLogger(t *testing.T) {
 	assert.FileExists(t, temp+"/gorse/gorse.log")
 }
 
+func TestSetTestLogger(t *testing.T) {
+	oldLogger := Logger()
+	oldOpenAILogger := OpenAILogger()
+	oldAccessLogger := accessLogger
+
+	t.Run("redirect", func(t *testing.T) {
+		SetTestLogger(t)
+
+		assert.NotSame(t, oldLogger, Logger())
+		assert.NotSame(t, oldOpenAILogger, OpenAILogger())
+		assert.NotSame(t, oldAccessLogger, accessLogger)
+		Logger().Info("test")
+		OpenAILogger().Info("test")
+		AccessLogger().Info("test")
+	})
+
+	assert.Same(t, oldLogger, Logger())
+	assert.Same(t, oldOpenAILogger, OpenAILogger())
+	assert.Same(t, oldAccessLogger, accessLogger)
+}
+
 func TestRedactDBURL(t *testing.T) {
 	assert.Equal(t, "sqlite://data/data.sqlite", RedactDBURL("sqlite://data/data.sqlite"))
 	assert.Equal(t, "mysql://xxxxx:xxxxxxxxxx@tcp(localhost:3306)/gorse?parseTime=true", RedactDBURL("mysql://gorse:gorse_pass@tcp(localhost:3306)/gorse?parseTime=true"))

--- a/common/mock/openai_test.go
+++ b/common/mock/openai_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/juju/errors"
 	"github.com/sashabaranov/go-openai"
 	"github.com/stretchr/testify/suite"
@@ -30,7 +31,12 @@ type OpenAITestSuite struct {
 	client *openai.Client
 }
 
+func (suite *OpenAITestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
+}
+
 func (suite *OpenAITestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	// Start mock server
 	suite.server = NewOpenAIServer()
 	go func() {

--- a/common/reranker/client_test.go
+++ b/common/reranker/client_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -26,7 +27,12 @@ type ClientTestSuite struct {
 	s *MockServer
 }
 
+func (suite *ClientTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
+}
+
 func (suite *ClientTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	suite.s = NewMockServer()
 	go func() {
 		err := suite.s.Start()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gorse-io/gorse/common/expression"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/sclevine/yj/convert"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -494,7 +495,12 @@ type ValidateTestSuite struct {
 	*Config
 }
 
+func (s *ValidateTestSuite) SetupSuite() {
+	log.SetTestLogger(s.T())
+}
+
 func (s *ValidateTestSuite) SetupTest() {
+	log.SetTestLogger(s.T())
 	s.Config = GetDefaultConfig()
 	s.Database.CacheStore = "redis://localhost:6379/0"
 	s.Database.DataStore = "mysql://gorse:gorse_pass@tcp(localhost:3306)/gorse"

--- a/logics/item_to_item_test.go
+++ b/logics/item_to_item_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gorse-io/gorse/common/floats"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/mock"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/dataset"
@@ -29,6 +30,14 @@ import (
 
 type ItemToItemTestSuite struct {
 	suite.Suite
+}
+
+func (suite *ItemToItemTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
+}
+
+func (suite *ItemToItemTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 }
 
 func (suite *ItemToItemTestSuite) TestColumnFunc() {

--- a/logics/recommend_test.go
+++ b/logics/recommend_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/gorse-io/gorse/common/expression"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/storage/cache"
 	"github.com/gorse-io/gorse/storage/data"
@@ -34,7 +35,12 @@ type RecommenderTestSuite struct {
 	cacheClient cache.Database
 }
 
+func (suite *RecommenderTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
+}
+
 func (suite *RecommenderTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	// open database
 	suite.dataClient, err = data.Open(fmt.Sprintf("sqlite://%s/data.db", suite.T().TempDir()), "")

--- a/logics/user_to_user_test.go
+++ b/logics/user_to_user_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/dataset"
 	"github.com/gorse-io/gorse/storage/data"
@@ -27,6 +28,14 @@ import (
 
 type UserToUserTestSuite struct {
 	suite.Suite
+}
+
+func (suite *UserToUserTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
+}
+
+func (suite *UserToUserTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 }
 
 func (suite *UserToUserTestSuite) TestEmbedding() {

--- a/master/master_test.go
+++ b/master/master_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/storage/cache"
@@ -31,7 +32,12 @@ type MasterTestSuite struct {
 	Master
 }
 
+func (s *MasterTestSuite) SetupSuite() {
+	log.SetTestLogger(s.T())
+}
+
 func (s *MasterTestSuite) SetupTest() {
+	log.SetTestLogger(s.T())
 	// open database
 	var err error
 	s.tracer = monitor.NewTracer("test")

--- a/master/rest_test.go
+++ b/master/rest_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/emicklei/go-restful/v3"
 	"github.com/go-viper/mapstructure/v2"
 	"github.com/gorse-io/gorse/common/expression"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/mock"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/protocol"
@@ -81,7 +82,12 @@ type MasterAPITestSuite struct {
 	cookie       string
 }
 
+func (suite *MasterAPITestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
+}
+
 func (suite *MasterAPITestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	// open database
 	var err error
 	suite.Config = config.GetDefaultConfig()

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/emicklei/go-restful/v3"
 	"github.com/gorse-io/gorse/common/expression"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/storage/cache"
 	"github.com/gorse-io/gorse/storage/data"
@@ -41,6 +42,7 @@ type ServerTestSuite struct {
 }
 
 func (suite *ServerTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	// create mock redis server
 	var err error
 	// open database
@@ -70,6 +72,7 @@ func (suite *ServerTestSuite) TearDownSuite() {
 }
 
 func (suite *ServerTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	err := suite.DataClient.Purge()
 	suite.NoError(err)
 	err = suite.CacheClient.Purge()

--- a/storage/cache/database_test.go
+++ b/storage/cache/database_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/fxtlabs/primes"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/juju/errors"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,7 @@ func (suite *baseTestSuite) TearDownSuite() {
 }
 
 func (suite *baseTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	err := suite.Database.Ping()
 	suite.NoError(err)
 	err = suite.Database.Purge()

--- a/storage/cache/mongodb_test.go
+++ b/storage/cache/mongodb_test.go
@@ -43,6 +43,7 @@ type MongoTestSuite struct {
 }
 
 func (suite *MongoTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	ctx := suite.T().Context()
 	var err error
 	// create database

--- a/storage/cache/proxy_test.go
+++ b/storage/cache/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 )
@@ -31,6 +32,7 @@ type ProxyTestSuite struct {
 }
 
 func (suite *ProxyTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	// create database
 	var err error
 	path := fmt.Sprintf("sqlite://%s/sqlite.db", suite.T().TempDir())
@@ -60,6 +62,7 @@ func (suite *ProxyTestSuite) TearDownSuite() {
 }
 
 func (suite *ProxyTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	err := suite.sqlite.Ping()
 	suite.NoError(err)
 	err = suite.sqlite.Purge()

--- a/storage/cache/redis_test.go
+++ b/storage/cache/redis_test.go
@@ -48,6 +48,7 @@ type RedisTestSuite struct {
 }
 
 func (suite *RedisTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	suite.Database, err = Open(redisDSN, "gorse_")
 	suite.NoError(err)

--- a/storage/cache/sql_test.go
+++ b/storage/cache/sql_test.go
@@ -49,6 +49,7 @@ type PostgresTestSuite struct {
 }
 
 func (suite *PostgresTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	// create database
 	databaseComm, err := sql.Open("postgres", postgresDSN+"?sslmode=disable")
@@ -77,6 +78,7 @@ type MySQLTestSuite struct {
 }
 
 func (suite *MySQLTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	// create database
 	databaseComm, err := sql.Open("mysql", mySqlDSN[len(storage.MySQLPrefix):])
 	suite.NoError(err)
@@ -114,6 +116,7 @@ type SQLiteTestSuite struct {
 }
 
 func (suite *SQLiteTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	// create database
 	path := fmt.Sprintf("sqlite://%s/sqlite.db", suite.T().TempDir())

--- a/storage/data/database_test.go
+++ b/storage/data/database_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gorse-io/gorse/common/expression"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/config"
 	"github.com/jaswdr/faker"
 	"github.com/juju/errors"
@@ -158,6 +159,7 @@ func (suite *baseTestSuite) TearDownSuite() {
 }
 
 func (suite *baseTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	err := suite.Database.Ping()
 	suite.NoError(err)
 	err = suite.Database.Purge()

--- a/storage/data/mongodb_test.go
+++ b/storage/data/mongodb_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -41,6 +42,7 @@ type MongoTestSuite struct {
 }
 
 func (suite *MongoTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	ctx := suite.T().Context()
 	var err error
 	// create database

--- a/storage/data/proxy_test.go
+++ b/storage/data/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 )
@@ -31,6 +32,7 @@ type ProxyTestSuite struct {
 }
 
 func (suite *ProxyTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	// create database
 	var err error
 	path := fmt.Sprintf("sqlite://%s/sqlite.db", suite.T().TempDir())
@@ -60,6 +62,7 @@ func (suite *ProxyTestSuite) TearDownSuite() {
 }
 
 func (suite *ProxyTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	err := suite.sqlite.Ping()
 	suite.NoError(err)
 	err = suite.sqlite.Purge()

--- a/storage/data/sql_test.go
+++ b/storage/data/sql_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -51,6 +52,7 @@ type MySQLTestSuite struct {
 }
 
 func (suite *MySQLTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	// create database
 	databaseComm, err := sql.Open("mysql", mySqlDSN[len(storage.MySQLPrefix):])
 	suite.NoError(err)
@@ -86,6 +88,7 @@ type PostgresTestSuite struct {
 }
 
 func (suite *PostgresTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	// create database
 	databaseComm, err := sql.Open("postgres", postgresDSN+"?sslmode=disable")
@@ -114,6 +117,7 @@ type ClickHouseTestSuite struct {
 }
 
 func (suite *ClickHouseTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	// create database
 	databaseComm, err := sql.Open("chhttp", "http://"+clickhouseDSN[len(storage.ClickhousePrefix):])
@@ -142,6 +146,7 @@ type SQLiteTestSuite struct {
 }
 
 func (suite *SQLiteTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	// create database
 	path := fmt.Sprintf("sqlite://%s/sqlite.db", suite.T().TempDir())

--- a/storage/meta/sqlite_test.go
+++ b/storage/meta/sqlite_test.go
@@ -16,6 +16,7 @@ package meta
 
 import (
 	"fmt"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
@@ -25,7 +26,12 @@ type SQLiteTestSuite struct {
 	baseTestSuite
 }
 
+func (suite *SQLiteTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
+}
+
 func (suite *SQLiteTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	var err error
 	// create database
 	path := fmt.Sprintf("sqlite://%s/sqlite.db", suite.T().TempDir())

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -17,6 +17,7 @@ package vectors
 import (
 	"time"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/juju/errors"
 	"github.com/stretchr/testify/suite"
 )
@@ -29,6 +30,7 @@ type vectorsTestSuite struct {
 }
 
 func (suite *vectorsTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	// purge
 	ctx := suite.T().Context()
 	collections, err := suite.Database.ListCollections(ctx)

--- a/storage/vectors/milvus_test.go
+++ b/storage/vectors/milvus_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -41,6 +42,7 @@ type MilvusTestSuite struct {
 }
 
 func (suite *MilvusTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	suite.Database, err = Open(milvusUri, "gorse_")
 	suite.NoError(err)

--- a/storage/vectors/proxy_test.go
+++ b/storage/vectors/proxy_test.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc"
 )
@@ -31,6 +32,7 @@ type ProxyTestSuite struct {
 }
 
 func (suite *ProxyTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	path := fmt.Sprintf("sqlite://%s/sqlite.db", suite.T().TempDir())
 	suite.sqlite, err = Open(path, "gorse_")

--- a/storage/vectors/qdrant_test.go
+++ b/storage/vectors/qdrant_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -41,6 +42,7 @@ type QdrantTestSuite struct {
 }
 
 func (suite *QdrantTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	suite.Database, err = Open(qdrantUri, "gorse_")
 	suite.NoError(err)

--- a/storage/vectors/sqlite_test.go
+++ b/storage/vectors/sqlite_test.go
@@ -17,6 +17,7 @@ package vectors
 import (
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,6 +26,7 @@ type SQLiteTestSuite struct {
 }
 
 func (suite *SQLiteTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	suite.Database, err = Open("sqlite://:memory:", "gorse_")
 	suite.NoError(err)

--- a/storage/vectors/weaviate_test.go
+++ b/storage/vectors/weaviate_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -41,6 +42,7 @@ type WeaviateTestSuite struct {
 }
 
 func (suite *WeaviateTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	suite.Database, err = Open(weaviateUri, "gorse_")
 	suite.NoError(err)

--- a/worker/pipeline_test.go
+++ b/worker/pipeline_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/storage/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -29,7 +30,12 @@ type PipelineTestSuite struct {
 	dataClient data.Database
 }
 
+func (suite *PipelineTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
+}
+
 func (suite *PipelineTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	var err error
 	suite.dataClient, err = data.Open(fmt.Sprintf("sqlite://%s/data.db", suite.T().TempDir()), "")
 	suite.NoError(err)

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/c-bata/goptuna"
 	"github.com/gorse-io/gorse/common/expression"
+	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
 	"github.com/gorse-io/gorse/common/reranker"
 	"github.com/gorse-io/gorse/common/util"
@@ -55,6 +56,7 @@ type WorkerTestSuite struct {
 }
 
 func (suite *WorkerTestSuite) SetupSuite() {
+	log.SetTestLogger(suite.T())
 	// open database
 	var err error
 	suite.Tracer = monitor.NewTracer("test")
@@ -78,6 +80,7 @@ func (suite *WorkerTestSuite) TearDownSuite() {
 }
 
 func (suite *WorkerTestSuite) SetupTest() {
+	log.SetTestLogger(suite.T())
 	err := suite.DataClient.Purge()
 	suite.NoError(err)
 	err = suite.CacheClient.Purge()


### PR DESCRIPTION
## Summary
- add log.SetTestLogger to route Gorse zap loggers to t.Log during tests
- enable the test logger in testify suite entry points
- remove -v from GitHub Actions go test commands

## Tests
- go test ./common/log -run TestSetTestLogger -count=1
- go test -timeout 20m ./... -skip "TestPostgres|TestMySQL|TestMongo|TestRedis|TestClickHouse|TestMilvus|TestQdrant|TestWeaviate"