### PR TITLE
fix(ctr): support variable AFM feature dimensions

### DIFF
--- a/model/ctr/fm.go
+++ b/model/ctr/fm.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/c-bata/goptuna"
 	"github.com/chewxy/math32"
-	"github.com/gorse-io/gorse/common/encoding"
 	"github.com/gorse-io/gorse/common/bfloats"
+	"github.com/gorse-io/gorse/common/encoding"
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
 	"github.com/gorse-io/gorse/common/nn"
@@ -110,8 +110,9 @@ func (fm *AFM) Invalid() bool {
 
 func (fm *AFM) Forward(indices, values *nn.Tensor, embeddings []*nn.Tensor, jobs int) *nn.Tensor {
 	batchSize := indices.Shape()[0]
+	numDimension := indices.Shape()[1]
 	v := fm.V.Forward(indices)
-	x := nn.Reshape(values, batchSize, fm.numDimension, 1)
+	x := nn.Reshape(values, batchSize, numDimension, 1)
 	vx := nn.BMM(v, x, true, false, jobs)
 	sumSquare := nn.Square(vx)
 	e2 := nn.Square(v)
@@ -532,8 +533,12 @@ func (fm *AFM) convertToTensors(x []lo.Tuple2[[]int32, []float32], e [][][]uint1
 		panic("length of x and y must be equal")
 	}
 
-	alignedIndices := make([]float32, len(x)*fm.numDimension)
-	alignedValues := make([]float32, len(x)*fm.numDimension)
+	numDimension := fm.numDimension
+	for i := range x {
+		numDimension = max(numDimension, len(x[i].A))
+	}
+	alignedIndices := make([]float32, len(x)*numDimension)
+	alignedValues := make([]float32, len(x)*numDimension)
 	alignedEmbeddings := make([][]float32, len(fm.embeddingDim))
 	for i := range fm.embeddingDim {
 		alignedEmbeddings[i] = make([]float32, 0, len(x)*fm.embeddingDim[i])
@@ -544,8 +549,8 @@ func (fm *AFM) convertToTensors(x []lo.Tuple2[[]int32, []float32], e [][][]uint1
 			panic("length of indices and values must be equal")
 		}
 		for j := range x[i].A {
-			alignedIndices[i*fm.numDimension+j] = float32(x[i].A[j])
-			alignedValues[i*fm.numDimension+j] = x[i].B[j]
+			alignedIndices[i*numDimension+j] = float32(x[i].A[j])
+			alignedValues[i*numDimension+j] = x[i].B[j]
 		}
 		for j := range fm.embeddingDim {
 			if len(e[i]) > j && len(e[i][j]) == fm.embeddingDim[j] {
@@ -559,8 +564,8 @@ func (fm *AFM) convertToTensors(x []lo.Tuple2[[]int32, []float32], e [][][]uint1
 		}
 	}
 
-	indicesTensor = nn.NewTensor(alignedIndices, len(x), fm.numDimension)
-	valuesTensor = nn.NewTensor(alignedValues, len(x), fm.numDimension)
+	indicesTensor = nn.NewTensor(alignedIndices, len(x), numDimension)
+	valuesTensor = nn.NewTensor(alignedValues, len(x), numDimension)
 	embeddingTensor = make([]*nn.Tensor, len(fm.embeddingDim))
 	for i := range fm.embeddingDim {
 		embeddingTensor[i] = nn.NewTensor(alignedEmbeddings[i], len(x), fm.embeddingDim[i])

--- a/model/ctr/fm_xla.go
+++ b/model/ctr/fm_xla.go
@@ -154,13 +154,14 @@ func (fm *AFM) forwardGraph(ctx *mlx_context.Context, indices, values *graph.Nod
 	ctx = ctx.Checked(false)
 	g := indices.Graph()
 	batchSize := indices.Shape().Dimensions[0]
+	numDimension := indices.Shape().Dimensions[1]
 
 	// V: Embedding(numFeatures, nFactors)
 	vCtx := ctx.In("V")
 	v := layers.Embedding(vCtx, indices, dtypes.F32, fm.numFeatures, fm.nFactors) // [batchSize, numDimension, nFactors]
 
 	// x: values [batchSize, numDimension, 1]
-	x := graph.Reshape(values, batchSize, fm.numDimension, 1)
+	x := graph.Reshape(values, batchSize, numDimension, 1)
 
 	// vx: BMM(v, x, true, false) -> [batchSize, nFactors, 1]
 	// contracting axes: [1] (numDimension), batch axes: [0]
@@ -257,9 +258,13 @@ func (fm *AFM) BatchInternalPredict(x []lo.Tuple2[[]int32, []float32], e [][][]u
 		start := b * fm.batchSize
 		end := min(start+fm.batchSize, len(x))
 		batchSize := end - start
+		numDimension := fm.numDimension
+		for i := start; i < end; i++ {
+			numDimension = max(numDimension, len(scaledX[i].A))
+		}
 
-		indicesData := make([]int32, batchSize*fm.numDimension)
-		valuesData := make([]float32, batchSize*fm.numDimension)
+		indicesData := make([]int32, batchSize*numDimension)
+		valuesData := make([]float32, batchSize*numDimension)
 		additionalData := make([][]float32, len(fm.embeddingDim))
 		for i := range additionalData {
 			additionalData[i] = make([]float32, batchSize*fm.embeddingDim[i])
@@ -268,8 +273,8 @@ func (fm *AFM) BatchInternalPredict(x []lo.Tuple2[[]int32, []float32], e [][][]u
 		for i := 0; i < batchSize; i++ {
 			row := scaledX[start+i]
 			for j := 0; j < len(row.A); j++ {
-				indicesData[i*fm.numDimension+j] = row.A[j]
-				valuesData[i*fm.numDimension+j] = row.B[j]
+				indicesData[i*numDimension+j] = row.A[j]
+				valuesData[i*numDimension+j] = row.B[j]
 			}
 			for j := range fm.embeddingDim {
 				if len(e[start+i]) > j && len(e[start+i][j]) == fm.embeddingDim[j] {
@@ -279,8 +284,8 @@ func (fm *AFM) BatchInternalPredict(x []lo.Tuple2[[]int32, []float32], e [][][]u
 		}
 
 		inputs := []any{
-			tensors.FromFlatDataAndDimensions(indicesData, batchSize, fm.numDimension),
-			tensors.FromFlatDataAndDimensions(valuesData, batchSize, fm.numDimension),
+			tensors.FromFlatDataAndDimensions(indicesData, batchSize, numDimension),
+			tensors.FromFlatDataAndDimensions(valuesData, batchSize, numDimension),
 		}
 		for i := range additionalData {
 			inputs = append(inputs, tensors.FromFlatDataAndDimensions(additionalData[i], batchSize, fm.embeddingDim[i]))

--- a/model/ctr/model_test.go
+++ b/model/ctr/model_test.go
@@ -257,3 +257,36 @@ func TestFactorizationMachines_NoEmbeddings(t *testing.T) {
 		batch.BatchPredict(inputs, [][]Embedding{{}}, 1),
 		batch.BatchPredict(inputs, [][]Embedding{{{Name: "unexpected", Value: []uint16{1}}}}, 1))
 }
+
+func TestFactorizationMachines_PredictWithMoreFeaturesThanTraining(t *testing.T) {
+	dataSet := newSynthesisDataset()
+	// Only the first user-item pair is present in the training set, while the index
+	// also contains users and items with more labels.
+	dataSet.UserLabels[0] = dataSet.UserLabels[0][:1]
+	dataSet.ItemLabels[0] = dataSet.ItemLabels[0][:1]
+	dataSet.Users = []int32{0}
+	dataSet.Items = []int32{0}
+	dataSet.Target = []float32{1}
+
+	m := NewAFM(nil)
+	m.Init(dataSet)
+	assert.Equal(t, 4, m.numDimension)
+
+	inputs := []lo.Tuple4[string, string, []Label, []Label]{
+		{A: "u0", B: "i0", C: []Label{{Name: "ul0", Value: 1}}, D: []Label{{Name: "il0", Value: 1}}},
+		{
+			A: "u1",
+			B: "i1",
+			C: []Label{{Name: "ul0", Value: 1}, {Name: "ul1", Value: 1}, {Name: "ul2", Value: 1}},
+			D: []Label{{Name: "il0", Value: 1}, {Name: "il1", Value: 1}, {Name: "il2", Value: 1}},
+		},
+	}
+	embeddings := make([][]Embedding, len(inputs))
+
+	batchPredictions := m.BatchPredict(inputs, embeddings, 1)
+	assert.Len(t, batchPredictions, len(inputs))
+	for i := range inputs {
+		prediction := m.BatchPredict(inputs[i:i+1], embeddings[i:i+1], 1)
+		assert.InDelta(t, prediction[0], batchPredictions[i], 1e-5)
+	}
+}


### PR DESCRIPTION
## Summary

Backport #1347 to `release-0.5`.

- dynamically expand AFM input dimensions when prediction samples contain more features than any training sample
- use the actual input tensor shape in CPU and XLA forward passes
- add a regression test covering batch prediction with more features than training

## Verification

- `/usr/local/go/bin/go test ./model/ctr`
