### PR TITLE
feat(storage): count vectors

### DIFF
--- a/protocol/vector_store.pb.go
+++ b/protocol/vector_store.pb.go
@@ -872,6 +872,94 @@ func (x *QueryVectorsResponse) GetVectors() []*Vector {
 	return nil
 }
 
+type CountVectorsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Collection    string                 `protobuf:"bytes,1,opt,name=collection,proto3" json:"collection,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CountVectorsRequest) Reset() {
+	*x = CountVectorsRequest{}
+	mi := &file_vector_store_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CountVectorsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CountVectorsRequest) ProtoMessage() {}
+
+func (x *CountVectorsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_vector_store_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CountVectorsRequest.ProtoReflect.Descriptor instead.
+func (*CountVectorsRequest) Descriptor() ([]byte, []int) {
+	return file_vector_store_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *CountVectorsRequest) GetCollection() string {
+	if x != nil {
+		return x.Collection
+	}
+	return ""
+}
+
+type CountVectorsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Count         int64                  `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CountVectorsResponse) Reset() {
+	*x = CountVectorsResponse{}
+	mi := &file_vector_store_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CountVectorsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CountVectorsResponse) ProtoMessage() {}
+
+func (x *CountVectorsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_vector_store_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CountVectorsResponse.ProtoReflect.Descriptor instead.
+func (*CountVectorsResponse) Descriptor() ([]byte, []int) {
+	return file_vector_store_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *CountVectorsResponse) GetCount() int64 {
+	if x != nil {
+		return x.Count
+	}
+	return 0
+}
+
 var File_vector_store_proto protoreflect.FileDescriptor
 
 const file_vector_store_proto_rawDesc = "" +
@@ -932,18 +1020,25 @@ const file_vector_store_proto_rawDesc = "" +
 	"categories\x12\x13\n" +
 	"\x05top_k\x18\x04 \x01(\x05R\x04topK\"B\n" +
 	"\x14QueryVectorsResponse\x12*\n" +
-	"\avectors\x18\x01 \x03(\v2\x10.protocol.VectorR\avectors*;\n" +
+	"\avectors\x18\x01 \x03(\v2\x10.protocol.VectorR\avectors\"5\n" +
+	"\x13CountVectorsRequest\x12\x1e\n" +
+	"\n" +
+	"collection\x18\x01 \x01(\tR\n" +
+	"collection\",\n" +
+	"\x14CountVectorsResponse\x12\x14\n" +
+	"\x05count\x18\x01 \x01(\x03R\x05count*;\n" +
 	"\bDistance\x12\v\n" +
 	"\aUnknown\x10\x00\x12\n" +
 	"\n" +
 	"\x06Cosine\x10\x01\x12\r\n" +
 	"\tEuclidean\x10\x02\x12\a\n" +
-	"\x03Dot\x10\x032\xeb\x04\n" +
+	"\x03Dot\x10\x032\xbc\x05\n" +
 	"\vVectorStore\x12X\n" +
 	"\x0fListCollections\x12 .protocol.ListCollectionsRequest\x1a!.protocol.ListCollectionsResponse\"\x00\x12a\n" +
 	"\x12DescribeCollection\x12#.protocol.DescribeCollectionRequest\x1a$.protocol.DescribeCollectionResponse\"\x00\x12R\n" +
 	"\rAddCollection\x12\x1e.protocol.AddCollectionRequest\x1a\x1f.protocol.AddCollectionResponse\"\x00\x12[\n" +
-	"\x10DeleteCollection\x12!.protocol.DeleteCollectionRequest\x1a\".protocol.DeleteCollectionResponse\"\x00\x12I\n" +
+	"\x10DeleteCollection\x12!.protocol.DeleteCollectionRequest\x1a\".protocol.DeleteCollectionResponse\"\x00\x12O\n" +
+	"\fCountVectors\x12\x1d.protocol.CountVectorsRequest\x1a\x1e.protocol.CountVectorsResponse\"\x00\x12I\n" +
 	"\n" +
 	"AddVectors\x12\x1b.protocol.AddVectorsRequest\x1a\x1c.protocol.AddVectorsResponse\"\x00\x12R\n" +
 	"\rDeleteVectors\x12\x1e.protocol.DeleteVectorsRequest\x1a\x1f.protocol.DeleteVectorsResponse\"\x00\x12O\n" +
@@ -962,7 +1057,7 @@ func file_vector_store_proto_rawDescGZIP() []byte {
 }
 
 var file_vector_store_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_vector_store_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
+var file_vector_store_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_vector_store_proto_goTypes = []any{
 	(Distance)(0),                      // 0: protocol.Distance
 	(*Vector)(nil),                     // 1: protocol.Vector
@@ -981,33 +1076,37 @@ var file_vector_store_proto_goTypes = []any{
 	(*DeleteVectorsResponse)(nil),      // 14: protocol.DeleteVectorsResponse
 	(*QueryVectorsRequest)(nil),        // 15: protocol.QueryVectorsRequest
 	(*QueryVectorsResponse)(nil),       // 16: protocol.QueryVectorsResponse
-	(*timestamppb.Timestamp)(nil),      // 17: google.protobuf.Timestamp
+	(*CountVectorsRequest)(nil),        // 17: protocol.CountVectorsRequest
+	(*CountVectorsResponse)(nil),       // 18: protocol.CountVectorsResponse
+	(*timestamppb.Timestamp)(nil),      // 19: google.protobuf.Timestamp
 }
 var file_vector_store_proto_depIdxs = []int32{
-	17, // 0: protocol.Vector.timestamp:type_name -> google.protobuf.Timestamp
+	19, // 0: protocol.Vector.timestamp:type_name -> google.protobuf.Timestamp
 	0,  // 1: protocol.DescribeCollectionResponse.distance:type_name -> protocol.Distance
 	4,  // 2: protocol.DescribeCollectionResponse.config:type_name -> protocol.VectorConfig
 	0,  // 3: protocol.AddCollectionRequest.distance:type_name -> protocol.Distance
 	4,  // 4: protocol.AddCollectionRequest.config:type_name -> protocol.VectorConfig
 	1,  // 5: protocol.AddVectorsRequest.vectors:type_name -> protocol.Vector
-	17, // 6: protocol.DeleteVectorsRequest.timestamp:type_name -> google.protobuf.Timestamp
+	19, // 6: protocol.DeleteVectorsRequest.timestamp:type_name -> google.protobuf.Timestamp
 	1,  // 7: protocol.QueryVectorsResponse.vectors:type_name -> protocol.Vector
 	2,  // 8: protocol.VectorStore.ListCollections:input_type -> protocol.ListCollectionsRequest
 	5,  // 9: protocol.VectorStore.DescribeCollection:input_type -> protocol.DescribeCollectionRequest
 	7,  // 10: protocol.VectorStore.AddCollection:input_type -> protocol.AddCollectionRequest
 	9,  // 11: protocol.VectorStore.DeleteCollection:input_type -> protocol.DeleteCollectionRequest
-	11, // 12: protocol.VectorStore.AddVectors:input_type -> protocol.AddVectorsRequest
-	13, // 13: protocol.VectorStore.DeleteVectors:input_type -> protocol.DeleteVectorsRequest
-	15, // 14: protocol.VectorStore.QueryVectors:input_type -> protocol.QueryVectorsRequest
-	3,  // 15: protocol.VectorStore.ListCollections:output_type -> protocol.ListCollectionsResponse
-	6,  // 16: protocol.VectorStore.DescribeCollection:output_type -> protocol.DescribeCollectionResponse
-	8,  // 17: protocol.VectorStore.AddCollection:output_type -> protocol.AddCollectionResponse
-	10, // 18: protocol.VectorStore.DeleteCollection:output_type -> protocol.DeleteCollectionResponse
-	12, // 19: protocol.VectorStore.AddVectors:output_type -> protocol.AddVectorsResponse
-	14, // 20: protocol.VectorStore.DeleteVectors:output_type -> protocol.DeleteVectorsResponse
-	16, // 21: protocol.VectorStore.QueryVectors:output_type -> protocol.QueryVectorsResponse
-	15, // [15:22] is the sub-list for method output_type
-	8,  // [8:15] is the sub-list for method input_type
+	17, // 12: protocol.VectorStore.CountVectors:input_type -> protocol.CountVectorsRequest
+	11, // 13: protocol.VectorStore.AddVectors:input_type -> protocol.AddVectorsRequest
+	13, // 14: protocol.VectorStore.DeleteVectors:input_type -> protocol.DeleteVectorsRequest
+	15, // 15: protocol.VectorStore.QueryVectors:input_type -> protocol.QueryVectorsRequest
+	3,  // 16: protocol.VectorStore.ListCollections:output_type -> protocol.ListCollectionsResponse
+	6,  // 17: protocol.VectorStore.DescribeCollection:output_type -> protocol.DescribeCollectionResponse
+	8,  // 18: protocol.VectorStore.AddCollection:output_type -> protocol.AddCollectionResponse
+	10, // 19: protocol.VectorStore.DeleteCollection:output_type -> protocol.DeleteCollectionResponse
+	18, // 20: protocol.VectorStore.CountVectors:output_type -> protocol.CountVectorsResponse
+	12, // 21: protocol.VectorStore.AddVectors:output_type -> protocol.AddVectorsResponse
+	14, // 22: protocol.VectorStore.DeleteVectors:output_type -> protocol.DeleteVectorsResponse
+	16, // 23: protocol.VectorStore.QueryVectors:output_type -> protocol.QueryVectorsResponse
+	16, // [16:24] is the sub-list for method output_type
+	8,  // [8:16] is the sub-list for method input_type
 	8,  // [8:8] is the sub-list for extension type_name
 	8,  // [8:8] is the sub-list for extension extendee
 	0,  // [0:8] is the sub-list for field type_name
@@ -1024,7 +1123,7 @@ func file_vector_store_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_vector_store_proto_rawDesc), len(file_vector_store_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   16,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protocol/vector_store.proto
+++ b/protocol/vector_store.proto
@@ -88,11 +88,16 @@ message QueryVectorsRequest {
 
 message QueryVectorsResponse { repeated Vector vectors = 1; }
 
+message CountVectorsRequest { string collection = 1; }
+
+message CountVectorsResponse { int64 count = 1; }
+
 service VectorStore {
   rpc ListCollections(ListCollectionsRequest) returns (ListCollectionsResponse) {}
   rpc DescribeCollection(DescribeCollectionRequest) returns (DescribeCollectionResponse) {}
   rpc AddCollection(AddCollectionRequest) returns (AddCollectionResponse) {}
   rpc DeleteCollection(DeleteCollectionRequest) returns (DeleteCollectionResponse) {}
+  rpc CountVectors(CountVectorsRequest) returns (CountVectorsResponse) {}
   rpc AddVectors(AddVectorsRequest) returns (AddVectorsResponse) {}
   rpc DeleteVectors(DeleteVectorsRequest) returns (DeleteVectorsResponse) {}
   rpc QueryVectors(QueryVectorsRequest) returns (QueryVectorsResponse) {}

--- a/protocol/vector_store_grpc.pb.go
+++ b/protocol/vector_store_grpc.pb.go
@@ -37,6 +37,7 @@ const (
 	VectorStore_DescribeCollection_FullMethodName = "/protocol.VectorStore/DescribeCollection"
 	VectorStore_AddCollection_FullMethodName      = "/protocol.VectorStore/AddCollection"
 	VectorStore_DeleteCollection_FullMethodName   = "/protocol.VectorStore/DeleteCollection"
+	VectorStore_CountVectors_FullMethodName       = "/protocol.VectorStore/CountVectors"
 	VectorStore_AddVectors_FullMethodName         = "/protocol.VectorStore/AddVectors"
 	VectorStore_DeleteVectors_FullMethodName      = "/protocol.VectorStore/DeleteVectors"
 	VectorStore_QueryVectors_FullMethodName       = "/protocol.VectorStore/QueryVectors"
@@ -50,6 +51,7 @@ type VectorStoreClient interface {
 	DescribeCollection(ctx context.Context, in *DescribeCollectionRequest, opts ...grpc.CallOption) (*DescribeCollectionResponse, error)
 	AddCollection(ctx context.Context, in *AddCollectionRequest, opts ...grpc.CallOption) (*AddCollectionResponse, error)
 	DeleteCollection(ctx context.Context, in *DeleteCollectionRequest, opts ...grpc.CallOption) (*DeleteCollectionResponse, error)
+	CountVectors(ctx context.Context, in *CountVectorsRequest, opts ...grpc.CallOption) (*CountVectorsResponse, error)
 	AddVectors(ctx context.Context, in *AddVectorsRequest, opts ...grpc.CallOption) (*AddVectorsResponse, error)
 	DeleteVectors(ctx context.Context, in *DeleteVectorsRequest, opts ...grpc.CallOption) (*DeleteVectorsResponse, error)
 	QueryVectors(ctx context.Context, in *QueryVectorsRequest, opts ...grpc.CallOption) (*QueryVectorsResponse, error)
@@ -103,6 +105,16 @@ func (c *vectorStoreClient) DeleteCollection(ctx context.Context, in *DeleteColl
 	return out, nil
 }
 
+func (c *vectorStoreClient) CountVectors(ctx context.Context, in *CountVectorsRequest, opts ...grpc.CallOption) (*CountVectorsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CountVectorsResponse)
+	err := c.cc.Invoke(ctx, VectorStore_CountVectors_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *vectorStoreClient) AddVectors(ctx context.Context, in *AddVectorsRequest, opts ...grpc.CallOption) (*AddVectorsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AddVectorsResponse)
@@ -141,6 +153,7 @@ type VectorStoreServer interface {
 	DescribeCollection(context.Context, *DescribeCollectionRequest) (*DescribeCollectionResponse, error)
 	AddCollection(context.Context, *AddCollectionRequest) (*AddCollectionResponse, error)
 	DeleteCollection(context.Context, *DeleteCollectionRequest) (*DeleteCollectionResponse, error)
+	CountVectors(context.Context, *CountVectorsRequest) (*CountVectorsResponse, error)
 	AddVectors(context.Context, *AddVectorsRequest) (*AddVectorsResponse, error)
 	DeleteVectors(context.Context, *DeleteVectorsRequest) (*DeleteVectorsResponse, error)
 	QueryVectors(context.Context, *QueryVectorsRequest) (*QueryVectorsResponse, error)
@@ -165,6 +178,9 @@ func (UnimplementedVectorStoreServer) AddCollection(context.Context, *AddCollect
 }
 func (UnimplementedVectorStoreServer) DeleteCollection(context.Context, *DeleteCollectionRequest) (*DeleteCollectionResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteCollection not implemented")
+}
+func (UnimplementedVectorStoreServer) CountVectors(context.Context, *CountVectorsRequest) (*CountVectorsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CountVectors not implemented")
 }
 func (UnimplementedVectorStoreServer) AddVectors(context.Context, *AddVectorsRequest) (*AddVectorsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddVectors not implemented")
@@ -268,6 +284,24 @@ func _VectorStore_DeleteCollection_Handler(srv interface{}, ctx context.Context,
 	return interceptor(ctx, in, info, handler)
 }
 
+func _VectorStore_CountVectors_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CountVectorsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(VectorStoreServer).CountVectors(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: VectorStore_CountVectors_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(VectorStoreServer).CountVectors(ctx, req.(*CountVectorsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _VectorStore_AddVectors_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(AddVectorsRequest)
 	if err := dec(in); err != nil {
@@ -344,6 +378,10 @@ var VectorStore_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteCollection",
 			Handler:    _VectorStore_DeleteCollection_Handler,
+		},
+		{
+			MethodName: "CountVectors",
+			Handler:    _VectorStore_CountVectors_Handler,
 		},
 		{
 			MethodName: "AddVectors",

--- a/storage/vectors/database.go
+++ b/storage/vectors/database.go
@@ -90,6 +90,7 @@ type Database interface {
 	DescribeCollection(ctx context.Context, name string) (*CollectionInfo, error)
 	AddCollection(ctx context.Context, name string, dimensions int, distance Distance, config VectorConfig) error
 	DeleteCollection(ctx context.Context, name string) error
+	CountVectors(ctx context.Context, collection string) (int64, error)
 	AddVectors(ctx context.Context, collection string, vectors []Vector) error
 	DeleteVectors(ctx context.Context, collection string, timestamp time.Time) error
 	QueryVectors(ctx context.Context, collection string, q []float32, categories []string, topK int) ([]Vector, error)

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -79,46 +79,13 @@ func (suite *vectorsTestSuite) TestCollections() {
 	suite.Error(err)
 }
 
-func (suite *vectorsTestSuite) TestCountVectors() {
-	ctx := suite.T().Context()
-	err := suite.Database.AddCollection(ctx, "test", defaultVectorSize, Cosine, VectorConfig{})
-	suite.NoError(err)
-
-	count, err := suite.Database.CountVectors(ctx, "test")
-	suite.NoError(err)
-	suite.Zero(count)
-
-	cutoff := time.Now().UTC().Truncate(time.Millisecond)
-	err = suite.Database.AddVectors(ctx, "test", []Vector{
-		{
-			Id:        "old",
-			Vector:    make([]float32, defaultVectorSize),
-			Timestamp: cutoff.Add(-time.Hour),
-		},
-		{
-			Id:        "new",
-			Vector:    make([]float32, defaultVectorSize),
-			Timestamp: cutoff,
-		},
-	})
-	suite.NoError(err)
-
-	count, err = suite.Database.CountVectors(ctx, "test")
-	suite.NoError(err)
-	suite.Equal(int64(2), count)
-
-	err = suite.Database.DeleteVectors(ctx, "test", cutoff)
-	suite.NoError(err)
-
-	count, err = suite.Database.CountVectors(ctx, "test")
-	suite.NoError(err)
-	suite.Equal(int64(1), count)
-}
-
 func (suite *vectorsTestSuite) TestVectors() {
 	ctx := suite.T().Context()
 	err := suite.Database.AddCollection(ctx, "test", defaultVectorSize, Cosine, VectorConfig{})
 	suite.NoError(err)
+	count, err := suite.Database.CountVectors(ctx, "test")
+	suite.NoError(err)
+	suite.Zero(count)
 
 	vectorA := make([]float32, defaultVectorSize)
 	vectorA[0] = 1
@@ -139,6 +106,9 @@ func (suite *vectorsTestSuite) TestVectors() {
 		},
 	})
 	suite.NoError(err)
+	count, err = suite.Database.CountVectors(ctx, "test")
+	suite.NoError(err)
+	suite.Equal(int64(2), count)
 
 	results, err := suite.Database.QueryVectors(ctx, "test", vectorA, []string{"cat-a"}, 10)
 	suite.NoError(err)
@@ -195,6 +165,9 @@ func (suite *vectorsTestSuite) TestDeleteVectors() {
 
 	err = suite.Database.DeleteVectors(ctx, "test", cutoff)
 	suite.NoError(err)
+	count, err := suite.Database.CountVectors(ctx, "test")
+	suite.NoError(err)
+	suite.Equal(int64(1), count)
 
 	results, err := suite.Database.QueryVectors(ctx, "test", vectorA, []string{"common"}, 10)
 	suite.NoError(err)

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -79,6 +79,42 @@ func (suite *vectorsTestSuite) TestCollections() {
 	suite.Error(err)
 }
 
+func (suite *vectorsTestSuite) TestCountVectors() {
+	ctx := suite.T().Context()
+	err := suite.Database.AddCollection(ctx, "test", defaultVectorSize, Cosine, VectorConfig{})
+	suite.NoError(err)
+
+	count, err := suite.Database.CountVectors(ctx, "test")
+	suite.NoError(err)
+	suite.Zero(count)
+
+	cutoff := time.Now().UTC().Truncate(time.Millisecond)
+	err = suite.Database.AddVectors(ctx, "test", []Vector{
+		{
+			Id:        "old",
+			Vector:    make([]float32, defaultVectorSize),
+			Timestamp: cutoff.Add(-time.Hour),
+		},
+		{
+			Id:        "new",
+			Vector:    make([]float32, defaultVectorSize),
+			Timestamp: cutoff,
+		},
+	})
+	suite.NoError(err)
+
+	count, err = suite.Database.CountVectors(ctx, "test")
+	suite.NoError(err)
+	suite.Equal(int64(2), count)
+
+	err = suite.Database.DeleteVectors(ctx, "test", cutoff)
+	suite.NoError(err)
+
+	count, err = suite.Database.CountVectors(ctx, "test")
+	suite.NoError(err)
+	suite.Equal(int64(1), count)
+}
+
 func (suite *vectorsTestSuite) TestVectors() {
 	ctx := suite.T().Context()
 	err := suite.Database.AddCollection(ctx, "test", defaultVectorSize, Cosine, VectorConfig{})

--- a/storage/vectors/milvus.go
+++ b/storage/vectors/milvus.go
@@ -223,6 +223,15 @@ func (db *Milvus) DeleteCollection(ctx context.Context, name string) error {
 	return errors.Trace(err)
 }
 
+func (db *Milvus) CountVectors(ctx context.Context, collection string) (int64, error) {
+	stats, err := db.client.GetCollectionStats(ctx, milvusclient.NewGetCollectionStatsOption(collection))
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	count, err := strconv.ParseInt(stats["row_count"], 10, 64)
+	return count, errors.Trace(err)
+}
+
 func (db *Milvus) AddVectors(ctx context.Context, collection string, vectors []Vector) error {
 	if len(vectors) == 0 {
 		return nil

--- a/storage/vectors/no_database.go
+++ b/storage/vectors/no_database.go
@@ -36,6 +36,9 @@ func (NoDatabase) AddCollection(_ context.Context, _ string, _ int, _ Distance, 
 	return ErrNoDatabase
 }
 func (NoDatabase) DeleteCollection(_ context.Context, _ string) error { return ErrNoDatabase }
+func (NoDatabase) CountVectors(_ context.Context, _ string) (int64, error) {
+	return 0, ErrNoDatabase
+}
 func (NoDatabase) AddVectors(_ context.Context, _ string, _ []Vector) error {
 	return ErrNoDatabase
 }

--- a/storage/vectors/no_database_test.go
+++ b/storage/vectors/no_database_test.go
@@ -49,6 +49,10 @@ func TestNoDatabase(t *testing.T) {
 	})
 
 	t.Run("vectors", func(t *testing.T) {
+		count, err := database.CountVectors(ctx, "test")
+		assert.ErrorIs(t, err, ErrNoDatabase)
+		assert.Zero(t, count)
+
 		assert.ErrorIs(t, database.AddVectors(ctx, "test", []Vector{
 			{Id: "a", Vector: []float32{1, 0, 0, 0}, Categories: []string{"cat-a"}},
 		}), ErrNoDatabase)

--- a/storage/vectors/proxy.go
+++ b/storage/vectors/proxy.go
@@ -99,6 +99,14 @@ func (p *ProxyServer) DeleteCollection(ctx context.Context, request *protocol.De
 	return &protocol.DeleteCollectionResponse{}, nil
 }
 
+func (p *ProxyServer) CountVectors(ctx context.Context, request *protocol.CountVectorsRequest) (*protocol.CountVectorsResponse, error) {
+	count, err := p.database.CountVectors(ctx, request.GetCollection())
+	if err != nil {
+		return nil, err
+	}
+	return &protocol.CountVectorsResponse{Count: count}, nil
+}
+
 func (p *ProxyServer) AddVectors(ctx context.Context, request *protocol.AddVectorsRequest) (*protocol.AddVectorsResponse, error) {
 	vectors := make([]Vector, len(request.Vectors))
 	for i, vector := range request.Vectors {
@@ -220,6 +228,14 @@ func (p ProxyClient) AddCollection(ctx context.Context, name string, dimensions 
 func (p ProxyClient) DeleteCollection(ctx context.Context, name string) error {
 	_, err := p.VectorStoreClient.DeleteCollection(ctx, &protocol.DeleteCollectionRequest{Name: name})
 	return err
+}
+
+func (p ProxyClient) CountVectors(ctx context.Context, collection string) (int64, error) {
+	resp, err := p.VectorStoreClient.CountVectors(ctx, &protocol.CountVectorsRequest{Collection: collection})
+	if err != nil {
+		return 0, err
+	}
+	return resp.GetCount(), nil
 }
 
 func (p ProxyClient) AddVectors(ctx context.Context, collection string, vectors []Vector) error {

--- a/storage/vectors/qdrant.go
+++ b/storage/vectors/qdrant.go
@@ -259,6 +259,14 @@ func (db *Qdrant) DeleteCollection(ctx context.Context, name string) error {
 	return db.client.DeleteCollection(ctx, name)
 }
 
+func (db *Qdrant) CountVectors(ctx context.Context, collection string) (int64, error) {
+	count, err := db.client.Count(ctx, &qdrant.CountPoints{
+		CollectionName: collection,
+		Exact:          new(true),
+	})
+	return int64(count), errors.Trace(err)
+}
+
 func (db *Qdrant) AddVectors(ctx context.Context, collection string, vectors []Vector) error {
 	if len(vectors) == 0 {
 		return nil

--- a/storage/vectors/sqlite.go
+++ b/storage/vectors/sqlite.go
@@ -157,6 +157,12 @@ func (db *SQLite) DeleteCollection(ctx context.Context, name string) error {
 	return errors.Trace(err)
 }
 
+func (db *SQLite) CountVectors(ctx context.Context, collection string) (int64, error) {
+	var count int64
+	err := db.db.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", collection)).Scan(&count)
+	return count, errors.Trace(err)
+}
+
 func (db *SQLite) AddVectors(ctx context.Context, collection string, vectors []Vector) error {
 	if len(vectors) == 0 {
 		return nil

--- a/storage/vectors/weaviate.go
+++ b/storage/vectors/weaviate.go
@@ -231,6 +231,43 @@ func (db *Weaviate) DeleteCollection(ctx context.Context, name string) error {
 	return errors.Trace(err)
 }
 
+func (db *Weaviate) CountVectors(ctx context.Context, collection string) (int64, error) {
+	result, err := db.client.GraphQL().Aggregate().
+		WithClassName(capitalize(collection)).
+		WithFields(graphql.Field{
+			Name:   "meta",
+			Fields: []graphql.Field{{Name: "count"}},
+		}).
+		Do(ctx)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	if len(result.Errors) > 0 {
+		return 0, errors.New(result.Errors[0].Message)
+	}
+	aggregate, ok := result.Data["Aggregate"].(map[string]any)
+	if !ok {
+		return 0, errors.Errorf("failed to parse aggregate response for collection %s", collection)
+	}
+	groups, ok := aggregate[capitalize(collection)].([]any)
+	if !ok || len(groups) == 0 {
+		return 0, errors.Errorf("failed to parse aggregate response for collection %s", collection)
+	}
+	group, ok := groups[0].(map[string]any)
+	if !ok {
+		return 0, errors.Errorf("failed to parse aggregate response for collection %s", collection)
+	}
+	meta, ok := group["meta"].(map[string]any)
+	if !ok {
+		return 0, errors.Errorf("failed to parse aggregate response for collection %s", collection)
+	}
+	count, ok := meta["count"].(float64)
+	if !ok {
+		return 0, errors.Errorf("failed to parse aggregate response for collection %s", collection)
+	}
+	return int64(count), nil
+}
+
 func (db *Weaviate) AddVectors(ctx context.Context, collection string, vectors []Vector) error {
 	if len(vectors) == 0 {
 		return nil


### PR DESCRIPTION
## Summary

- add `CountVectors` to the vector database interface
- implement exact/current vector counts for SQLite, Qdrant, Milvus, and Weaviate
- expose vector counting through the vector-store gRPC proxy and `NoDatabase`
- extend the shared vector backend contract test to cover empty, populated, and deleted-vector counts

## Testing

- `go test ./storage/vectors ./protocol -count=1`
- `go vet ./storage/vectors ./protocol`
- `QDRANT_URI=qdrant://127.0.0.1:6334 WEAVIATE_URI=weaviate://127.0.0.1:8080 go test ./storage/vectors -count=1 -timeout=5m`
