### PR TITLE
test(client): cover admin feedback methods

### DIFF
--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -39,6 +39,11 @@ func (suite *AdminClientTestSuite) SetupSuite() {
 			response = `["news","tech"]`
 		case "/api/user/alice":
 			response = `{"UserId":"alice"}`
+		case "/api/feedback/click":
+			suite.Equal("1", r.URL.Query().Get("n"))
+			response = `{"Feedback":[]}`
+		case "/api/feedback/alice/item", "/api/user/alice/feedback", "/api/item/item/feedback/":
+			response = `[]`
 		default:
 			suite.Fail("unexpected request path", r.URL.Path)
 		}
@@ -62,6 +67,17 @@ func (suite *AdminClientTestSuite) TestGetUser() {
 	user, err := suite.client.GetUser(suite.T().Context(), "alice")
 	suite.NoError(err)
 	suite.Equal("alice", user.UserId)
+}
+
+func (suite *AdminClientTestSuite) TestGetFeedback() {
+	_, err := suite.client.GetTypedFeedback("click", 1)
+	suite.NoError(err)
+	_, err = suite.client.GetUserItemFeedback("alice", "item")
+	suite.NoError(err)
+	_, err = suite.client.GetUserFeedback("alice")
+	suite.NoError(err)
+	_, err = suite.client.GetItemFeedback("item")
+	suite.NoError(err)
 }
 
 func TestAdminClient(t *testing.T) {


### PR DESCRIPTION
## Summary

- cover the Admin client feedback query methods that were left uncovered after #1340
- verify the inlined `n` query parameter and feedback endpoint paths

## Tests

- `/usr/local/go/bin/go test ./client -run 'TestAdminClient/TestGetFeedback' -count=1`
- `/usr/local/go/bin/go test ./...`
