### PR TITLE
test: skip external database tests without DSN

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -181,7 +181,7 @@ jobs:
         go-version-file: ./go.mod
 
     - name: Test
-      run: go test -timeout 20m ./... -skip "TestPostgres|TestMySQL|TestMongo|TestRedis|TestClickHouse|TestMilvus|TestQdrant|TestWeaviate"
+      run: go test -timeout 20m ./...
 
   unit_test_windows:
     strategy:
@@ -215,7 +215,7 @@ jobs:
         go-version-file: ./go.mod
 
     - name: Test
-      run: go test -timeout 20m ./... -skip "TestPostgres|TestMySQL|TestMongo|TestRedis|TestClickHouse|TestMilvus|TestQdrant|TestWeaviate"
+      run: go test -timeout 20m ./...
 
   integrate_test:
     name: integrate tests

--- a/storage/cache/mongodb_test.go
+++ b/storage/cache/mongodb_test.go
@@ -28,14 +28,8 @@ var (
 )
 
 func init() {
-	// get environment variables
-	env := func(key, defaultValue string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultValue
-	}
-	mongoUri = env("MONGO_URI", "mongodb://root:password@127.0.0.1:27017/")
+	// os.Setenv("MONGO_URI", "mongodb://root:password@127.0.0.1:27017/")
+	mongoUri = os.Getenv("MONGO_URI")
 }
 
 type MongoTestSuite struct {
@@ -74,10 +68,16 @@ func (suite *MongoTestSuite) getMongoDB() *MongoDB {
 }
 
 func TestMongo(t *testing.T) {
+	if mongoUri == "" {
+		t.Skip("MONGO_URI is not set, skipping MongoDB test")
+	}
 	suite.Run(t, new(MongoTestSuite))
 }
 
 func BenchmarkMongo(b *testing.B) {
+	if mongoUri == "" {
+		b.Skip("MONGO_URI is not set, skipping MongoDB benchmark")
+	}
 	log.CloseLogger()
 	ctx := b.Context()
 	// create database

--- a/storage/cache/redis_test.go
+++ b/storage/cache/redis_test.go
@@ -33,14 +33,8 @@ var (
 )
 
 func init() {
-	// get environment variables
-	env := func(key, defaultValue string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultValue
-	}
-	redisDSN = env("REDIS_URI", "redis://127.0.0.1:6379/")
+	// os.Setenv("REDIS_URI", "redis://127.0.0.1:6379/")
+	redisDSN = os.Getenv("REDIS_URI")
 }
 
 type RedisTestSuite struct {
@@ -214,6 +208,9 @@ func (suite *RedisTestSuite) TestUpdateScoresWithPaginationAndTiedScores() {
 }
 
 func TestRedis(t *testing.T) {
+	if redisDSN == "" {
+		t.Skip("REDIS_URI is not set, skipping Redis test")
+	}
 	suite.Run(t, new(RedisTestSuite))
 }
 

--- a/storage/cache/sql_test.go
+++ b/storage/cache/sql_test.go
@@ -33,15 +33,10 @@ var (
 )
 
 func init() {
-	// get environment variables
-	env := func(key, defaultValue string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultValue
-	}
-	mySqlDSN = env("MYSQL_URI", "mysql://root:password@tcp(127.0.0.1:3306)/")
-	postgresDSN = env("POSTGRES_URI", "postgres://gorse:gorse_pass@127.0.0.1/")
+	// os.Setenv("MYSQL_URI", "mysql://root:password@tcp(127.0.0.1:3306)/")
+	// os.Setenv("POSTGRES_URI", "postgres://gorse:gorse_pass@127.0.0.1/")
+	mySqlDSN = os.Getenv("MYSQL_URI")
+	postgresDSN = os.Getenv("POSTGRES_URI")
 }
 
 type PostgresTestSuite struct {
@@ -70,6 +65,9 @@ func (suite *PostgresTestSuite) SetupSuite() {
 }
 
 func TestPostgres(t *testing.T) {
+	if postgresDSN == "" {
+		t.Skip("POSTGRES_URI is not set, skipping PostgreSQL test")
+	}
 	suite.Run(t, new(PostgresTestSuite))
 }
 
@@ -108,6 +106,9 @@ func (suite *MySQLTestSuite) TestInit() {
 }
 
 func TestMySQL(t *testing.T) {
+	if mySqlDSN == "" {
+		t.Skip("MYSQL_URI is not set, skipping MySQL test")
+	}
 	suite.Run(t, new(MySQLTestSuite))
 }
 

--- a/storage/data/mongodb_test.go
+++ b/storage/data/mongodb_test.go
@@ -27,14 +27,8 @@ var (
 )
 
 func init() {
-	// get environment variables
-	env := func(key, defaultValue string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultValue
-	}
-	mongoUri = env("MONGO_URI", "mongodb://root:password@127.0.0.1:27017/")
+	// os.Setenv("MONGO_URI", "mongodb://root:password@127.0.0.1:27017/")
+	mongoUri = os.Getenv("MONGO_URI")
 }
 
 type MongoTestSuite struct {
@@ -72,10 +66,16 @@ func (suite *MongoTestSuite) getMongoDB() *MongoDB {
 }
 
 func TestMongo(t *testing.T) {
+	if mongoUri == "" {
+		t.Skip("MONGO_URI is not set, skipping MongoDB test")
+	}
 	suite.Run(t, new(MongoTestSuite))
 }
 
 func BenchmarkMongo_CountItems(b *testing.B) {
+	if mongoUri == "" {
+		b.Skip("MONGO_URI is not set, skipping MongoDB benchmark")
+	}
 	ctx := b.Context()
 	var err error
 

--- a/storage/data/sql_test.go
+++ b/storage/data/sql_test.go
@@ -35,16 +35,12 @@ var (
 )
 
 func init() {
-	// get environment variables
-	env := func(key, defaultValue string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultValue
-	}
-	mySqlDSN = env("MYSQL_URI", "mysql://root:password@tcp(127.0.0.1:3306)/")
-	postgresDSN = env("POSTGRES_URI", "postgres://gorse:gorse_pass@127.0.0.1/")
-	clickhouseDSN = env("CLICKHOUSE_URI", "clickhouse://127.0.0.1:8123/")
+	// os.Setenv("MYSQL_URI", "mysql://root:password@tcp(127.0.0.1:3306)/")
+	// os.Setenv("POSTGRES_URI", "postgres://gorse:gorse_pass@127.0.0.1/")
+	// os.Setenv("CLICKHOUSE_URI", "clickhouse://127.0.0.1:8123/")
+	mySqlDSN = os.Getenv("MYSQL_URI")
+	postgresDSN = os.Getenv("POSTGRES_URI")
+	clickhouseDSN = os.Getenv("CLICKHOUSE_URI")
 }
 
 type MySQLTestSuite struct {
@@ -80,6 +76,9 @@ func (suite *MySQLTestSuite) TestInit() {
 }
 
 func TestMySQL(t *testing.T) {
+	if mySqlDSN == "" {
+		t.Skip("MYSQL_URI is not set, skipping MySQL test")
+	}
 	suite.Run(t, new(MySQLTestSuite))
 }
 
@@ -109,6 +108,9 @@ func (suite *PostgresTestSuite) SetupSuite() {
 }
 
 func TestPostgres(t *testing.T) {
+	if postgresDSN == "" {
+		t.Skip("POSTGRES_URI is not set, skipping PostgreSQL test")
+	}
 	suite.Run(t, new(PostgresTestSuite))
 }
 
@@ -138,6 +140,9 @@ func (suite *ClickHouseTestSuite) SetupSuite() {
 }
 
 func TestClickHouse(t *testing.T) {
+	if clickhouseDSN == "" {
+		t.Skip("CLICKHOUSE_URI is not set, skipping ClickHouse test")
+	}
 	suite.Run(t, new(ClickHouseTestSuite))
 }
 
@@ -176,6 +181,9 @@ func assertQuery(t *testing.T, connection *sql.DB, sql string, expected string) 
 }
 
 func BenchmarkMySQL_CountItems(b *testing.B) {
+	if mySqlDSN == "" {
+		b.Skip("MYSQL_URI is not set, skipping MySQL benchmark")
+	}
 	// create database
 	database, err := Open(mySqlDSN, "gorse_")
 	require.NoError(b, err)
@@ -197,6 +205,9 @@ func BenchmarkMySQL_CountItems(b *testing.B) {
 }
 
 func BenchmarkPostgres_CountItems(b *testing.B) {
+	if postgresDSN == "" {
+		b.Skip("POSTGRES_URI is not set, skipping PostgreSQL benchmark")
+	}
 	// create database
 	database, err := Open(postgresDSN+"gorse_data_test?sslmode=disable", "gorse_")
 	require.NoError(b, err)
@@ -210,6 +221,9 @@ func BenchmarkPostgres_CountItems(b *testing.B) {
 }
 
 func BenchmarkClickHouse_CountItems(b *testing.B) {
+	if clickhouseDSN == "" {
+		b.Skip("CLICKHOUSE_URI is not set, skipping ClickHouse benchmark")
+	}
 	// create database
 	databaseComm, err := sql.Open("chhttp", "http://"+clickhouseDSN[len(storage.ClickhousePrefix):])
 	require.NoError(b, err)

--- a/storage/vectors/milvus_test.go
+++ b/storage/vectors/milvus_test.go
@@ -27,14 +27,8 @@ var (
 )
 
 func init() {
-	// get environment variables
-	env := func(key, defaultValue string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultValue
-	}
-	milvusUri = env("MILVUS_URI", "milvus://127.0.0.1:19530")
+	// os.Setenv("MILVUS_URI", "milvus://127.0.0.1:19530")
+	milvusUri = os.Getenv("MILVUS_URI")
 }
 
 type MilvusTestSuite struct {
@@ -58,5 +52,8 @@ func (suite *MilvusTestSuite) TestQuantization() {
 }
 
 func TestMilvus(t *testing.T) {
+	if milvusUri == "" {
+		t.Skip("MILVUS_URI is not set, skipping Milvus test")
+	}
 	suite.Run(t, new(MilvusTestSuite))
 }

--- a/storage/vectors/qdrant_test.go
+++ b/storage/vectors/qdrant_test.go
@@ -27,14 +27,8 @@ var (
 )
 
 func init() {
-	// get environment variables
-	env := func(key, defaultValue string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultValue
-	}
-	qdrantUri = env("QDRANT_URI", "qdrant://127.0.0.1:6334")
+	// os.Setenv("QDRANT_URI", "qdrant://127.0.0.1:6334")
+	qdrantUri = os.Getenv("QDRANT_URI")
 }
 
 type QdrantTestSuite struct {
@@ -64,5 +58,8 @@ func (suite *QdrantTestSuite) TestQuantization() {
 }
 
 func TestQdrant(t *testing.T) {
+	if qdrantUri == "" {
+		t.Skip("QDRANT_URI is not set, skipping Qdrant test")
+	}
 	suite.Run(t, new(QdrantTestSuite))
 }

--- a/storage/vectors/weaviate_test.go
+++ b/storage/vectors/weaviate_test.go
@@ -27,14 +27,8 @@ var (
 )
 
 func init() {
-	// get environment variables
-	env := func(key, defaultValue string) string {
-		if value := os.Getenv(key); value != "" {
-			return value
-		}
-		return defaultValue
-	}
-	weaviateUri = env("WEAVIATE_URI", "weaviate://127.0.0.1:8080")
+	// os.Setenv("WEAVIATE_URI", "weaviate://127.0.0.1:8080")
+	weaviateUri = os.Getenv("WEAVIATE_URI")
 }
 
 type WeaviateTestSuite struct {
@@ -58,5 +52,8 @@ func (suite *WeaviateTestSuite) TestQuantization() {
 }
 
 func TestWeaviate(t *testing.T) {
+	if weaviateUri == "" {
+		t.Skip("WEAVIATE_URI is not set, skipping Weaviate test")
+	}
 	suite.Run(t, new(WeaviateTestSuite))
 }


### PR DESCRIPTION
## Summary
- remove default local DSNs from external database tests while leaving commented `os.Setenv` examples for local use
- skip external database tests and benchmarks when their DSN environment variable is not set
- remove CI `-skip` filters from macOS and Windows unit tests now that external DB tests self-skip

## Tests
- `env -u MYSQL_URI -u POSTGRES_URI -u MONGO_URI -u REDIS_URI -u CLICKHOUSE_URI -u QDRANT_URI -u MILVUS_URI -u WEAVIATE_URI /usr/local/go/bin/go test ./storage/cache ./storage/data ./storage/vectors -count=1`
