### PR TITLE
test(nn): stabilize Abs gradient check

### DIFF
--- a/common/nn/op_test.go
+++ b/common/nn/op_test.go
@@ -297,8 +297,8 @@ func TestAbs(t *testing.T) {
 	y := Abs(x)
 	assert.Equal(t, []float32{1, 2, 3, 4, 5, 6}, y.data)
 
-	// Test gradient
-	x = Rand(2, 3)
+	// Test gradient away from zero, where Abs is not differentiable.
+	x = NewTensor([]float32{-0.9, -0.5, -0.1, 0.1, 0.5, 0.9}, 2, 3)
 	y = Abs(x)
 	y.Backward()
 	dx := numericalDiff(Abs, x)


### PR DESCRIPTION
## Summary

Backport #1350 to `release-0.5`.

`TestAbs` previously used random values for a central-difference gradient check. Values within `eps` of zero cross the nondifferentiable point of `abs`, causing intermittent failures. Use deterministic positive and negative inputs away from zero instead.

## Verification

- `/usr/local/go/bin/go test ./common/nn -run '^TestAbs$' -count=10000`
- `/usr/local/go/bin/go test ./common/nn`
