### PR TITLE
fix(event): capture handler before async emit

### DIFF
--- a/common/event/event.go
+++ b/common/event/event.go
@@ -16,6 +16,7 @@ package event
 
 import (
 	"context"
+	"sync"
 	"time"
 )
 
@@ -57,17 +58,37 @@ func (n *NopHandler) EmitRequest(ctx context.Context, event Request) {}
 
 func (n *NopHandler) EmitSnapshot(ctx context.Context, event Snapshot) {}
 
-var handler Handler = &NopHandler{}
+var (
+	handlerMu sync.RWMutex
+	handler   Handler = &NopHandler{}
+)
 
 func SetEventHandler(r Handler) {
+	handlerMu.Lock()
+	defer handlerMu.Unlock()
 	handler = r
 }
 
-func Emit[T Request | Snapshot](ctx context.Context, event T) {
+func getEventHandler() Handler {
+	handlerMu.RLock()
+	defer handlerMu.RUnlock()
+	return handler
+}
+
+func emit[T Request | Snapshot](handler Handler, ctx context.Context, event T) {
 	switch e := any(event).(type) {
 	case Request:
 		handler.EmitRequest(ctx, e)
 	case Snapshot:
 		handler.EmitSnapshot(ctx, e)
 	}
+}
+
+func Emit[T Request | Snapshot](ctx context.Context, event T) {
+	emit(getEventHandler(), ctx, event)
+}
+
+func EmitAsync[T Request | Snapshot](ctx context.Context, event T) {
+	handler := getEventHandler()
+	go emit(handler, ctx, event)
 }

--- a/common/event/event_test.go
+++ b/common/event/event_test.go
@@ -26,6 +26,16 @@ type MockHandler struct {
 	mock.Mock
 }
 
+type channelHandler struct {
+	requests chan Request
+}
+
+func (h *channelHandler) EmitRequest(_ context.Context, request Request) {
+	h.requests <- request
+}
+
+func (h *channelHandler) EmitSnapshot(context.Context, Snapshot) {}
+
 func (m *MockHandler) EmitRequest(ctx context.Context, event Request) {
 	m.Called(ctx, event)
 }
@@ -63,4 +73,28 @@ func TestSetEventRecorder(t *testing.T) {
 	Emit(t.Context(), request)
 	Emit(t.Context(), snapshot)
 	handler.AssertExpectations(t)
+}
+
+func TestEmitAsyncCapturesHandler(t *testing.T) {
+	t.Cleanup(func() {
+		SetEventHandler(&NopHandler{})
+	})
+
+	request := Request{RequestID: "request-id"}
+	first := &channelHandler{requests: make(chan Request, 1)}
+	second := &channelHandler{requests: make(chan Request, 1)}
+	SetEventHandler(first)
+	EmitAsync(t.Context(), request)
+	SetEventHandler(second)
+
+	select {
+	case actual := <-first.requests:
+		if actual != request {
+			t.Fatalf("unexpected request: %+v", actual)
+		}
+	case actual := <-second.requests:
+		t.Fatalf("request was emitted to replacement handler: %+v", actual)
+	case <-time.After(time.Second):
+		t.Fatal("request was not emitted")
+	}
 }

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -122,7 +122,7 @@ func (m *Master) loadDataset(parent context.Context) (datasets Datasets, err err
 	if err != nil {
 		return Datasets{}, errors.Trace(err)
 	}
-	go event.Emit(context.WithoutCancel(ctx), snapshot)
+	event.EmitAsync(context.WithoutCancel(ctx), snapshot)
 
 	// save non-personalized recommenders to cache
 	for i, recommender := range nonPersonalizedRecommenders {

--- a/server/rest.go
+++ b/server/rest.go
@@ -172,7 +172,7 @@ func (s *RestServer) LogFilter(req *restful.Request, resp *restful.Response, cha
 			zap.Int("status_code", resp.StatusCode()),
 			zap.Duration("response_time", responseTime),
 			zap.String("remote_addr", req.Request.RemoteAddr))
-		go event.Emit(context.WithoutCancel(req.Request.Context()), event.Request{
+		event.EmitAsync(context.WithoutCancel(req.Request.Context()), event.Request{
 			RequestID:     requestId,
 			Method:        req.Request.Method,
 			Route:         route,


### PR DESCRIPTION
## Problem

Request and snapshot events are currently emitted with `go event.Emit(...)`. The goroutine resolves the package-global event handler only when it is scheduled. If the handler is replaced in the meantime, the event can be delivered to the wrong handler. This makes `server.TestServer/TestEmitRequest` flaky and leaves the global handler subject to concurrent reads and writes.

## Fix

- add `event.EmitAsync`, which captures the current handler before starting the goroutine
- protect global handler access with an RW mutex
- use `EmitAsync` for request and snapshot event producers
- add a regression test proving an async event stays bound to the handler active when it was submitted

## Verification

```text
go test ./common/event -run '^TestEmitAsyncCapturesHandler$' -count=1000
go test -race ./common/event
go test ./server -run '^TestServer$/^TestEmitRequest$' -count=20
go test ./master -run '^TestMaster$/^TestEmitSnapshot$' -count=10
```
