### PR TITLE
ci: use Redis 8 cluster action

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -64,7 +64,7 @@ jobs:
           --health-retries=5
 
       redis:
-        image: redis/redis-stack:6.2.6-v9
+        image: redis:8
         ports:
           - 6379
 
@@ -272,20 +272,10 @@ jobs:
       - name: Install pre-requisites
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: redis-tools qemu-user-static
-
-      - uses: actions/checkout@v5
-        with:
-          repository: gorse-cloud/redis-stack
-          path: redis-stack
+          packages: qemu-user-static
 
       - name: Setup Redis cluster
-        run: |
-          docker compose -f redis-stack/docker-compose.yml --project-directory redis-stack up -d
-          for i in {1..5}; do
-            redis-cli -p 7005 ping | grep PONG && break
-            sleep 10
-          done
+        uses: gorse-cloud/redis-cluster@v1.0.0
 
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5

--- a/client/docker-compose.yml.j2
+++ b/client/docker-compose.yml.j2
@@ -68,7 +68,7 @@ services:
       retries: 5
 
   redis:
-    image: redis/redis-stack:6.2.6-v9
+    image: redis:8
     restart: unless-stopped
     ports:
       - 6379:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   #     - clickhouse_data:/var/lib/clickhouse
 
   # redis:
-  #   image: redis/redis-stack
+  #   image: redis:8
   #   restart: unless-stopped
   #   ports:
   #     - 6379:6379

--- a/storage/docker-compose.yml
+++ b/storage/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   redis:
-    image: redis/redis-stack:6.2.6-v9
+    image: redis:8
     ports:
       - 6379:6379
 


### PR DESCRIPTION
## Summary
- replace Redis Stack with the official Redis 8 image in CI and docker-compose examples/templates
- replace the compatibility job's hand-written Redis cluster setup with `gorse-cloud/redis-cluster@v1.0.0`

## Test plan
- `python3` assertion/YAML parse for `.github/workflows/build_test.yml`
- `git diff --check`
- `go test ./storage/cache -run '^$' -count=0` (blocked locally: `go` command not installed in this environment)
