### PR TITLE
refactor(model): register recommenders

### DIFF
--- a/master/tasks.go
+++ b/master/tasks.go
@@ -1098,14 +1098,13 @@ func (m *Master) trainCollaborativeFiltering(parent context.Context, trainSet, t
 }
 
 func (m *Master) newCollaborativeFilteringModel(modelType string, params model.Params) cf.MatrixFactorization {
-	switch modelType {
-	case "BPR":
-		return cf.NewBPR(params)
-	case "ALS":
-		return cf.NewALS(params)
-	default:
-		return cf.NewBPR(params)
+	model, err := cf.NewModel(modelType, params)
+	if err != nil {
+		log.Logger().Warn("failed to create collaborative filtering model, fallback to BPR",
+			zap.String("model_type", modelType), zap.Error(err))
+		model, _ = cf.NewModel("BPR", params)
 	}
+	return model
 }
 
 func (m *Master) trainClickThroughRatePrediction(parent context.Context, trainSet, testSet *ctr.Dataset) error {
@@ -1142,7 +1141,16 @@ func (m *Master) trainClickThroughRatePrediction(parent context.Context, trainSe
 			zap.Float32("Recall", m.clickThroughRateTarget.Score.Recall),
 			zap.Any("params", clickThroughRateParams))
 	}
-	clickModel := ctr.NewAFM(clickThroughRateParams)
+	clickModel, err := ctr.NewModel(clickThroughRateType, clickThroughRateParams)
+	if err != nil {
+		log.Logger().Warn("failed to create click-through rate model, fallback to FM",
+			zap.String("model_type", clickThroughRateType), zap.Error(err))
+		clickModel, err = ctr.NewModel("FM", clickThroughRateParams)
+		if err != nil {
+			m.clickThroughRateModelMutex.Unlock()
+			return errors.Trace(err)
+		}
+	}
 	m.clickThroughRateModelMutex.Unlock()
 
 	startFitTime := time.Now()
@@ -1315,14 +1323,7 @@ func (m *Master) optimizeCollaborativeFiltering(parent context.Context, trainSet
 		return nil
 	}
 
-	search := cf.NewModelSearch(map[string]cf.ModelCreator{
-		"BPR": func() cf.MatrixFactorization {
-			return cf.NewBPR(nil)
-		},
-		"ALS": func() cf.MatrixFactorization {
-			return cf.NewALS(nil)
-		},
-	}, trainSet, testSet,
+	search := cf.NewModelSearch(cf.RegisteredModelCreators(), trainSet, testSet,
 		cf.NewFitConfig().
 			SetJobs(m.Config.Master.NumJobs).
 			SetPatience(m.Config.Recommend.Collaborative.EarlyStopping.Patience)).
@@ -1365,11 +1366,7 @@ func (m *Master) optimizeClickThroughRatePrediction(parent context.Context, trai
 		return nil
 	}
 
-	search := ctr.NewModelSearch(map[string]ctr.ModelCreator{
-		"FM": func() ctr.FactorizationMachines {
-			return ctr.NewAFM(nil)
-		},
-	}, trainSet, testSet,
+	search := ctr.NewModelSearch(ctr.RegisteredModelCreators(), trainSet, testSet,
 		ctr.NewFitConfig().
 			SetJobs(m.Config.Master.NumJobs).
 			SetPatience(m.Config.Recommend.Ranker.EarlyStopping.Patience)).

--- a/model/cf/model.go
+++ b/model/cf/model.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"sort"
 	"time"
 
 	"github.com/bits-and-blooms/bitset"
@@ -113,6 +114,60 @@ type MatrixFactorization interface {
 	Marshal(w io.Writer) error
 	// Unmarshal model from byte stream.
 	Unmarshal(r io.Reader) error
+}
+
+// Creator creates a matrix factorization model with parameters.
+type Creator func(params model.Params) MatrixFactorization
+
+type modelInfo struct {
+	modelType string
+	modelName string
+	creator   Creator
+}
+
+var (
+	modelInfosByType        = make(map[string]modelInfo)
+	modelInfosByName        = make(map[string]modelInfo)
+	modelNamesByReflectType = make(map[reflect.Type]string)
+)
+
+// Register a matrix factorization model creator.
+func Register(modelType, modelName string, creator Creator) {
+	info := modelInfo{modelType: modelType, modelName: modelName, creator: creator}
+	modelInfosByType[modelType] = info
+	modelInfosByName[modelName] = info
+	modelNamesByReflectType[reflect.TypeOf(creator(nil))] = modelName
+}
+
+// NewModel creates a matrix factorization model by type.
+func NewModel(modelType string, params model.Params) (MatrixFactorization, error) {
+	info, ok := modelInfosByType[modelType]
+	if !ok {
+		return nil, fmt.Errorf("unknown model: %v", modelType)
+	}
+	return info.creator(params), nil
+}
+
+// RegisteredModelCreators returns all registered model creators for hyper-parameter search.
+func RegisteredModelCreators() map[string]ModelCreator {
+	creators := make(map[string]ModelCreator, len(modelInfosByType))
+	for modelType, info := range modelInfosByType {
+		creator := info.creator
+		creators[modelType] = func() MatrixFactorization {
+			return creator(nil)
+		}
+	}
+	return creators
+}
+
+// RegisteredModelTypes returns all registered model types.
+func RegisteredModelTypes() []string {
+	modelTypes := make([]string, 0, len(modelInfosByType))
+	for modelType := range modelInfosByType {
+		modelTypes = append(modelTypes, modelType)
+	}
+	sort.Strings(modelTypes)
+	return modelTypes
 }
 
 type BaseMatrixFactorization struct {
@@ -307,14 +362,10 @@ func (baseModel *BaseMatrixFactorization) Invalid() bool {
 }
 
 func GetModelName(m Model) string {
-	switch m.(type) {
-	case *BPR:
-		return "bpr"
-	case *ALS:
-		return "als"
-	default:
-		return reflect.TypeOf(m).String()
+	if name, ok := modelNamesByReflectType[reflect.TypeOf(m)]; ok {
+		return name
 	}
+	return reflect.TypeOf(m).String()
 }
 
 func MarshalModel(w io.Writer, m Model) error {
@@ -332,21 +383,24 @@ func UnmarshalModel(r io.Reader) (MatrixFactorization, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	switch name {
-	case "bpr":
-		var bpr BPR
-		if err := bpr.Unmarshal(r); err != nil {
-			return nil, errors.Trace(err)
-		}
-		return &bpr, nil
-	case "als":
-		var als ALS
-		if err := als.Unmarshal(r); err != nil {
-			return nil, errors.Trace(err)
-		}
-		return &als, nil
+	info, ok := modelInfosByName[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown model %v", name)
 	}
-	return nil, fmt.Errorf("unknown model %v", name)
+	m := info.creator(nil)
+	if err := m.Unmarshal(r); err != nil {
+		return nil, errors.Trace(err)
+	}
+	return m, nil
+}
+
+func init() {
+	Register("BPR", "bpr", func(params model.Params) MatrixFactorization {
+		return NewBPR(params)
+	})
+	Register("ALS", "als", func(params model.Params) MatrixFactorization {
+		return NewALS(params)
+	})
 }
 
 // BPR means Bayesian Personal Ranking, is a pairwise learning algorithm for matrix factorization

--- a/model/cf/model_test.go
+++ b/model/cf/model_test.go
@@ -27,6 +27,25 @@ import (
 
 const benchDelta = 0.01
 
+func TestRegisterModel(t *testing.T) {
+	bpr, err := NewModel("BPR", model.Params{model.NEpochs: 1})
+	assert.NoError(t, err)
+	assert.IsType(t, &BPR{}, bpr)
+	assert.Equal(t, "bpr", GetModelName(bpr))
+
+	als, err := NewModel("ALS", model.Params{model.NEpochs: 1})
+	assert.NoError(t, err)
+	assert.IsType(t, &ALS{}, als)
+	assert.Equal(t, "als", GetModelName(als))
+
+	_, err = NewModel("unknown", nil)
+	assert.Error(t, err)
+	assert.Contains(t, RegisteredModelTypes(), "BPR")
+	assert.Contains(t, RegisteredModelTypes(), "ALS")
+	assert.Contains(t, RegisteredModelCreators(), "BPR")
+	assert.Contains(t, RegisteredModelCreators(), "ALS")
+}
+
 func newFitConfig(_ int) *FitConfig {
 	cfg := NewFitConfig().SetVerbose(1).SetJobs(runtime.NumCPU())
 	return cfg

--- a/model/ctr/fm.go
+++ b/model/ctr/fm.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/c-bata/goptuna"
 	"github.com/chewxy/math32"
-	"github.com/gorse-io/gorse/common/encoding"
 	"github.com/gorse-io/gorse/common/bfloats"
+	"github.com/gorse-io/gorse/common/encoding"
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
 	"github.com/gorse-io/gorse/common/nn"
@@ -74,6 +74,28 @@ func NewAFM(params model.Params) *AFM {
 	fm := new(AFM)
 	fm.SetParams(params)
 	return fm
+}
+
+func init() {
+	Register("FM", []string{headerAFM, headerAFM2}, func(params model.Params) FactorizationMachines {
+		return NewAFM(params)
+	}, func(m FactorizationMachines) (string, bool) {
+		fm, ok := m.(*AFM)
+		if !ok {
+			return "", false
+		}
+		if fm.autoScale {
+			return headerAFM2, true
+		}
+		return headerAFM, true
+	}, func(header string, r io.Reader) (FactorizationMachines, error) {
+		var fm AFM
+		fm.autoScale = header == headerAFM2
+		if err := fm.Unmarshal(r); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return &fm, nil
+	})
 }
 
 func (fm *AFM) SuggestParams(trial goptuna.Trial) model.Params {

--- a/model/ctr/fm_xla.go
+++ b/model/ctr/fm_xla.go
@@ -86,6 +86,28 @@ func NewAFM(params model.Params) *AFM {
 	return fm
 }
 
+func init() {
+	Register("FM", []string{headerAFM, headerAFM2}, func(params model.Params) FactorizationMachines {
+		return NewAFM(params)
+	}, func(m FactorizationMachines) (string, bool) {
+		fm, ok := m.(*AFM)
+		if !ok {
+			return "", false
+		}
+		if fm.autoScale {
+			return headerAFM2, true
+		}
+		return headerAFM, true
+	}, func(header string, r io.Reader) (FactorizationMachines, error) {
+		var fm AFM
+		fm.autoScale = header == headerAFM2
+		if err := fm.Unmarshal(r); err != nil {
+			return nil, errors.Trace(err)
+		}
+		return &fm, nil
+	})
+}
+
 func (fm *AFM) SuggestParams(trial goptuna.Trial) model.Params {
 	return model.Params{
 		model.NFactors:   16,

--- a/model/ctr/model.go
+++ b/model/ctr/model.go
@@ -18,12 +18,11 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"reflect"
+	"sort"
 
 	"github.com/gorse-io/gorse/common/encoding"
 	"github.com/gorse-io/gorse/dataset"
 	"github.com/gorse-io/gorse/model"
-	"github.com/juju/errors"
 	"github.com/samber/lo"
 	"go.uber.org/zap"
 )
@@ -97,6 +96,71 @@ type FactorizationMachines interface {
 	Marshal(w io.Writer) error
 }
 
+// Creator creates a factorization machine model with parameters.
+type Creator func(params model.Params) FactorizationMachines
+
+// Marshaller returns the storage header for a model instance.
+type Marshaller func(FactorizationMachines) (string, bool)
+
+// Unmarshaller creates and loads a model from a storage header and payload.
+type Unmarshaller func(header string, r io.Reader) (FactorizationMachines, error)
+
+type modelInfo struct {
+	modelType    string
+	creator      Creator
+	marshaller   Marshaller
+	unmarshaller Unmarshaller
+}
+
+var (
+	modelInfosByType     = make(map[string]modelInfo)
+	modelInfosByHeader   = make(map[string]modelInfo)
+	registeredModelTypes []string
+)
+
+// Register a factorization machine model creator.
+func Register(modelType string, headers []string, creator Creator, marshaller Marshaller, unmarshaller Unmarshaller) {
+	info := modelInfo{modelType: modelType, creator: creator, marshaller: marshaller, unmarshaller: unmarshaller}
+	modelInfosByType[modelType] = info
+	for _, header := range headers {
+		modelInfosByHeader[header] = info
+	}
+	registeredModelTypes = nil
+}
+
+// NewModel creates a factorization machine model by type.
+func NewModel(modelType string, params model.Params) (FactorizationMachines, error) {
+	info, ok := modelInfosByType[modelType]
+	if !ok {
+		return nil, fmt.Errorf("unknown model: %v", modelType)
+	}
+	return info.creator(params), nil
+}
+
+// RegisteredModelCreators returns all registered model creators for hyper-parameter search.
+func RegisteredModelCreators() map[string]ModelCreator {
+	creators := make(map[string]ModelCreator, len(modelInfosByType))
+	for modelType, info := range modelInfosByType {
+		creator := info.creator
+		creators[modelType] = func() FactorizationMachines {
+			return creator(nil)
+		}
+	}
+	return creators
+}
+
+// RegisteredModelTypes returns all registered model types.
+func RegisteredModelTypes() []string {
+	if registeredModelTypes == nil {
+		registeredModelTypes = make([]string, 0, len(modelInfosByType))
+		for modelType := range modelInfosByType {
+			registeredModelTypes = append(registeredModelTypes, modelType)
+		}
+		sort.Strings(registeredModelTypes)
+	}
+	return append([]string(nil), registeredModelTypes...)
+}
+
 type BatchInference interface {
 	BatchPredict(inputs []lo.Tuple4[string, string, []Label, []Label], e [][]Embedding, jobs int) []float32
 	BatchInternalPredict(x []lo.Tuple2[[]int32, []float32], e [][][]uint16, jobs int) []float32
@@ -112,19 +176,17 @@ func (b *BaseFactorizationMachines) Init(trainSet dataset.CTRSplit) {
 }
 
 func MarshalModel(w io.Writer, m FactorizationMachines) error {
-	// write header
-	var err error
-	switch fm := m.(type) {
-	case *AFM:
-		if !fm.autoScale {
-			err = encoding.WriteString(w, headerAFM)
-		} else {
-			err = encoding.WriteString(w, headerAFM2)
+	var header string
+	for _, info := range modelInfosByType {
+		var ok bool
+		if header, ok = info.marshaller(m); ok {
+			break
 		}
-	default:
-		return fmt.Errorf("unknown model: %v", reflect.TypeOf(m))
 	}
-	if err != nil {
+	if header == "" {
+		return fmt.Errorf("unknown model: %T", m)
+	}
+	if err := encoding.WriteString(w, header); err != nil {
 		return err
 	}
 	return m.Marshal(w)
@@ -136,14 +198,9 @@ func UnmarshalModel(r io.Reader) (FactorizationMachines, error) {
 	if err != nil {
 		return nil, err
 	}
-	switch header {
-	case headerAFM, headerAFM2:
-		var fm AFM
-		fm.autoScale = header == headerAFM2
-		if err := fm.Unmarshal(r); err != nil {
-			return nil, errors.Trace(err)
-		}
-		return &fm, nil
+	info, ok := modelInfosByHeader[header]
+	if !ok {
+		return nil, fmt.Errorf("unknown model: %v", header)
 	}
-	return nil, fmt.Errorf("unknown model: %v", header)
+	return info.unmarshaller(header, r)
 }

--- a/model/ctr/model_test.go
+++ b/model/ctr/model_test.go
@@ -27,6 +27,17 @@ import (
 
 const classificationDelta = 0.01
 
+func TestRegisterModel(t *testing.T) {
+	fm, err := NewModel("FM", model.Params{model.NEpochs: 1})
+	assert.NoError(t, err)
+	assert.IsType(t, &AFM{}, fm)
+	assert.Contains(t, RegisteredModelTypes(), "FM")
+	assert.Contains(t, RegisteredModelCreators(), "FM")
+
+	_, err = NewModel("unknown", nil)
+	assert.Error(t, err)
+}
+
 func newFitConfigWithTestTracker() *FitConfig {
 	cfg := NewFitConfig().SetVerbose(1).SetJobs(runtime.NumCPU())
 	return cfg


### PR DESCRIPTION
## Summary

- add registries for collaborative filtering and click-through-rate models
- route model creation, model search, and model serialization/deserialization through registries
- preserve existing model type/name/header compatibility for BPR, ALS, and FM/AFM

## Tests

- `/usr/local/go/bin/go test ./model/cf ./model/ctr ./master ./worker`
