### PR TITLE
fix(cli): make installer compatible with sh

### DIFF
--- a/cmd/gorse-cli/install.sh
+++ b/cmd/gorse-cli/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
+set -eu
 
 REPO="${GORSE_REPO:-gorse-io/gorse}"
 VERSION="${GORSE_CLI_VERSION:-latest}"


### PR DESCRIPTION
## What does this PR do?

Make `cmd/gorse-cli/install.sh` compatible with `curl ... | sh` on systems where `/bin/sh` is `dash`.

Invoking the installer through `sh` ignores its Bash shebang, and `dash` rejects `set -o pipefail`. The installer does not contain pipelines, so keeping `-eu` preserves its existing error and unset-variable handling without requiring Bash.

## Test

- `sh -n cmd/gorse-cli/install.sh`
- `dash -n cmd/gorse-cli/install.sh`
- Executed the script through `curl ... | sh` with a mocked release download and verified that the installed executable runs
- `git diff --check`
