### PR TITLE
修复修改用户或物品时静默吞掉缓存错误

### DIFF
--- a/server/rest.go
+++ b/server/rest.go
@@ -1201,6 +1201,7 @@ func (s *RestServer) modifyUser(request *restful.Request, response *restful.Resp
 	}
 	// insert modify timestamp
 	if err := s.CacheClient.Set(ctx, cache.Time(cache.Key(cache.LastModifyUserTime, userId), time.Now())); err != nil {
+		InternalServerError(response, err)
 		return
 	}
 	Ok(response, Success{RowAffected: 1})
@@ -1544,6 +1545,7 @@ func (s *RestServer) modifyItem(request *restful.Request, response *restful.Resp
 	}
 	// insert modify timestamp
 	if err := s.CacheClient.Set(ctx, cache.Time(cache.Key(cache.LastModifyItemTime, itemId), time.Now())); err != nil {
+		InternalServerError(response, err)
 		return
 	}
 	Ok(response, Success{RowAffected: 1})

--- a/server/rest_test.go
+++ b/server/rest_test.go
@@ -719,6 +719,38 @@ func (suite *ServerTestSuite) TestQuota() {
 		End()
 }
 
+func (suite *ServerTestSuite) TestModifyCacheError() {
+	t := suite.T()
+	ctx := t.Context()
+	err := suite.DataClient.BatchInsertUsers(ctx, []data.User{{UserId: "user"}})
+	suite.NoError(err)
+	err = suite.DataClient.BatchInsertItems(ctx, []data.Item{{ItemId: "item"}})
+	suite.NoError(err)
+
+	cacheClient := suite.CacheClient
+	suite.CacheClient = cache.NoDatabase{}
+	defer func() {
+		suite.CacheClient = cacheClient
+	}()
+
+	apitest.New().
+		Handler(suite.handler).
+		Patch("/api/user/user").
+		Header("X-API-Key", apiKey).
+		JSON(data.UserPatch{Comment: new("modified")}).
+		Expect(t).
+		Status(http.StatusInternalServerError).
+		End()
+	apitest.New().
+		Handler(suite.handler).
+		Patch("/api/item/item").
+		Header("X-API-Key", apiKey).
+		JSON(data.ItemPatch{Comment: new("modified")}).
+		Expect(t).
+		Status(http.StatusInternalServerError).
+		End()
+}
+
 func (suite *ServerTestSuite) TestSearchItems() {
 	t := suite.T()
 


### PR DESCRIPTION
## 变更说明

修复修改用户或物品后，写入最后修改时间缓存失败时接口静默返回的问题。

## 问题原因

PATCH /api/user/{user-id} 和 PATCH /api/item/{item-id} 会先更新数据存储，再写入最后修改时间缓存。缓存写入失败时，现有代码直接 return，没有生成 HTTP 错误响应，客户端无法判断操作未完整完成。

## 修复内容

- 用户修改后的缓存写入失败时调用 InternalServerError。
- 物品修改后的缓存写入失败时调用 InternalServerError。
- 增加回归测试，模拟不可用的缓存存储并验证两个接口均返回 HTTP 500。

## 行为说明

数据存储与缓存之间没有跨存储事务，因此发生该错误时数据可能已经修改。返回 500 表示整个业务操作未完整完成，与同文件中新增用户和新增物品的错误处理方式保持一致，也避免将不一致状态静默报告为成功。

## 验证

- [x] 用户修改遇到缓存错误时返回 HTTP 500
- [x] 物品修改遇到缓存错误时返回 HTTP 500
- [x] go test ./server -count=1
- [x] go vet ./server
- [x] git diff --check
