### PR TITLE
docs: fix contributors image repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ In addition, the administrator can perform system monitoring, data import and ex
 ## Contributors
 
 <a href="https://github.com/gorse-io/gorse/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=zhenghaoz/gorse" />
+  <img src="https://contrib.rocks/image?repo=gorse-io/gorse" />
 </a>
 
 Any contribution is appreciated: report a bug, give advice or create a pull request. Read [CONTRIBUTING.md](CONTRIBUTING.md) for more information.


### PR DESCRIPTION
## Summary

Update the contrib.rocks image URL to reference `gorse-io/gorse` instead of the old `zhenghaoz/gorse` repository.

## Verification

- `git diff --check`