### PR TITLE
feat(data): match any search token [release-0.5]

### DIFF
--- a/cmd/gorse-cli/main_test.go
+++ b/cmd/gorse-cli/main_test.go
@@ -375,20 +375,6 @@ func (s *CLITestSuite) TestGetItems() {
 	s.Require().NotContains(out, "└")
 }
 
-func (s *CLITestSuite) TestSearchItems() {
-	out, err := s.execute("get", "items", "raw", "item", "-n", "10")
-	s.Require().NoError(err)
-
-	lines := strings.Split(strings.TrimSpace(out), "\n")
-	s.Require().Len(lines, 3)
-	s.Require().Regexp(`^ITEM-ID\s+COMMENT\s+CATEGORIES\s+IS-HIDDEN\s+TIMESTAMP\s+LABELS$`, lines[0])
-	s.Require().Regexp(`^item-1\s+raw item\s+\["news"\]\s+false\s+2026-01-01T01:00:00Z\s+\{"embedding":"\[0\.1, 0\.2, 0\.3, \.\.\.\] \(10 values\)"\}$`, lines[1])
-	s.Require().Regexp(`^item-2\s+listed item\s+\["books"\]\s+false\s+2026-01-01T02:00:00Z\s+\{"description":"`+strings.Repeat("x", 120)+`"\}$`, lines[2])
-	s.Require().NotContains(out, "┌")
-	s.Require().NotContains(out, "│")
-	s.Require().NotContains(out, "└")
-}
-
 func (s *CLITestSuite) TestPipelineGetCmd() {
 	out, err := s.execute("pipeline", "get")
 	s.Require().NoError(err)

--- a/cmd/gorse-cli/main_test.go
+++ b/cmd/gorse-cli/main_test.go
@@ -375,6 +375,20 @@ func (s *CLITestSuite) TestGetItems() {
 	s.Require().NotContains(out, "└")
 }
 
+func (s *CLITestSuite) TestSearchItems() {
+	out, err := s.execute("get", "items", "raw", "item", "-n", "10")
+	s.Require().NoError(err)
+
+	lines := strings.Split(strings.TrimSpace(out), "\n")
+	s.Require().Len(lines, 3)
+	s.Require().Regexp(`^ITEM-ID\s+COMMENT\s+CATEGORIES\s+IS-HIDDEN\s+TIMESTAMP\s+LABELS$`, lines[0])
+	s.Require().Regexp(`^item-1\s+raw item\s+\["news"\]\s+false\s+2026-01-01T01:00:00Z\s+\{"embedding":"\[0\.1, 0\.2, 0\.3, \.\.\.\] \(10 values\)"\}$`, lines[1])
+	s.Require().Regexp(`^item-2\s+listed item\s+\["books"\]\s+false\s+2026-01-01T02:00:00Z\s+\{"description":"`+strings.Repeat("x", 120)+`"\}$`, lines[2])
+	s.Require().NotContains(out, "┌")
+	s.Require().NotContains(out, "│")
+	s.Require().NotContains(out, "└")
+}
+
 func (s *CLITestSuite) TestPipelineGetCmd() {
 	out, err := s.execute("pipeline", "get")
 	s.Require().NoError(err)

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/gomlx/gomlx v0.27.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/securecookie v1.1.2
-	github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb
+	github.com/gorse-io/dashboard v0.5.20260714
 	github.com/gorse-io/gorse-go v0.5.0-alpha.3
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jaswdr/faker v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -363,8 +363,8 @@ github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pw
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gorse-io/clickhouse v0.3.3-0.20260331225025-ab309f55941d h1:ehE+4aaZ1kU2x6fB/OtsgAfZ8UOnB6bFygI4URyolVs=
 github.com/gorse-io/clickhouse v0.3.3-0.20260331225025-ab309f55941d/go.mod h1:6aZpl8cJgPkqNVeZiEgQJ+yLCC0NyDfv7gF/3/pJywU=
-github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb h1:ES79cPTUrtVSrJNg+Cseyj0vJ9Gvv28Q9AuHgENkdqU=
-github.com/gorse-io/dashboard v0.0.0-20260612180846-e25aefea3ceb/go.mod h1:qz7Y16kcH61Qxr6uQtq7a1FbSujErfr020SZH1SVX3g=
+github.com/gorse-io/dashboard v0.5.20260714 h1:Sy7G7Jw1JywSl5KYDSLiIYctKHBxom4qQmIn+aS1Z1c=
+github.com/gorse-io/dashboard v0.5.20260714/go.mod h1:qz7Y16kcH61Qxr6uQtq7a1FbSujErfr020SZH1SVX3g=
 github.com/gorse-io/goat v0.2.0 h1:EJGnSrYcIHPwZxiPu2wbNuiMGk5n/OQ4ho8EfDzbs2k=
 github.com/gorse-io/goat v0.2.0/go.mod h1:gJNF0DP4jKvNp4R36LSOBi7tP1BO2GkscC2+PsyDcTE=
 github.com/gorse-io/goat v0.2.1-0.20260618151728-201cbcf325ad h1:HESEie1ivHg8yI9Qnej4Cu+AP8w8gQ9gqpYcnV5zC7Q=

--- a/storage/data/database_test.go
+++ b/storage/data/database_test.go
@@ -1025,6 +1025,7 @@ func (suite *baseTestSuite) TestSearch() {
 	suite.ElementsMatch([]string{"gorse-io:gorse"}, searchItemIDs("gorse-io:gorse", 10))
 	suite.ElementsMatch([]string{"running-shoes", "trail-watch"}, searchItemIDs("running", 10))
 	suite.ElementsMatch([]string{"coffee-grinder"}, searchItemIDs("coffee", 10))
+	suite.ElementsMatch([]string{"running-shoes", "trail-watch", "coffee-grinder"}, searchItemIDs("running coffee", 10))
 	suite.ElementsMatch([]string{"trail-watch"}, searchItemIDs("electronics", 10))
 	suite.ElementsMatch([]string{"running-shoes", "coffee-grinder"}, searchItemIDs("acme", 10))
 	suite.Len(searchItemIDs("running", 1), 1)

--- a/storage/data/sql.go
+++ b/storage/data/sql.go
@@ -770,16 +770,13 @@ func sqliteSearchColumn(column, qualifier string) (string, bool) {
 	return "", false
 }
 
-func sqlitePlainTextSearchQuery(query string) string {
+func sqliteAnyTokenSearchQuery(query string) string {
 	terms := strings.Fields(query)
-	if len(terms) == 0 {
-		return `""`
-	}
 	quotedTerms := make([]string, len(terms))
 	for i, term := range terms {
 		quotedTerms[i] = `"` + strings.ReplaceAll(term, `"`, `""`) + `"`
 	}
-	return strings.Join(quotedTerms, " ")
+	return strings.Join(quotedTerms, " OR ")
 }
 
 func (d *SQLDatabase) dropMySQLIndexIfExists(tableName, indexName string) error {
@@ -970,11 +967,19 @@ func (d *SQLDatabase) SearchItems(ctx context.Context, query string, n int) ([]S
 	var tx *gorm.DB
 	switch d.driver {
 	case Postgres:
+		terms := strings.Fields(query)
+		queries := make([]string, len(terms))
+		args := make([]any, len(terms))
+		for i, term := range terms {
+			queries[i] = "plainto_tsquery('simple', ?)"
+			args[i] = term
+		}
+		searchQuery := strings.Join(queries, " || ")
 		tx = d.gormDB.WithContext(ctx).
 			Table(d.ItemsTable()).
-			Select(fmt.Sprintf("item_id, is_hidden, categories, time_stamp, labels, comment, ts_rank(%s, plainto_tsquery('simple', ?)) AS score", d.searchVector), query).
-			Where(fmt.Sprintf("%s @@ plainto_tsquery('simple', ?)", d.searchVector), query).
-			Order(clause.Expr{SQL: fmt.Sprintf("ts_rank(%s, plainto_tsquery('simple', ?)) DESC", d.searchVector), Vars: []any{query}}).
+			Select(fmt.Sprintf("item_id, is_hidden, categories, time_stamp, labels, comment, ts_rank(%s, %s) AS score", d.searchVector, searchQuery), args...).
+			Where(fmt.Sprintf("%s @@ (%s)", d.searchVector, searchQuery), args...).
+			Order(clause.Expr{SQL: fmt.Sprintf("ts_rank(%s, %s) DESC", d.searchVector, searchQuery), Vars: args}).
 			Limit(n)
 	case MySQL:
 		tx = d.gormDB.WithContext(ctx).
@@ -984,7 +989,7 @@ func (d *SQLDatabase) SearchItems(ctx context.Context, query string, n int) ([]S
 			Order(clause.Expr{SQL: fmt.Sprintf("MATCH(%s) AGAINST (? IN NATURAL LANGUAGE MODE) DESC", mysqlSearchDocumentColumn), Vars: []any{query}}).
 			Limit(n)
 	case SQLite:
-		query = sqlitePlainTextSearchQuery(query)
+		query = sqliteAnyTokenSearchQuery(query)
 		tx = d.gormDB.WithContext(ctx).
 			Table(fmt.Sprintf("%s AS items", d.ItemsTable())).
 			Select(fmt.Sprintf("items.item_id, items.is_hidden, items.categories, items.time_stamp, items.labels, items.comment, -bm25(%s) AS score", searchIndexName)).


### PR DESCRIPTION
Backport #1323 to `release-0.5`.

Changes:
- Match any search token in PostgreSQL and SQLite.
- Keep PostgreSQL compatible with 10.0 by combining parameterized `plainto_tsquery` expressions with `||`.
- Update Dashboard to `v0.5.20260714`.
- Update CLI search expectations.

Conflict resolution:
- Preserved the existing `release-0.5` dependency versions, including `gorse-go`.
- Applied only the Dashboard dependency update from #1323.

Testing:
- Not run locally, per request.
