### PR TITLE
feat(data): support item search in ClickHouse

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -54,7 +54,7 @@ jobs:
           --health-retries 5
 
       clickhouse:
-        image: clickhouse/clickhouse-server:23
+        image: clickhouse/clickhouse-server:26.2
         ports:
           - 8123
         options: >-

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -57,6 +57,9 @@ jobs:
         image: clickhouse/clickhouse-server:26.2
         ports:
           - 8123
+        env:
+          CLICKHOUSE_USER: gorse
+          CLICKHOUSE_PASSWORD: gorse_pass
         options: >-
           --health-cmd="clickhouse-client --query 'SELECT 1'" 
           --health-interval=10s 
@@ -130,7 +133,7 @@ jobs:
         # MongoDB
         MONGO_URI: mongodb://root:password@localhost:${{ job.services.mongo.ports[27017] }}/
         # ClickHouse
-        CLICKHOUSE_URI: clickhouse://localhost:${{ job.services.clickhouse.ports[8123] }}/
+        CLICKHOUSE_URI: clickhouse://gorse:gorse_pass@localhost:${{ job.services.clickhouse.ports[8123] }}/
         # Redis
         REDIS_URI: redis://localhost:${{ job.services.redis.ports[6379] }}/
         # S3

--- a/client/docker-compose.yml.j2
+++ b/client/docker-compose.yml.j2
@@ -54,7 +54,7 @@ services:
   {% elif database == 'clickhouse+redis' %}
 
   clickhouse:
-    image: clickhouse/clickhouse-server:23
+    image: clickhouse/clickhouse-server:26.2
     ports:
       - 8123:8123
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
   #     - mongo_data:/data/db
 
   # clickhouse:
-  #   image: clickhouse/clickhouse-server:22
+  #   image: clickhouse/clickhouse-server:26.2
   #   ports:
   #     - 8123:8123
   #   environment:

--- a/storage/data/database_test.go
+++ b/storage/data/database_test.go
@@ -962,9 +962,6 @@ func (suite *baseTestSuite) TestCollation() {
 }
 
 func (suite *baseTestSuite) TestSearch() {
-	if suite.isClickHouse() {
-		suite.T().Skip("ClickHouse doesn't support item search")
-	}
 	ctx := suite.T().Context()
 	err := suite.Database.Reconcile(config.SearchConfig{Columns: []string{
 		"item.ItemId",

--- a/storage/data/sql.go
+++ b/storage/data/sql.go
@@ -253,11 +253,12 @@ type SQLDatabase struct {
 }
 
 const (
-	searchIndexName               = "gorse_search_index"
-	mysqlSearchDocumentColumn     = "gorse_search_document"
-	sqliteSearchInsertTriggerName = searchIndexName + "_insert"
-	sqliteSearchUpdateTriggerName = searchIndexName + "_update"
-	sqliteSearchDeleteTriggerName = searchIndexName + "_delete"
+	searchIndexName                = "gorse_search_index"
+	mysqlSearchDocumentColumn      = "gorse_search_document"
+	clickHouseSearchDocumentColumn = "gorse_search_document"
+	sqliteSearchInsertTriggerName  = searchIndexName + "_insert"
+	sqliteSearchUpdateTriggerName  = searchIndexName + "_update"
+	sqliteSearchDeleteTriggerName  = searchIndexName + "_delete"
 )
 
 // Optimize is used by ClickHouse only.
@@ -528,6 +529,33 @@ func (d *SQLDatabase) Reconcile(searchConfig config.SearchConfig) error {
 		if err = d.gormDB.Exec(fmt.Sprintf("CREATE FULLTEXT INDEX %s ON %s(%s)", searchIndexName, d.ItemsTable(), mysqlSearchDocumentColumn)).Error; err != nil {
 			return errors.Trace(err)
 		}
+	case ClickHouse:
+		searchDocument := buildClickHouseSearchDocument(searchConfig.Columns)
+		if searchDocument == "" {
+			return nil
+		}
+		matched, err := d.clickHouseSearchIndexMatches(searchDocument)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if matched {
+			return nil
+		}
+		if err = d.gormDB.Exec(fmt.Sprintf("ALTER TABLE %s DROP INDEX IF EXISTS %s", d.ItemsTable(), searchIndexName)).Error; err != nil {
+			return errors.Trace(err)
+		}
+		if err = d.gormDB.Exec(fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s", d.ItemsTable(), clickHouseSearchDocumentColumn)).Error; err != nil {
+			return errors.Trace(err)
+		}
+		if err = d.gormDB.Exec(fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s String MATERIALIZED %s", d.ItemsTable(), clickHouseSearchDocumentColumn, searchDocument)).Error; err != nil {
+			return errors.Trace(err)
+		}
+		if err = d.gormDB.Exec(fmt.Sprintf("ALTER TABLE %s ADD INDEX %s %s TYPE text(tokenizer = splitByNonAlpha, preprocessor = lowerUTF8(%s))", d.ItemsTable(), searchIndexName, clickHouseSearchDocumentColumn, clickHouseSearchDocumentColumn)).Error; err != nil {
+			return errors.Trace(err)
+		}
+		if err = d.gormDB.Exec(fmt.Sprintf("ALTER TABLE %s MATERIALIZE INDEX %s SETTINGS mutations_sync = 2", d.ItemsTable(), searchIndexName)).Error; err != nil {
+			return errors.Trace(err)
+		}
 	case SQLite:
 		searchDocument := buildSQLiteSearchDocument(searchConfig.Columns, "")
 		newSearchDocument := buildSQLiteSearchDocument(searchConfig.Columns, "new")
@@ -581,6 +609,28 @@ func (d *SQLDatabase) postgresSearchIndexMatches(searchVector string) (bool, err
 		return false, nil
 	}
 	return searchExpressionContainsAll(indexDef, strings.Split(searchVector, " || ")), nil
+}
+
+func (d *SQLDatabase) clickHouseSearchIndexMatches(searchDocument string) (bool, error) {
+	var column struct {
+		DefaultKind       string `gorm:"column:default_kind"`
+		DefaultExpression string `gorm:"column:default_expression"`
+	}
+	if err := d.gormDB.Raw("SELECT default_kind, default_expression FROM system.columns WHERE database = currentDatabase() AND table = ? AND name = ?", d.ItemsTable(), clickHouseSearchDocumentColumn).Scan(&column).Error; err != nil {
+		return false, errors.Trace(err)
+	}
+	if column.DefaultKind != "MATERIALIZED" || normalizeSearchIndexExpression(column.DefaultExpression) != normalizeSearchIndexExpression(searchDocument) {
+		return false, nil
+	}
+	var index struct {
+		Expression string `gorm:"column:expr"`
+		Type       string `gorm:"column:type_full"`
+	}
+	if err := d.gormDB.Raw("SELECT expr, type_full FROM system.data_skipping_indices WHERE database = currentDatabase() AND table = ? AND name = ?", d.ItemsTable(), searchIndexName).Scan(&index).Error; err != nil {
+		return false, errors.Trace(err)
+	}
+	expectedType := fmt.Sprintf("text(tokenizer = splitByNonAlpha, preprocessor = lowerUTF8(%s))", clickHouseSearchDocumentColumn)
+	return index.Expression == clickHouseSearchDocumentColumn && normalizeSearchIndexExpression(index.Type) == normalizeSearchIndexExpression(expectedType), nil
 }
 
 func (d *SQLDatabase) mysqlSearchIndexMatches(tableName, searchDocument string) (bool, error) {
@@ -690,6 +740,47 @@ func isPostgresJSONPathElement(s string) bool {
 		return false
 	}
 	return true
+}
+
+func buildClickHouseSearchDocument(columns []string) string {
+	searchColumns := make([]string, 0, len(columns))
+	for _, column := range columns {
+		searchColumn, ok := clickHouseSearchColumn(column)
+		if !ok {
+			continue
+		}
+		searchColumns = append(searchColumns, searchColumn)
+	}
+	if len(searchColumns) == 0 {
+		return ""
+	}
+	sort.Strings(searchColumns)
+	if len(searchColumns) == 1 {
+		return searchColumns[0]
+	}
+	return fmt.Sprintf("concat(%s)", strings.Join(searchColumns, ", ' ', "))
+}
+
+func clickHouseSearchColumn(column string) (string, bool) {
+	switch column {
+	case "item.ItemId":
+		return "item_id", true
+	case "item.Categories":
+		return "categories", true
+	case "item.Comment":
+		return "comment", true
+	case "item.Labels":
+		return "labels", true
+	default:
+		const labelsPrefix = "item.Labels."
+		if len(column) > len(labelsPrefix) && strings.HasPrefix(column, labelsPrefix) {
+			path := strings.Split(column[len(labelsPrefix):], ".")
+			if lo.EveryBy(path, isPostgresJSONPathElement) {
+				return fmt.Sprintf("JSONExtractRaw(labels, '%s')", strings.Join(path, "', '")), true
+			}
+		}
+	}
+	return "", false
 }
 
 func buildMySQLSearchDocument(columns []string) string {
@@ -992,6 +1083,13 @@ func (d *SQLDatabase) SearchItems(ctx context.Context, query string, n int) ([]S
 			Select(fmt.Sprintf("item_id, is_hidden, categories, time_stamp, labels, comment, MATCH(%s) AGAINST (? IN NATURAL LANGUAGE MODE) AS score", mysqlSearchDocumentColumn), query).
 			Where(fmt.Sprintf("MATCH(%s) AGAINST (? IN NATURAL LANGUAGE MODE)", mysqlSearchDocumentColumn), query).
 			Order(clause.Expr{SQL: fmt.Sprintf("MATCH(%s) AGAINST (? IN NATURAL LANGUAGE MODE) DESC", mysqlSearchDocumentColumn), Vars: []any{query}}).
+			Limit(n)
+	case ClickHouse:
+		tx = d.gormDB.WithContext(ctx).
+			Table(d.ItemsTable()+" FINAL").
+			Select("item_id, is_hidden, categories, time_stamp, labels, comment, toFloat64(1) AS score").
+			Where(fmt.Sprintf("hasAnyTokens(%s, ?)", clickHouseSearchDocumentColumn), query).
+			Order("item_id").
 			Limit(n)
 	case SQLite:
 		query = sqliteAnyTokenSearchQuery(query)

--- a/storage/data/sql_test.go
+++ b/storage/data/sql_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/gorse-io/gorse/common/log"
-	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -138,42 +137,6 @@ func (suite *ClickHouseTestSuite) SetupSuite() {
 	// create schema
 	err = suite.Database.Init()
 	suite.NoError(err)
-}
-
-func (suite *ClickHouseTestSuite) TestSearchItemsAfterUpdate() {
-	ctx := suite.T().Context()
-	err := suite.Database.Reconcile(config.SearchConfig{Columns: []string{"item.Comment"}})
-	suite.NoError(err)
-	err = suite.Database.BatchInsertItems(ctx, []Item{{ItemId: "instant-search", Comment: "before-update"}})
-	suite.NoError(err)
-
-	items, err := suite.Database.SearchItems(ctx, "before", 10)
-	suite.NoError(err)
-	if suite.Len(items, 1) {
-		suite.Equal("instant-search", items[0].ItemId)
-		suite.Equal("before-update", items[0].Comment)
-		suite.Equal(float64(1), items[0].Score)
-	}
-
-	comment := "after-update"
-	err = suite.Database.ModifyItem(ctx, "instant-search", ItemPatch{Comment: &comment})
-	suite.NoError(err)
-	items, err = suite.Database.SearchItems(ctx, "before", 10)
-	suite.NoError(err)
-	suite.Empty(items)
-	items, err = suite.Database.SearchItems(ctx, "after", 10)
-	suite.NoError(err)
-	if suite.Len(items, 1) {
-		suite.Equal("instant-search", items[0].ItemId)
-		suite.Equal("after-update", items[0].Comment)
-		suite.Equal(float64(1), items[0].Score)
-	}
-
-	err = suite.Database.DeleteItem(ctx, "instant-search")
-	suite.NoError(err)
-	items, err = suite.Database.SearchItems(ctx, "after", 10)
-	suite.NoError(err)
-	suite.Empty(items)
 }
 
 func TestClickHouse(t *testing.T) {
@@ -293,19 +256,4 @@ func BenchmarkSQLite_CountItems(b *testing.B) {
 	// close database
 	err = database.Close()
 	require.NoError(b, err)
-}
-
-func TestBuildClickHouseSearchDocument(t *testing.T) {
-	assert.Equal(t,
-		"concat(JSONExtractRaw(labels, 'brand'), ' ', categories, ' ', comment, ' ', item_id)",
-		buildClickHouseSearchDocument([]string{
-			"item.ItemId",
-			"item.Categories",
-			"item.Labels.brand",
-			"item.Comment",
-		}))
-	assert.Equal(t,
-		"JSONExtractRaw(labels, 'profile', 'brand')",
-		buildClickHouseSearchDocument([]string{"item.Labels.profile.brand"}))
-	assert.Empty(t, buildClickHouseSearchDocument([]string{"item.Labels.invalid-path"}))
 }

--- a/storage/data/sql_test.go
+++ b/storage/data/sql_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/gorse-io/gorse/common/log"
+	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,6 +138,42 @@ func (suite *ClickHouseTestSuite) SetupSuite() {
 	// create schema
 	err = suite.Database.Init()
 	suite.NoError(err)
+}
+
+func (suite *ClickHouseTestSuite) TestSearchItemsAfterUpdate() {
+	ctx := suite.T().Context()
+	err := suite.Database.Reconcile(config.SearchConfig{Columns: []string{"item.Comment"}})
+	suite.NoError(err)
+	err = suite.Database.BatchInsertItems(ctx, []Item{{ItemId: "instant-search", Comment: "before-update"}})
+	suite.NoError(err)
+
+	items, err := suite.Database.SearchItems(ctx, "before", 10)
+	suite.NoError(err)
+	if suite.Len(items, 1) {
+		suite.Equal("instant-search", items[0].ItemId)
+		suite.Equal("before-update", items[0].Comment)
+		suite.Equal(float64(1), items[0].Score)
+	}
+
+	comment := "after-update"
+	err = suite.Database.ModifyItem(ctx, "instant-search", ItemPatch{Comment: &comment})
+	suite.NoError(err)
+	items, err = suite.Database.SearchItems(ctx, "before", 10)
+	suite.NoError(err)
+	suite.Empty(items)
+	items, err = suite.Database.SearchItems(ctx, "after", 10)
+	suite.NoError(err)
+	if suite.Len(items, 1) {
+		suite.Equal("instant-search", items[0].ItemId)
+		suite.Equal("after-update", items[0].Comment)
+		suite.Equal(float64(1), items[0].Score)
+	}
+
+	err = suite.Database.DeleteItem(ctx, "instant-search")
+	suite.NoError(err)
+	items, err = suite.Database.SearchItems(ctx, "after", 10)
+	suite.NoError(err)
+	suite.Empty(items)
 }
 
 func TestClickHouse(t *testing.T) {
@@ -256,4 +293,19 @@ func BenchmarkSQLite_CountItems(b *testing.B) {
 	// close database
 	err = database.Close()
 	require.NoError(b, err)
+}
+
+func TestBuildClickHouseSearchDocument(t *testing.T) {
+	assert.Equal(t,
+		"concat(JSONExtractRaw(labels, 'brand'), ' ', categories, ' ', comment, ' ', item_id)",
+		buildClickHouseSearchDocument([]string{
+			"item.ItemId",
+			"item.Categories",
+			"item.Labels.brand",
+			"item.Comment",
+		}))
+	assert.Equal(t,
+		"JSONExtractRaw(labels, 'profile', 'brand')",
+		buildClickHouseSearchDocument([]string{"item.Labels.profile.brand"}))
+	assert.Empty(t, buildClickHouseSearchDocument([]string{"item.Labels.invalid-path"}))
 }

--- a/storage/docker-compose.yml
+++ b/storage/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: password
 
   clickhouse:
-    image: clickhouse/clickhouse-server:23
+    image: clickhouse/clickhouse-server:26.2
     ports:
       - 8123:8123
   

--- a/storage/docker-compose.yml
+++ b/storage/docker-compose.yml
@@ -35,6 +35,9 @@ services:
     image: clickhouse/clickhouse-server:26.2
     ports:
       - 8123:8123
+    environment:
+      CLICKHOUSE_USER: gorse
+      CLICKHOUSE_PASSWORD: gorse_pass
   
   rustfs:
     image: rustfs/rustfs:alpha


### PR DESCRIPTION
## Summary

- add ClickHouse `SearchItems` using a materialized search document and MergeTree text index
- preserve immediate correctness on `ReplacingMergeTree` with `FINAL` and return deterministic positive scores
- upgrade ClickHouse test and Compose images to 26.2, where text indexes are generally available

## Implementation

- reconcile `gorse_search_document` and `gorse_search_index` from `recommend.search.columns`
- use `splitByNonAlpha` with `lowerUTF8` on ClickHouse 26.2
- query with `hasAnyTokens` to match the shared any-token search contract
- materialize the index for existing table parts

## Tests

- `CLICKHOUSE_URI='clickhouse://gorse:gorse_pass@127.0.0.1:18123/' go test ./storage/data -run '^TestClickHouse$' -count=1`
- `CLICKHOUSE_URI='clickhouse://gorse:gorse_pass@127.0.0.1:18123/' go test ./storage/data -count=1`
- `CLICKHOUSE_URI='clickhouse://gorse:gorse_pass@127.0.0.1:18123/' go test -timeout 30m ./... -count=1`
- `docker compose -f storage/docker-compose.yml config`
- `docker compose -f docker-compose.yml config`

Tested against `clickhouse/clickhouse-server:26.2` (`26.2.19.43`).
