### PR TITLE
docs: establish security policy (SECURITY.md)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Security issues should not be reported via public GitHub issues or pull requests. Please report any potential vulnerabilities privately to keep the system secure.
+
+Vulnerabilities can be reported through:
+* The **Security** tab of this repository on GitHub using the **"Report a vulnerability"** private channel (if enabled).
+* Emailing the maintainers directly (placeholder: contact@gorse.io or via the profile contact).
+
+We will acknowledge receipt of the report, investigate the issue, and coordinate a fix and release.


### PR DESCRIPTION
Establishing a clear process for reporting vulnerabilities helps protect the project from accidental public disclosure of security issues. Adding a `SECURITY.md` file provides direct guidance for contributors on how to report concerns privately.

GitHub security features, such as the private vulnerability reporting channel, are referenced to encourage secure disclosure paths. Maintainers can update contact details or enable the built-in private reporting tab as preferred.