### PR TITLE
fix: close databases on shutdown

### DIFF
--- a/cmd/gorse-worker/main.go
+++ b/cmd/gorse-worker/main.go
@@ -72,10 +72,9 @@ var workerCommand = &cobra.Command{
 			sigint := make(chan os.Signal, 1)
 			signal.Notify(sigint, os.Interrupt)
 			<-sigint
-			w.Stop()
+			w.Shutdown()
 		}()
 		w.Serve()
-		w.Shutdown()
 		log.Logger().Info("stop gorse worker successfully")
 	},
 }

--- a/cmd/gorse-worker/main.go
+++ b/cmd/gorse-worker/main.go
@@ -16,6 +16,8 @@ package main
 import (
 	"fmt"
 	_ "net/http/pprof"
+	"os"
+	"os/signal"
 	"time"
 
 	"github.com/gorse-io/gorse/cmd/version"
@@ -66,7 +68,15 @@ var workerCommand = &cobra.Command{
 		}
 		interval, _ := cmd.PersistentFlags().GetDuration("interval")
 		w := worker.NewWorker(masterHost, masterPort, httpHost, httpPort, workingJobs, cachePath, tlsConfig, interval)
+		go func() {
+			sigint := make(chan os.Signal, 1)
+			signal.Notify(sigint, os.Interrupt)
+			<-sigint
+			w.Stop()
+		}()
 		w.Serve()
+		w.Shutdown()
+		log.Logger().Info("stop gorse worker successfully")
 	},
 }
 

--- a/master/master.go
+++ b/master/master.go
@@ -485,6 +485,19 @@ func (m *Master) Shutdown() {
 	}
 	// stop grpc server
 	m.grpcServer.GracefulStop()
+	// close databases
+	if err = m.metaStore.Close(); err != nil {
+		log.Logger().Error("failed to close meta database", zap.Error(err))
+	}
+	if err = m.DataClient.Close(); err != nil {
+		log.Logger().Error("failed to close data database", zap.Error(err))
+	}
+	if err = m.CacheClient.Close(); err != nil {
+		log.Logger().Error("failed to close cache database", zap.Error(err))
+	}
+	if err = m.VectorClient.Close(); err != nil {
+		log.Logger().Error("failed to close vector database", zap.Error(err))
+	}
 }
 
 func (m *Master) RunTasksLoop() {

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/emicklei/go-restful/v3"
@@ -62,6 +63,9 @@ type Server struct {
 	tlsConfig    *util.TLSConfig
 	testMode     bool
 	cacheFile    string
+	done         chan struct{}
+	shutdown     sync.Once
+	syncWait     sync.WaitGroup
 }
 
 // NewServer creates a server node.
@@ -78,6 +82,7 @@ func NewServer(
 		masterPort: masterPort,
 		tlsConfig:  tlsConfig,
 		cacheFile:  cacheFile,
+		done:       make(chan struct{}),
 		RestServer: RestServer{
 			Config:       config.GetDefaultConfig(),
 			CacheClient:  new(cache.NoDatabase),
@@ -124,7 +129,11 @@ func (s *Server) Serve() {
 	}
 	s.masterClient = protocol.NewMasterClient(s.conn)
 
-	go s.Sync()
+	s.syncWait.Add(1)
+	go func() {
+		defer s.syncWait.Done()
+		s.Sync()
+	}()
 	container := restful.NewContainer()
 	s.StartHttpServer(container)
 }
@@ -143,10 +152,29 @@ func (s *Server) ServerName() (string, error) {
 }
 
 func (s *Server) Shutdown() {
-	err := s.HttpServer.Shutdown(context.TODO())
-	if err != nil {
-		log.Logger().Fatal("failed to shutdown http server", zap.Error(err))
-	}
+	s.shutdown.Do(func() {
+		close(s.done)
+		if s.HttpServer != nil {
+			if err := s.HttpServer.Shutdown(context.TODO()); err != nil {
+				log.Logger().Error("failed to shutdown http server", zap.Error(err))
+			}
+		}
+		if s.conn != nil {
+			if err := s.conn.Close(); err != nil {
+				log.Logger().Error("failed to close master connection", zap.Error(err))
+			}
+		}
+		s.syncWait.Wait()
+		if err := s.DataClient.Close(); err != nil {
+			log.Logger().Error("failed to close data database", zap.Error(err))
+		}
+		if err := s.CacheClient.Close(); err != nil {
+			log.Logger().Error("failed to close cache database", zap.Error(err))
+		}
+		if err := s.VectorClient.Close(); err != nil {
+			log.Logger().Error("failed to close vector database", zap.Error(err))
+		}
+	})
 }
 
 // Sync this server to the master.
@@ -242,6 +270,10 @@ func (s *Server) Sync() {
 		if s.testMode {
 			return
 		}
-		time.Sleep(s.Config.Master.MetaTimeout)
+		select {
+		case <-time.After(s.Config.Master.MetaTimeout):
+		case <-s.done:
+			return
+		}
 	}
 }

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gorse-io/gorse/cmd/version"
@@ -98,6 +99,11 @@ type Worker struct {
 	ticker       *time.Ticker
 	syncedChan   chan struct{} // meta synced events
 	pulledChan   chan struct{} // model pulled events
+	done         chan struct{}
+	stopOnce     sync.Once
+	shutdownOnce sync.Once
+	syncWait     sync.WaitGroup
+	httpServer   *http.Server
 }
 
 // NewWorker creates a new worker node.
@@ -132,6 +138,7 @@ func NewWorker(
 		ticker:       time.NewTicker(interval),
 		syncedChan:   make(chan struct{}, 1),
 		pulledChan:   make(chan struct{}, 1),
+		done:         make(chan struct{}),
 	}
 }
 
@@ -254,7 +261,11 @@ func (w *Worker) Sync() {
 		if w.testMode {
 			return
 		}
-		time.Sleep(w.Config.Master.MetaTimeout)
+		select {
+		case <-time.After(w.Config.Master.MetaTimeout):
+		case <-w.done:
+			return
+		}
 	}
 }
 
@@ -324,10 +335,44 @@ func (w *Worker) ServeHTTP() {
 	http.Handle("/metrics", promhttp.Handler())
 	http.HandleFunc("/api/health/live", w.checkLive)
 	http.HandleFunc("/api/health/ready", w.checkReady)
-	err := http.ListenAndServe(fmt.Sprintf("%s:%d", w.httpHost, w.httpPort), nil)
-	if err != nil {
+	w.httpServer = &http.Server{Addr: fmt.Sprintf("%s:%d", w.httpHost, w.httpPort)}
+	err := w.httpServer.ListenAndServe()
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Logger().Fatal("failed to start http server", zap.Error(err))
 	}
+}
+
+func (w *Worker) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.done)
+		w.ticker.Stop()
+	})
+}
+
+func (w *Worker) Shutdown() {
+	w.shutdownOnce.Do(func() {
+		w.Stop()
+		if w.httpServer != nil {
+			if err := w.httpServer.Shutdown(context.TODO()); err != nil {
+				log.Logger().Error("failed to shutdown http server", zap.Error(err))
+			}
+		}
+		if w.conn != nil {
+			if err := w.conn.Close(); err != nil {
+				log.Logger().Error("failed to close master connection", zap.Error(err))
+			}
+		}
+		w.syncWait.Wait()
+		if err := w.DataClient.Close(); err != nil {
+			log.Logger().Error("failed to close data database", zap.Error(err))
+		}
+		if err := w.CacheClient.Close(); err != nil {
+			log.Logger().Error("failed to close cache database", zap.Error(err))
+		}
+		if err := w.vectorStore.Close(); err != nil {
+			log.Logger().Error("failed to close vector database", zap.Error(err))
+		}
+	})
 }
 
 func writeJSON(w http.ResponseWriter, content any) {
@@ -374,7 +419,11 @@ func (w *Worker) Serve() {
 	}
 	w.masterClient = protocol.NewMasterClient(w.conn)
 
-	go w.Sync()
+	w.syncWait.Add(1)
+	go func() {
+		defer w.syncWait.Done()
+		w.Sync()
+	}()
 	go w.Pull()
 	go w.ServeHTTP()
 
@@ -403,6 +452,8 @@ func (w *Worker) Serve() {
 
 	for {
 		select {
+		case <-w.done:
+			return
 		case tick := <-w.ticker.C:
 			if time.Since(tick) <= w.tickDuration {
 				loop()

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -100,8 +100,7 @@ type Worker struct {
 	syncedChan   chan struct{} // meta synced events
 	pulledChan   chan struct{} // model pulled events
 	done         chan struct{}
-	stopOnce     sync.Once
-	shutdownOnce sync.Once
+	shutdown     sync.Once
 	syncWait     sync.WaitGroup
 	httpServer   *http.Server
 }
@@ -342,37 +341,34 @@ func (w *Worker) ServeHTTP() {
 	}
 }
 
-func (w *Worker) Stop() {
-	w.stopOnce.Do(func() {
+func (w *Worker) Shutdown() {
+	w.shutdown.Do(func() {
 		close(w.done)
 		w.ticker.Stop()
 	})
 }
 
-func (w *Worker) Shutdown() {
-	w.shutdownOnce.Do(func() {
-		w.Stop()
-		if w.httpServer != nil {
-			if err := w.httpServer.Shutdown(context.TODO()); err != nil {
-				log.Logger().Error("failed to shutdown http server", zap.Error(err))
-			}
+func (w *Worker) close() {
+	if w.httpServer != nil {
+		if err := w.httpServer.Shutdown(context.TODO()); err != nil {
+			log.Logger().Error("failed to shutdown http server", zap.Error(err))
 		}
-		if w.conn != nil {
-			if err := w.conn.Close(); err != nil {
-				log.Logger().Error("failed to close master connection", zap.Error(err))
-			}
+	}
+	if w.conn != nil {
+		if err := w.conn.Close(); err != nil {
+			log.Logger().Error("failed to close master connection", zap.Error(err))
 		}
-		w.syncWait.Wait()
-		if err := w.DataClient.Close(); err != nil {
-			log.Logger().Error("failed to close data database", zap.Error(err))
-		}
-		if err := w.CacheClient.Close(); err != nil {
-			log.Logger().Error("failed to close cache database", zap.Error(err))
-		}
-		if err := w.vectorStore.Close(); err != nil {
-			log.Logger().Error("failed to close vector database", zap.Error(err))
-		}
-	})
+	}
+	w.syncWait.Wait()
+	if err := w.DataClient.Close(); err != nil {
+		log.Logger().Error("failed to close data database", zap.Error(err))
+	}
+	if err := w.CacheClient.Close(); err != nil {
+		log.Logger().Error("failed to close cache database", zap.Error(err))
+	}
+	if err := w.vectorStore.Close(); err != nil {
+		log.Logger().Error("failed to close vector database", zap.Error(err))
+	}
 }
 
 func writeJSON(w http.ResponseWriter, content any) {
@@ -418,6 +414,7 @@ func (w *Worker) Serve() {
 		log.Logger().Fatal("failed to connect master", zap.Error(err))
 	}
 	w.masterClient = protocol.NewMasterClient(w.conn)
+	defer w.close()
 
 	w.syncWait.Add(1)
 	go func() {


### PR DESCRIPTION
## Summary

- close the master meta, data, cache, and vector databases after its servers stop
- stop server metadata synchronization before closing its data, cache, and vector databases and Master connection
- add graceful worker shutdown for its HTTP server, synchronization loop, data, cache, and vector databases, and Master connection
- handle interrupt signals in `gorse-worker`
- log each close failure independently so remaining resources are still closed

## Verification

- `/usr/local/go/bin/go test ./master ./server ./worker ./cmd/gorse-server ./cmd/gorse-worker -count=1`