### PR TITLE
修复查询不存在的指定类型反馈时发生 panic

### DIFF
--- a/server/rest.go
+++ b/server/rest.go
@@ -1885,7 +1885,7 @@ func (s *RestServer) getTypedUserItemFeedback(request *restful.Request, response
 	itemId := request.PathParameter("item-id")
 	if feedback, err := s.DataClient.GetUserItemFeedback(ctx, userId, itemId, feedbackType); err != nil {
 		InternalServerError(response, err)
-	} else if feedbackType == "" {
+	} else if len(feedback) == 0 {
 		Text(response, "{}")
 	} else {
 		Ok(response, feedback[0])

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -1098,6 +1098,15 @@ func (suite *ServerTestSuite) TestUserToUser() {
 
 func (suite *ServerTestSuite) TestDeleteFeedback() {
 	t := suite.T()
+	// Get nonexistent typed feedback.
+	apitest.New().
+		Handler(suite.handler).
+		Get("/api/feedback/missing/missing/missing").
+		Header("X-API-Key", apiKey).
+		Expect(t).
+		Status(http.StatusOK).
+		Body("{}").
+		End()
 	// Insert feedback
 	feedback := []data.Feedback{
 		{FeedbackKey: data.FeedbackKey{FeedbackType: "type1", UserId: "2", ItemId: "3"}},


### PR DESCRIPTION
## 变更说明

修复查询不存在的指定类型反馈时访问空切片并触发 panic 的问题。

## 问题原因

GET /api/feedback/{feedback-type}/{user-id}/{item-id} 在数据层返回空切片时，错误地检查 feedbackType 是否为空。由于路由中的 feedback-type 正常情况下不会为空，代码会继续访问 feedback[0]，导致请求连接被异常断开。

## 修复内容

- 将错误的 feedbackType 空字符串判断改为 len(feedback) == 0。
- 查询结果为空时沿用原有意图返回 200 和空对象 {}。
- 增加不存在指定类型反馈的回归测试。

## 验证

- [x] 缺失反馈返回 200 {}
- [x] 原有反馈新增、查询和删除流程通过
- [x] go test ./server -count=1
- [x] go vet ./server
- [x] git diff --check
