### PR TITLE
refactor(client): move admin client

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -128,23 +128,23 @@ func NewAdminClient(endpoint, apiKey string) *AdminClient {
 }
 
 func (c *AdminClient) GetCluster() ([]Node, error) {
-	return getJSON[[]Node](c, "/dashboard/cluster", nil)
+	return get[[]Node](c, "/dashboard/cluster", nil)
 }
 
 func (c *AdminClient) GetTasks() ([]Progress, error) {
-	return getJSON[[]Progress](c, "/dashboard/tasks", nil)
+	return get[[]Progress](c, "/dashboard/tasks", nil)
 }
 
 func (c *AdminClient) GetConfig() (map[string]any, error) {
-	return getJSON[map[string]any](c, "/dashboard/config", nil)
+	return get[map[string]any](c, "/dashboard/config", nil)
 }
 
 func (c *AdminClient) GetConfigMap() (map[string]any, error) {
-	return getJSON[map[string]any](c, "/dashboard/config", nil)
+	return get[map[string]any](c, "/dashboard/config", nil)
 }
 
 func (c *AdminClient) GetConfigSchema() (map[string]any, error) {
-	return getJSON[map[string]any](c, "/dashboard/config/schema", nil)
+	return get[map[string]any](c, "/dashboard/config/schema", nil)
 }
 
 func (c *AdminClient) UpdateConfig(configPatch map[string]any) (map[string]any, error) {
@@ -178,62 +178,76 @@ func (c *AdminClient) ResetConfig() (map[string]any, error) {
 }
 
 func (c *AdminClient) GetCategories() ([]string, error) {
-	return getJSON[[]string](c, "/dashboard/categories", nil)
+	return get[[]string](c, "/dashboard/categories", nil)
 }
 
 func (c *AdminClient) GetStats() (Status, error) {
-	return getJSON[Status](c, "/dashboard/stats", nil)
+	return get[Status](c, "/dashboard/stats", nil)
 }
 
 func (c *AdminClient) GetFeedback(n int) (FeedbackIterator, error) {
 	params := url.Values{}
-	addIntParam(params, "n", n)
-	return getJSON[FeedbackIterator](c, "/feedback", params)
+	if n != 0 {
+		params.Set("n", fmt.Sprint(n))
+	}
+	return get[FeedbackIterator](c, "/feedback", params)
 }
 
 func (c *AdminClient) GetTypedFeedback(feedbackType string, n int) (FeedbackIterator, error) {
 	params := url.Values{}
-	addIntParam(params, "n", n)
-	return getJSON[FeedbackIterator](c, "/feedback/"+url.PathEscape(feedbackType), params)
+	if n != 0 {
+		params.Set("n", fmt.Sprint(n))
+	}
+	return get[FeedbackIterator](c, "/feedback/"+url.PathEscape(feedbackType), params)
 }
 
 func (c *AdminClient) GetUserItemFeedback(userID, itemID string) ([]Feedback, error) {
-	return getJSON[[]Feedback](c, "/feedback/"+url.PathEscape(userID)+"/"+url.PathEscape(itemID), nil)
+	return get[[]Feedback](c, "/feedback/"+url.PathEscape(userID)+"/"+url.PathEscape(itemID), nil)
 }
 
 func (c *AdminClient) GetTypedUserItemFeedback(feedbackType, userID, itemID string) (Feedback, error) {
-	return getJSON[Feedback](c, "/feedback/"+url.PathEscape(feedbackType)+"/"+url.PathEscape(userID)+"/"+url.PathEscape(itemID), nil)
+	return get[Feedback](c, "/feedback/"+url.PathEscape(feedbackType)+"/"+url.PathEscape(userID)+"/"+url.PathEscape(itemID), nil)
 }
 
 func (c *AdminClient) GetUserFeedback(userID string) ([]Feedback, error) {
-	return getJSON[[]Feedback](c, "/user/"+url.PathEscape(userID)+"/feedback", nil)
+	return get[[]Feedback](c, "/user/"+url.PathEscape(userID)+"/feedback", nil)
 }
 
 func (c *AdminClient) GetTypedUserFeedback(userID, feedbackType string) ([]Feedback, error) {
-	return getJSON[[]Feedback](c, "/user/"+url.PathEscape(userID)+"/feedback/"+url.PathEscape(feedbackType), nil)
+	return get[[]Feedback](c, "/user/"+url.PathEscape(userID)+"/feedback/"+url.PathEscape(feedbackType), nil)
 }
 
 func (c *AdminClient) GetItemFeedback(itemID string) ([]Feedback, error) {
-	return getJSON[[]Feedback](c, "/item/"+url.PathEscape(itemID)+"/feedback/", nil)
+	return get[[]Feedback](c, "/item/"+url.PathEscape(itemID)+"/feedback/", nil)
 }
 
 func (c *AdminClient) GetTypedItemFeedback(itemID, feedbackType string) ([]Feedback, error) {
-	return getJSON[[]Feedback](c, "/item/"+url.PathEscape(itemID)+"/feedback/"+url.PathEscape(feedbackType), nil)
+	return get[[]Feedback](c, "/item/"+url.PathEscape(itemID)+"/feedback/"+url.PathEscape(feedbackType), nil)
 }
 
 func (c *AdminClient) GetLatest(n int, categories []string) ([]ScoredItem, error) {
 	params := url.Values{}
-	addIntParam(params, "n", n)
-	addStringArrayParam(params, "category", categories)
-	return getJSON[[]ScoredItem](c, "/dashboard/latest", params)
+	if n != 0 {
+		params.Set("n", fmt.Sprint(n))
+	}
+	for _, category := range categories {
+		params.Add("category", category)
+	}
+	return get[[]ScoredItem](c, "/dashboard/latest", params)
 }
 
 func (c *AdminClient) GetNonPersonalized(name string, n int, userID string, categories []string) ([]ScoredItem, error) {
 	params := url.Values{}
-	addIntParam(params, "n", n)
-	addStringParam(params, "user-id", userID)
-	addStringArrayParam(params, "category", categories)
-	return getJSON[[]ScoredItem](c, "/dashboard/non-personalized/"+url.PathEscape(name), params)
+	if n != 0 {
+		params.Set("n", fmt.Sprint(n))
+	}
+	if userID != "" {
+		params.Set("user-id", userID)
+	}
+	for _, category := range categories {
+		params.Add("category", category)
+	}
+	return get[[]ScoredItem](c, "/dashboard/non-personalized/"+url.PathEscape(name), params)
 }
 
 func (c *AdminClient) GetRecommend(userID, recommender, name string, n int, categories []string) ([]ScoredItem, error) {
@@ -245,22 +259,32 @@ func (c *AdminClient) GetRecommend(userID, recommender, name string, n int, cate
 		path += "/" + url.PathEscape(name)
 	}
 	params := url.Values{}
-	addIntParam(params, "n", n)
-	addStringArrayParam(params, "category", categories)
-	return getJSON[[]ScoredItem](c, path, params)
+	if n != 0 {
+		params.Set("n", fmt.Sprint(n))
+	}
+	for _, category := range categories {
+		params.Add("category", category)
+	}
+	return get[[]ScoredItem](c, path, params)
 }
 
 func (c *AdminClient) GetItemToItem(name, itemID string, n int, categories []string) ([]ScoredItem, error) {
 	params := url.Values{}
-	addIntParam(params, "n", n)
-	addStringArrayParam(params, "category", categories)
-	return getJSON[[]ScoredItem](c, "/dashboard/item-to-item/"+url.PathEscape(name)+"/"+url.PathEscape(itemID), params)
+	if n != 0 {
+		params.Set("n", fmt.Sprint(n))
+	}
+	for _, category := range categories {
+		params.Add("category", category)
+	}
+	return get[[]ScoredItem](c, "/dashboard/item-to-item/"+url.PathEscape(name)+"/"+url.PathEscape(itemID), params)
 }
 
 func (c *AdminClient) GetUserToUser(name, userID string, n int) ([]ScoreUser, error) {
 	params := url.Values{}
-	addIntParam(params, "n", n)
-	return getJSON[[]ScoreUser](c, "/dashboard/user-to-user/"+url.PathEscape(name)+"/"+url.PathEscape(userID), params)
+	if n != 0 {
+		params.Set("n", fmt.Sprint(n))
+	}
+	return get[[]ScoreUser](c, "/dashboard/user-to-user/"+url.PathEscape(name)+"/"+url.PathEscape(userID), params)
 }
 
 func (c *AdminClient) Restore(reader io.Reader) (*DumpStats, error) {
@@ -297,7 +321,7 @@ func (c *AdminClient) Dump(output io.Writer) error {
 	return nil
 }
 
-func getJSON[T any](c *AdminClient, path string, params url.Values) (T, error) {
+func get[T any](c *AdminClient, path string, params url.Values) (T, error) {
 	var result T
 	if len(params) > 0 {
 		path += "?" + params.Encode()
@@ -312,24 +336,6 @@ func getJSON[T any](c *AdminClient, path string, params url.Values) (T, error) {
 		return result, newAdminAPIError(resp)
 	}
 	return result, nil
-}
-
-func addIntParam(params url.Values, name string, value int) {
-	if value != 0 {
-		params.Set(name, fmt.Sprint(value))
-	}
-}
-
-func addStringParam(params url.Values, name, value string) {
-	if value != "" {
-		params.Set(name, value)
-	}
-}
-
-func addStringArrayParam(params url.Values, name string, values []string) {
-	for _, value := range values {
-		params.Add(name, value)
-	}
 }
 
 func newAdminAPIError(resp *resty.Response) error {

--- a/client/admin.go
+++ b/client/admin.go
@@ -22,10 +22,12 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+	client "github.com/gorse-io/gorse-go"
 )
 
 // AdminClient is a client for the Gorse admin API.
 type AdminClient struct {
+	*client.GorseClient
 	client *resty.Client
 }
 
@@ -121,10 +123,14 @@ type DumpStats struct {
 
 // NewAdminClient creates a new client for the Gorse admin API.
 func NewAdminClient(endpoint, apiKey string) *AdminClient {
-	client := resty.New()
-	client.SetBaseURL(strings.TrimRight(endpoint, "/") + "/api")
-	client.SetHeader("X-Api-Key", apiKey)
-	return &AdminClient{client: client}
+	endpoint = strings.TrimRight(endpoint, "/")
+	adminClient := resty.New()
+	adminClient.SetBaseURL(endpoint + "/api")
+	adminClient.SetHeader("X-Api-Key", apiKey)
+	return &AdminClient{
+		GorseClient: client.NewGorseClient(endpoint, apiKey),
+		client:      adminClient,
+	}
 }
 
 func (c *AdminClient) GetCluster() ([]Node, error) {

--- a/client/admin.go
+++ b/client/admin.go
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package client
 
 import (
 	"fmt"
 	"io"
 	"net/url"
-	"sort"
 	"strings"
 	"time"
 
@@ -120,12 +119,6 @@ type DumpStats struct {
 	Duration time.Duration
 }
 
-func sortFeedback(feedback []Feedback) {
-	sort.Slice(feedback, func(i, j int) bool {
-		return feedback[i].Timestamp.After(feedback[j].Timestamp)
-	})
-}
-
 // NewAdminClient creates a new client for the Gorse admin API.
 func NewAdminClient(endpoint, apiKey string) *AdminClient {
 	client := resty.New()
@@ -182,48 +175,6 @@ func (c *AdminClient) ResetConfig() (map[string]any, error) {
 		return result, newAdminAPIError(resp)
 	}
 	return result, nil
-}
-
-func getConfigValue(configMap map[string]any, names ...string) (string, any, bool) {
-	for _, name := range names {
-		value, ok := configMap[name]
-		if ok {
-			return name, value, true
-		}
-	}
-	return "", nil, false
-}
-
-func formatConfigMap(configMap map[string]any) map[string]any {
-	formatted := make(map[string]any, len(configMap))
-	for key, value := range configMap {
-		formatted[key] = formatConfigValue(value)
-	}
-	return formatted
-}
-
-func formatConfigValue(value any) any {
-	switch v := value.(type) {
-	case time.Duration:
-		s := v.String()
-		if strings.HasSuffix(s, "m0s") {
-			s = s[:len(s)-2]
-		}
-		if strings.HasSuffix(s, "h0m") {
-			s = s[:len(s)-2]
-		}
-		return s
-	case map[string]any:
-		return formatConfigMap(v)
-	case []any:
-		formatted := make([]any, len(v))
-		for i, item := range v {
-			formatted[i] = formatConfigValue(item)
-		}
-		return formatted
-	default:
-		return v
-	}
 }
 
 func (c *AdminClient) GetCategories() ([]string, error) {

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 gorse Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorse-io/gorse/client"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/dashboard/categories", r.URL.Path)
+		require.Equal(t, "secret", r.Header.Get("X-Api-Key"))
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`["news","tech"]`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	categories, err := client.NewAdminClient(server.URL, "secret").GetCategories()
+	require.NoError(t, err)
+	require.Equal(t, []string{"news", "tech"}, categories)
+}

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -31,10 +31,18 @@ type AdminClientTestSuite struct {
 
 func (suite *AdminClientTestSuite) SetupSuite() {
 	suite.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		suite.Equal("/api/dashboard/categories", r.URL.Path)
 		suite.Equal("secret", r.Header.Get("X-Api-Key"))
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`["news","tech"]`))
+		var response string
+		switch r.URL.Path {
+		case "/api/dashboard/categories":
+			response = `["news","tech"]`
+		case "/api/user/alice":
+			response = `{"UserId":"alice"}`
+		default:
+			suite.Fail("unexpected request path", r.URL.Path)
+		}
+		_, err := w.Write([]byte(response))
 		suite.NoError(err)
 	}))
 	suite.client = client.NewAdminClient(suite.server.URL, "secret")
@@ -48,6 +56,12 @@ func (suite *AdminClientTestSuite) TestGetCategories() {
 	categories, err := suite.client.GetCategories()
 	suite.NoError(err)
 	suite.Equal([]string{"news", "tech"}, categories)
+}
+
+func (suite *AdminClientTestSuite) TestGetUser() {
+	user, err := suite.client.GetUser(suite.T().Context(), "alice")
+	suite.NoError(err)
+	suite.Equal("alice", user.UserId)
 }
 
 func TestAdminClient(t *testing.T) {

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -20,20 +20,36 @@ import (
 	"testing"
 
 	"github.com/gorse-io/gorse/client"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestAdminClient(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/api/dashboard/categories", r.URL.Path)
-		require.Equal(t, "secret", r.Header.Get("X-Api-Key"))
+type AdminClientTestSuite struct {
+	suite.Suite
+	client *client.AdminClient
+	server *httptest.Server
+}
+
+func (suite *AdminClientTestSuite) SetupSuite() {
+	suite.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		suite.Equal("/api/dashboard/categories", r.URL.Path)
+		suite.Equal("secret", r.Header.Get("X-Api-Key"))
 		w.Header().Set("Content-Type", "application/json")
 		_, err := w.Write([]byte(`["news","tech"]`))
-		require.NoError(t, err)
+		suite.NoError(err)
 	}))
-	defer server.Close()
+	suite.client = client.NewAdminClient(suite.server.URL, "secret")
+}
 
-	categories, err := client.NewAdminClient(server.URL, "secret").GetCategories()
-	require.NoError(t, err)
-	require.Equal(t, []string{"news", "tech"}, categories)
+func (suite *AdminClientTestSuite) TearDownSuite() {
+	suite.server.Close()
+}
+
+func (suite *AdminClientTestSuite) TestGetCategories() {
+	categories, err := suite.client.GetCategories()
+	suite.NoError(err)
+	suite.Equal([]string{"news", "tech"}, categories)
+}
+
+func TestAdminClient(t *testing.T) {
+	suite.Run(t, new(AdminClientTestSuite))
 }

--- a/cmd/gorse-cli/format.go
+++ b/cmd/gorse-cli/format.go
@@ -1,0 +1,71 @@
+// Copyright 2026 gorse Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	adminclient "github.com/gorse-io/gorse/client"
+)
+
+func sortFeedback(feedback []adminclient.Feedback) {
+	sort.Slice(feedback, func(i, j int) bool {
+		return feedback[i].Timestamp.After(feedback[j].Timestamp)
+	})
+}
+
+func getConfigValue(configMap map[string]any, names ...string) (string, any, bool) {
+	for _, name := range names {
+		value, ok := configMap[name]
+		if ok {
+			return name, value, true
+		}
+	}
+	return "", nil, false
+}
+
+func formatConfigMap(configMap map[string]any) map[string]any {
+	formatted := make(map[string]any, len(configMap))
+	for key, value := range configMap {
+		formatted[key] = formatConfigValue(value)
+	}
+	return formatted
+}
+
+func formatConfigValue(value any) any {
+	switch v := value.(type) {
+	case time.Duration:
+		s := v.String()
+		if strings.HasSuffix(s, "m0s") {
+			s = s[:len(s)-2]
+		}
+		if strings.HasSuffix(s, "h0m") {
+			s = s[:len(s)-2]
+		}
+		return s
+	case map[string]any:
+		return formatConfigMap(v)
+	case []any:
+		formatted := make([]any, len(v))
+		for i, item := range v {
+			formatted[i] = formatConfigValue(item)
+		}
+		return formatted
+	default:
+		return v
+	}
+}

--- a/cmd/gorse-cli/main.go
+++ b/cmd/gorse-cli/main.go
@@ -84,12 +84,7 @@ func requireEndpointAndKey(cmd *cobra.Command) (string, string) {
 	return endpoint, apiKey
 }
 
-func newGorseClient(cmd *cobra.Command) *gorse.GorseClient {
-	endpoint, apiKey := requireEndpointAndKey(cmd)
-	return gorse.NewGorseClient(strings.TrimRight(endpoint, "/"), apiKey)
-}
-
-func newAdminClient(cmd *cobra.Command) *adminclient.AdminClient {
+func newClient(cmd *cobra.Command) *adminclient.AdminClient {
 	endpoint, apiKey := requireEndpointAndKey(cmd)
 	return adminclient.NewAdminClient(endpoint, apiKey)
 }
@@ -127,7 +122,7 @@ var getClusterCmd = &cobra.Command{
 	Use:   "cluster-info",
 	Short: "List cluster nodes",
 	Run: func(cmd *cobra.Command, args []string) {
-		cluster, err := newAdminClient(cmd).GetCluster()
+		cluster, err := newClient(cmd).GetCluster()
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -139,7 +134,7 @@ var psCmd = &cobra.Command{
 	Use:   "ps",
 	Short: "List task progress",
 	Run: func(cmd *cobra.Command, args []string) {
-		tasks, err := newAdminClient(cmd).GetTasks()
+		tasks, err := newClient(cmd).GetTasks()
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -163,7 +158,7 @@ var pipelineGetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "Get recommendation pipeline configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-		configValue, err := newAdminClient(cmd).GetConfig()
+		configValue, err := newClient(cmd).GetConfig()
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -184,7 +179,7 @@ var pipelineSchemaCmd = &cobra.Command{
 	Use:   "schema",
 	Short: "Get recommendation pipeline configuration schema",
 	Run: func(cmd *cobra.Command, args []string) {
-		schema, err := newAdminClient(cmd).GetConfigSchema()
+		schema, err := newClient(cmd).GetConfigSchema()
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -209,7 +204,7 @@ var dumpCmd = &cobra.Command{
 			fatalErr(cmd, fmt.Sprintf("failed to create dump file %q", outputPath), err)
 		}
 		defer file.Close()
-		if err = newAdminClient(cmd).Dump(file); err != nil {
+		if err = newClient(cmd).Dump(file); err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), "Data dumped to "+outputPath)
@@ -237,7 +232,7 @@ var restoreCmd = &cobra.Command{
 			fatalErr(cmd, fmt.Sprintf("failed to open restore file %q", args[0]), err)
 		}
 		defer file.Close()
-		stats, err := newAdminClient(cmd).Restore(file)
+		stats, err := newClient(cmd).Restore(file)
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -256,7 +251,7 @@ var pipelinePatchCmd = &cobra.Command{
   gorse-cli pipeline patch '[{"op":"replace","path":"/cache_size","value":1000},{"op":"replace","path":"/data_source/item_ttl","value":72}]'`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		client := newAdminClient(cmd)
+		client := newClient(cmd)
 		currentConfigMap, err := client.GetConfigMap()
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
@@ -306,7 +301,7 @@ var pipelineResetCmd = &cobra.Command{
 			fmt.Fprintln(cmd.OutOrStdout(), "Pipeline reset canceled")
 			return
 		}
-		result, err := newAdminClient(cmd).ResetConfig()
+		result, err := newClient(cmd).ResetConfig()
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -322,7 +317,7 @@ var getCategoriesCmd = &cobra.Command{
 	Use:   "categories",
 	Short: "Get item categories",
 	Run: func(cmd *cobra.Command, args []string) {
-		categories, err := newAdminClient(cmd).GetCategories()
+		categories, err := newClient(cmd).GetCategories()
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -334,7 +329,7 @@ var getStatsCmd = &cobra.Command{
 	Use:   "stats",
 	Short: "Get global statistics",
 	Run: func(cmd *cobra.Command, args []string) {
-		stats, err := newAdminClient(cmd).GetStats()
+		stats, err := newClient(cmd).GetStats()
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -347,7 +342,7 @@ var getUserCmd = &cobra.Command{
 	Short: "Get user details",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		user, err := newGorseClient(cmd).GetUser(cmd.Context(), args[0])
+		user, err := newClient(cmd).GetUser(cmd.Context(), args[0])
 		if err != nil {
 			fatalErr(cmd, "API request failed", err)
 		}
@@ -360,7 +355,7 @@ var getItemCmd = &cobra.Command{
 	Short: "Get item details",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		item, err := newGorseClient(cmd).GetItem(cmd.Context(), args[0])
+		item, err := newClient(cmd).GetItem(cmd.Context(), args[0])
 		if err != nil {
 			fatalErr(cmd, "API request failed", err)
 		}
@@ -376,7 +371,7 @@ var getUsersCmd = &cobra.Command{
 		if n == 0 {
 			n = 10
 		}
-		users, err := newGorseClient(cmd).GetUsers(cmd.Context(), n, "")
+		users, err := newClient(cmd).GetUsers(cmd.Context(), n, "")
 		if err != nil {
 			fatalErr(cmd, "API request failed", err)
 		}
@@ -393,7 +388,7 @@ var getItemsCmd = &cobra.Command{
 		if n == 0 {
 			n = 10
 		}
-		client := newGorseClient(cmd)
+		client := newClient(cmd)
 		var (
 			items gorse.ItemIterator
 			err   error
@@ -422,7 +417,7 @@ var getFeedbackCmd = &cobra.Command{
 		feedbackType := lo.Must(cmd.Flags().GetString("type"))
 		userID := lo.Must(cmd.Flags().GetString("user"))
 		itemID := lo.Must(cmd.Flags().GetString("item"))
-		client := newAdminClient(cmd)
+		client := newClient(cmd)
 		var (
 			feedback []adminclient.Feedback
 			err      error
@@ -471,7 +466,7 @@ var getLatestCmd = &cobra.Command{
 		if n == 0 {
 			n = 10
 		}
-		latest, err := newAdminClient(cmd).GetLatest(n, categories)
+		latest, err := newClient(cmd).GetLatest(n, categories)
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -484,7 +479,7 @@ var getNonPersonalizedCmd = &cobra.Command{
 	Short: "Get non-personalized recommendations",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		recommendations, err := newAdminClient(cmd).GetNonPersonalized(
+		recommendations, err := newClient(cmd).GetNonPersonalized(
 			args[0],
 			lo.Must(cmd.Flags().GetInt("n")),
 			lo.Must(cmd.Flags().GetString("user-id")),
@@ -514,7 +509,7 @@ var recommendUserCmd = &cobra.Command{
 		if len(args) > 2 {
 			name = args[2]
 		}
-		recommendations, err := newAdminClient(cmd).GetRecommend(args[0], recommender, name, n, categories)
+		recommendations, err := newClient(cmd).GetRecommend(args[0], recommender, name, n, categories)
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}
@@ -527,7 +522,7 @@ var getItemToItemCmd = &cobra.Command{
 	Short: "Get item-to-item recommendations",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		recommendations, err := newAdminClient(cmd).GetItemToItem(
+		recommendations, err := newClient(cmd).GetItemToItem(
 			args[0],
 			args[1],
 			lo.Must(cmd.Flags().GetInt("n")),
@@ -545,7 +540,7 @@ var getUserToUserCmd = &cobra.Command{
 	Short: "Get user-to-user recommendations",
 	Args:  cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
-		recommendations, err := newAdminClient(cmd).GetUserToUser(args[0], args[1], lo.Must(cmd.Flags().GetInt("n")))
+		recommendations, err := newClient(cmd).GetUserToUser(args[0], args[1], lo.Must(cmd.Flags().GetInt("n")))
 		if err != nil {
 			fatalErr(cmd, "admin API request failed", err)
 		}

--- a/cmd/gorse-cli/main.go
+++ b/cmd/gorse-cli/main.go
@@ -25,6 +25,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	gorse "github.com/gorse-io/gorse-go"
+	adminclient "github.com/gorse-io/gorse/client"
 	"github.com/gorse-io/gorse/cmd/version"
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
@@ -88,9 +89,9 @@ func newGorseClient(cmd *cobra.Command) *gorse.GorseClient {
 	return gorse.NewGorseClient(strings.TrimRight(endpoint, "/"), apiKey)
 }
 
-func newAdminClient(cmd *cobra.Command) *AdminClient {
+func newAdminClient(cmd *cobra.Command) *adminclient.AdminClient {
 	endpoint, apiKey := requireEndpointAndKey(cmd)
-	return NewAdminClient(endpoint, apiKey)
+	return adminclient.NewAdminClient(endpoint, apiKey)
 }
 
 // getCmd is the parent command for get operations
@@ -423,14 +424,14 @@ var getFeedbackCmd = &cobra.Command{
 		itemID := lo.Must(cmd.Flags().GetString("item"))
 		client := newAdminClient(cmd)
 		var (
-			feedback []Feedback
+			feedback []adminclient.Feedback
 			err      error
 		)
 		switch {
 		case userID != "" && itemID != "" && feedbackType != "":
 			record, requestErr := client.GetTypedUserItemFeedback(feedbackType, userID, itemID)
 			err = requestErr
-			feedback = []Feedback{record}
+			feedback = []adminclient.Feedback{record}
 		case userID != "" && itemID != "":
 			feedback, err = client.GetUserItemFeedback(userID, itemID)
 		case userID != "" && feedbackType != "":

--- a/cmd/gorse-cli/main_test.go
+++ b/cmd/gorse-cli/main_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 	"unsafe"
 
+	adminclient "github.com/gorse-io/gorse/client"
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
 	"github.com/gorse-io/gorse/config"
@@ -567,7 +568,7 @@ func waitForMaster(t *testing.T, endpoint string) {
 
 func waitForInitialTask(t *testing.T, endpoint string) {
 	t.Helper()
-	client := NewAdminClient(endpoint, testAPIKey)
+	client := adminclient.NewAdminClient(endpoint, testAPIKey)
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		tasks, err := client.GetTasks()


### PR DESCRIPTION
## Summary

- move the Gorse admin API client from `cmd/gorse-cli` to the reusable `client` package
- expose it as `client.AdminClient` while keeping CLI-only formatting helpers in `cmd/gorse-cli`
- add an external-package test for the public constructor, API path, authentication header, and response decoding

## Tests

- `/usr/local/go/bin/go test ./client -run '^TestAdminClient$' -count=1`
- `/usr/local/go/bin/go test ./cmd/gorse-cli ./client`
- `/usr/local/go/bin/go vet ./client ./cmd/gorse-cli`
- `/usr/local/go/bin/go test ./...`
