### PR TITLE
feat(client): add GetTimeseries

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -121,6 +121,12 @@ type DumpStats struct {
 	Duration time.Duration
 }
 
+type TimeSeriesPoint struct {
+	Name      string
+	Timestamp time.Time
+	Value     float64
+}
+
 // NewAdminClient creates a new client for the Gorse admin API.
 func NewAdminClient(endpoint, apiKey string) *AdminClient {
 	endpoint = strings.TrimRight(endpoint, "/")
@@ -189,6 +195,20 @@ func (c *AdminClient) GetCategories() ([]string, error) {
 
 func (c *AdminClient) GetStats() (Status, error) {
 	return get[Status](c, "/dashboard/stats", nil)
+}
+
+func (c *AdminClient) GetTimeseries(name, begin, end, duration string) ([]TimeSeriesPoint, error) {
+	params := url.Values{}
+	if begin != "" {
+		params.Set("begin", begin)
+	}
+	if end != "" {
+		params.Set("end", end)
+	}
+	if duration != "" {
+		params.Set("duration", duration)
+	}
+	return get[[]TimeSeriesPoint](c, "/dashboard/timeseries/"+url.PathEscape(name), params)
 }
 
 func (c *AdminClient) GetFeedback(n int) (FeedbackIterator, error) {

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -16,7 +16,6 @@ package client_test
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -46,7 +45,6 @@ func (suite *AdminClientTestSuite) SetupSuite() {
 	cfg.Database.CacheStore = "sqlite://" + filepath.Join(tempDir, "cache.db")
 	cfg.Blob.URI = filepath.Join(tempDir, "blob")
 	cfg.Master.Host = "127.0.0.1"
-	cfg.Master.Port, cfg.Master.HttpPort = freePorts(suite.T())
 	cfg.Master.HttpHost = "127.0.0.1"
 	cfg.Master.AdminAPIKey = "secret"
 	cfg.OpenAI.AuthToken = "test"
@@ -94,17 +92,6 @@ func (suite *AdminClientTestSuite) TestGetUser() {
 
 func TestAdminClient(t *testing.T) {
 	suite.Run(t, new(AdminClientTestSuite))
-}
-
-func freePorts(t *testing.T) (int, int) {
-	t.Helper()
-	grpcListener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer grpcListener.Close()
-	httpListener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer httpListener.Close()
-	return grpcListener.Addr().(*net.TCPAddr).Port, httpListener.Addr().(*net.TCPAddr).Port
 }
 
 func waitForMaster(t *testing.T, endpoint string) {

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -43,6 +43,7 @@ func (suite *AdminClientTestSuite) SetupSuite() {
 	cfg := config.GetDefaultConfig()
 	cfg.Database.DataStore = "sqlite://" + filepath.Join(tempDir, "data.db")
 	cfg.Database.CacheStore = "sqlite://" + filepath.Join(tempDir, "cache.db")
+	cfg.Database.VectorStore = "sqlite://" + filepath.Join(tempDir, "vector.db")
 	cfg.Blob.URI = filepath.Join(tempDir, "blob")
 	cfg.Master.Host = "127.0.0.1"
 	cfg.Master.Port = 18086

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -64,11 +64,6 @@ func (suite *AdminClientTestSuite) SetupSuite() {
 		{Id: "news", Score: 2},
 		{Id: "tech", Score: 1},
 	}))
-	suite.Require().NoError(suite.master.CacheClient.AddTimeSeriesPoints(ctx, []cache.TimeSeriesPoint{{
-		Name:      "requests",
-		Timestamp: time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
-		Value:     1,
-	}}))
 }
 
 func (suite *AdminClientTestSuite) TearDownSuite() {
@@ -82,6 +77,11 @@ func (suite *AdminClientTestSuite) TestGetCategories() {
 }
 
 func (suite *AdminClientTestSuite) TestGetTimeseries() {
+	suite.Require().NoError(suite.master.CacheClient.AddTimeSeriesPoints(suite.T().Context(), []cache.TimeSeriesPoint{{
+		Name:      "requests",
+		Timestamp: time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+		Value:     1,
+	}}))
 	points, err := suite.client.GetTimeseries("requests", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z", "1h")
 	suite.NoError(err)
 	suite.Equal("requests", points[0].Name)

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -46,9 +46,8 @@ func (suite *AdminClientTestSuite) SetupSuite() {
 	cfg.Database.CacheStore = "sqlite://" + filepath.Join(tempDir, "cache.db")
 	cfg.Blob.URI = filepath.Join(tempDir, "blob")
 	cfg.Master.Host = "127.0.0.1"
-	cfg.Master.Port = freePort(suite.T())
+	cfg.Master.Port, cfg.Master.HttpPort = freePorts(suite.T())
 	cfg.Master.HttpHost = "127.0.0.1"
-	cfg.Master.HttpPort = freePort(suite.T())
 	cfg.Master.AdminAPIKey = "secret"
 	cfg.OpenAI.AuthToken = "test"
 
@@ -97,12 +96,15 @@ func TestAdminClient(t *testing.T) {
 	suite.Run(t, new(AdminClientTestSuite))
 }
 
-func freePort(t *testing.T) int {
+func freePorts(t *testing.T) (int, int) {
 	t.Helper()
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	grpcListener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	defer listener.Close()
-	return listener.Addr().(*net.TCPAddr).Port
+	defer grpcListener.Close()
+	httpListener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer httpListener.Close()
+	return grpcListener.Addr().(*net.TCPAddr).Port, httpListener.Addr().(*net.TCPAddr).Port
 }
 
 func waitForMaster(t *testing.T, endpoint string) {

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -15,47 +15,64 @@
 package client_test
 
 import (
+	"fmt"
+	"net"
 	"net/http"
-	"net/http/httptest"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/gorse-io/gorse/client"
+	"github.com/gorse-io/gorse/common/log"
+	"github.com/gorse-io/gorse/config"
+	"github.com/gorse-io/gorse/master"
+	"github.com/gorse-io/gorse/storage/cache"
+	"github.com/gorse-io/gorse/storage/data"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type AdminClientTestSuite struct {
 	suite.Suite
 	client *client.AdminClient
-	server *httptest.Server
+	master *master.Master
 }
 
 func (suite *AdminClientTestSuite) SetupSuite() {
-	suite.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		suite.Equal("secret", r.Header.Get("X-Api-Key"))
-		w.Header().Set("Content-Type", "application/json")
-		var response string
-		switch r.URL.Path {
-		case "/api/dashboard/categories":
-			response = `["news","tech"]`
-		case "/api/dashboard/timeseries/requests":
-			suite.Equal("2026-01-01T00:00:00Z", r.URL.Query().Get("begin"))
-			suite.Equal("2026-01-02T00:00:00Z", r.URL.Query().Get("end"))
-			suite.Equal("1h", r.URL.Query().Get("duration"))
-			response = `[{"Name":"requests","Timestamp":"2026-01-01T01:00:00Z","Value":1}]`
-		case "/api/user/alice":
-			response = `{"UserId":"alice"}`
-		default:
-			suite.Fail("unexpected request path", r.URL.Path)
-		}
-		_, err := w.Write([]byte(response))
-		suite.NoError(err)
+	log.SetTestLogger(suite.T())
+	tempDir := suite.T().TempDir()
+	cfg := config.GetDefaultConfig()
+	cfg.Database.DataStore = "sqlite://" + filepath.Join(tempDir, "data.db")
+	cfg.Database.CacheStore = "sqlite://" + filepath.Join(tempDir, "cache.db")
+	cfg.Blob.URI = filepath.Join(tempDir, "blob")
+	cfg.Master.Host = "127.0.0.1"
+	cfg.Master.Port = freePort(suite.T())
+	cfg.Master.HttpHost = "127.0.0.1"
+	cfg.Master.HttpPort = freePort(suite.T())
+	cfg.Master.AdminAPIKey = "secret"
+	cfg.OpenAI.AuthToken = "test"
+
+	suite.master = master.NewMaster(cfg, tempDir, true, "")
+	go suite.master.Serve()
+	endpoint := fmt.Sprintf("http://%s:%d", cfg.Master.HttpHost, cfg.Master.HttpPort)
+	waitForMaster(suite.T(), endpoint)
+	suite.client = client.NewAdminClient(endpoint, cfg.Master.AdminAPIKey)
+
+	ctx := suite.T().Context()
+	suite.Require().NoError(suite.master.DataClient.BatchInsertUsers(ctx, []data.User{{UserId: "alice"}}))
+	suite.Require().NoError(suite.master.CacheClient.AddScores(ctx, cache.ItemCategories, "", []cache.Score{
+		{Id: "news", Score: 2},
+		{Id: "tech", Score: 1},
 	}))
-	suite.client = client.NewAdminClient(suite.server.URL, "secret")
+	suite.Require().NoError(suite.master.CacheClient.AddTimeSeriesPoints(ctx, []cache.TimeSeriesPoint{{
+		Name:      "requests",
+		Timestamp: time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC),
+		Value:     1,
+	}}))
 }
 
 func (suite *AdminClientTestSuite) TearDownSuite() {
-	suite.server.Close()
+	suite.master.Shutdown()
 }
 
 func (suite *AdminClientTestSuite) TestGetCategories() {
@@ -80,4 +97,29 @@ func (suite *AdminClientTestSuite) TestGetUser() {
 
 func TestAdminClient(t *testing.T) {
 	suite.Run(t, new(AdminClientTestSuite))
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+func waitForMaster(t *testing.T, endpoint string) {
+	t.Helper()
+	client := http.Client{Timeout: time.Second}
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(endpoint + "/api/health/live")
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.Fail(t, "master didn't become ready")
 }

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gorse-io/gorse/client"
 	"github.com/stretchr/testify/suite"
@@ -37,6 +38,11 @@ func (suite *AdminClientTestSuite) SetupSuite() {
 		switch r.URL.Path {
 		case "/api/dashboard/categories":
 			response = `["news","tech"]`
+		case "/api/dashboard/timeseries/requests":
+			suite.Equal("2026-01-01T00:00:00Z", r.URL.Query().Get("begin"))
+			suite.Equal("2026-01-02T00:00:00Z", r.URL.Query().Get("end"))
+			suite.Equal("1h", r.URL.Query().Get("duration"))
+			response = `[{"Name":"requests","Timestamp":"2026-01-01T01:00:00Z","Value":1}]`
 		case "/api/user/alice":
 			response = `{"UserId":"alice"}`
 		default:
@@ -56,6 +62,14 @@ func (suite *AdminClientTestSuite) TestGetCategories() {
 	categories, err := suite.client.GetCategories()
 	suite.NoError(err)
 	suite.Equal([]string{"news", "tech"}, categories)
+}
+
+func (suite *AdminClientTestSuite) TestGetTimeseries() {
+	points, err := suite.client.GetTimeseries("requests", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z", "1h")
+	suite.NoError(err)
+	suite.Equal("requests", points[0].Name)
+	suite.Equal(time.Date(2026, 1, 1, 1, 0, 0, 0, time.UTC), points[0].Timestamp)
+	suite.Equal(float64(1), points[0].Value)
 }
 
 func (suite *AdminClientTestSuite) TestGetUser() {

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -45,7 +45,9 @@ func (suite *AdminClientTestSuite) SetupSuite() {
 	cfg.Database.CacheStore = "sqlite://" + filepath.Join(tempDir, "cache.db")
 	cfg.Blob.URI = filepath.Join(tempDir, "blob")
 	cfg.Master.Host = "127.0.0.1"
+	cfg.Master.Port = 18086
 	cfg.Master.HttpHost = "127.0.0.1"
+	cfg.Master.HttpPort = 18088
 	cfg.Master.AdminAPIKey = "secret"
 	cfg.OpenAI.AuthToken = "test"
 

--- a/client/admin_test.go
+++ b/client/admin_test.go
@@ -57,13 +57,6 @@ func (suite *AdminClientTestSuite) SetupSuite() {
 	endpoint := fmt.Sprintf("http://%s:%d", cfg.Master.HttpHost, cfg.Master.HttpPort)
 	waitForMaster(suite.T(), endpoint)
 	suite.client = client.NewAdminClient(endpoint, cfg.Master.AdminAPIKey)
-
-	ctx := suite.T().Context()
-	suite.Require().NoError(suite.master.DataClient.BatchInsertUsers(ctx, []data.User{{UserId: "alice"}}))
-	suite.Require().NoError(suite.master.CacheClient.AddScores(ctx, cache.ItemCategories, "", []cache.Score{
-		{Id: "news", Score: 2},
-		{Id: "tech", Score: 1},
-	}))
 }
 
 func (suite *AdminClientTestSuite) TearDownSuite() {
@@ -71,6 +64,10 @@ func (suite *AdminClientTestSuite) TearDownSuite() {
 }
 
 func (suite *AdminClientTestSuite) TestGetCategories() {
+	suite.Require().NoError(suite.master.CacheClient.AddScores(suite.T().Context(), cache.ItemCategories, "", []cache.Score{
+		{Id: "news", Score: 2},
+		{Id: "tech", Score: 1},
+	}))
 	categories, err := suite.client.GetCategories()
 	suite.NoError(err)
 	suite.Equal([]string{"news", "tech"}, categories)
@@ -90,6 +87,7 @@ func (suite *AdminClientTestSuite) TestGetTimeseries() {
 }
 
 func (suite *AdminClientTestSuite) TestGetUser() {
+	suite.Require().NoError(suite.master.DataClient.BatchInsertUsers(suite.T().Context(), []data.User{{UserId: "alice"}}))
 	user, err := suite.client.GetUser(suite.T().Context(), "alice")
 	suite.NoError(err)
 	suite.Equal("alice", user.UserId)

--- a/cmd/gorse-cli/main_test.go
+++ b/cmd/gorse-cli/main_test.go
@@ -495,6 +495,7 @@ func newTestMaster(t *testing.T) (*master.Master, string) {
 	cfg := config.GetDefaultConfig()
 	cfg.Database.DataStore = "sqlite://" + filepath.Join(tempDir, "data.db")
 	cfg.Database.CacheStore = "sqlite://" + filepath.Join(tempDir, "cache.db")
+	cfg.Database.VectorStore = "sqlite://" + filepath.Join(tempDir, "vector.db")
 	cfg.Blob.URI = filepath.Join(tempDir, "blob")
 	cfg.Master.Host = "127.0.0.1"
 	cfg.Master.Port = freePort(t)


### PR DESCRIPTION
## Summary

- add `AdminClient.GetTimeseries` for the dashboard time-series endpoint
- expose `TimeSeriesPoint` in the reusable client package
- test query parameters and response decoding

## Test

- `/usr/local/go/bin/go test ./client -count=1`
- `/usr/local/go/bin/go vet ./client`
