### PR TITLE
fix(ctr): ignore embeddings without index

### DIFF
--- a/model/ctr/fm.go
+++ b/model/ctr/fm.go
@@ -207,6 +207,9 @@ func (fm *AFM) BatchPredict(inputs []lo.Tuple4[string, string, []Label, []Label]
 	e := make([][][]uint16, len(inputs))
 	for i := range inputs {
 		e[i] = make([][]uint16, len(fm.embeddingDim))
+		if fm.embeddingIndex == nil {
+			continue
+		}
 		for _, embedding := range embeddings[i] {
 			itemIndex := fm.embeddingIndex.ToNumber(embedding.Name)
 			if itemIndex == dataset.NotId {

--- a/model/ctr/fm_xla.go
+++ b/model/ctr/fm_xla.go
@@ -325,6 +325,9 @@ func (fm *AFM) BatchPredict(inputs []lo.Tuple4[string, string, []Label, []Label]
 	e := make([][][]uint16, len(inputs))
 	for i := range inputs {
 		e[i] = make([][]uint16, len(fm.embeddingDim))
+		if fm.embeddingIndex == nil {
+			continue
+		}
 		for _, embedding := range embeddings[i] {
 			itemIndex := fm.embeddingIndex.ToNumber(embedding.Name)
 			if itemIndex == dataset.NotId {

--- a/model/ctr/model_test.go
+++ b/model/ctr/model_test.go
@@ -237,7 +237,7 @@ func TestFactorizationMachines_Classification_Synthesis(t *testing.T) {
 	), 4)
 }
 
-func TestAFMBatchPredictIgnoreEmbeddingsWithoutIndex(t *testing.T) {
+func TestFactorizationMachines_NoEmbeddings(t *testing.T) {
 	dataSet := newSynthesisDataset()
 	dataSet.ItemEmbeddingIndex = dataset.NewMapIndex()
 	dataSet.ItemEmbeddingDimension = nil

--- a/model/ctr/model_test.go
+++ b/model/ctr/model_test.go
@@ -236,3 +236,24 @@ func TestFactorizationMachines_Classification_Synthesis(t *testing.T) {
 		fitConfig.Jobs,
 	), 4)
 }
+
+func TestAFMBatchPredictIgnoreEmbeddingsWithoutIndex(t *testing.T) {
+	dataSet := newSynthesisDataset()
+	dataSet.ItemEmbeddingIndex = dataset.NewMapIndex()
+	dataSet.ItemEmbeddingDimension = nil
+	dataSet.ItemEmbeddings = nil
+
+	m := NewAFM(nil)
+	m.Init(dataSet)
+
+	buf := bytes.NewBuffer(nil)
+	assert.NoError(t, MarshalModel(buf, m))
+	clone, err := UnmarshalModel(buf)
+	assert.NoError(t, err)
+
+	batch := clone.(BatchInference)
+	inputs := []lo.Tuple4[string, string, []Label, []Label]{{A: "u0", B: "i0"}}
+	assert.Equal(t,
+		batch.BatchPredict(inputs, [][]Embedding{{}}, 1),
+		batch.BatchPredict(inputs, [][]Embedding{{{Name: "unexpected", Value: []uint16{1}}}}, 1))
+}


### PR DESCRIPTION
## Summary

- ignore inference-time item embeddings when an AFM model has no embedding index
- apply the same guard to both the standard and XLA implementations
- add a regression test covering an AFM model after marshal/unmarshal

## Tests

- `go test ./model/ctr -run '^TestFactorizationMachines_NoEmbeddings$' -count=1`
- `go test ./model/ctr -count=1`
- `go vet ./model/ctr`

Closes #1322
