### PR TITLE
fix(master): wait for tasks before shutdown

### DIFF
--- a/cmd/gorse-cli/main_test.go
+++ b/cmd/gorse-cli/main_test.go
@@ -8,12 +8,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
-	"unsafe"
 
 	adminclient "github.com/gorse-io/gorse/client"
 	"github.com/gorse-io/gorse/common/log"
@@ -515,7 +513,6 @@ func newTestMaster(t *testing.T) (*master.Master, string) {
 	waitForInitialTask(t, endpoint)
 	t.Cleanup(func() {
 		m.Shutdown()
-		closeTestMasterStores(t, m)
 		for range 10 {
 			if err := os.RemoveAll(tempDir); err == nil {
 				return
@@ -525,21 +522,6 @@ func newTestMaster(t *testing.T) (*master.Master, string) {
 		require.NoError(t, os.RemoveAll(tempDir))
 	})
 	return m, endpoint
-}
-
-func closeTestMasterStores(t *testing.T, m *master.Master) {
-	t.Helper()
-	require.NoError(t, m.DataClient.Close())
-	require.NoError(t, m.CacheClient.Close())
-
-	metaStoreValue := reflect.ValueOf(m).Elem().FieldByName("metaStore")
-	if metaStoreValue.IsNil() {
-		return
-	}
-	metaStore := reflect.NewAt(metaStoreValue.Type(), unsafe.Pointer(metaStoreValue.UnsafeAddr())).Elem().Interface()
-	closer, ok := metaStore.(interface{ Close() error })
-	require.True(t, ok)
-	require.NoError(t, closer.Close())
 }
 
 func freePort(t *testing.T) int {

--- a/master/master.go
+++ b/master/master.go
@@ -105,10 +105,15 @@ type Master struct {
 	tokenCache   *ttlcache.Cache[string, UserInfo]
 
 	// events
-	ticker      *time.Ticker
-	scheduled   chan struct{}
-	cancel      context.CancelFunc
-	reconciling atomic.Bool
+	ticker       *time.Ticker
+	scheduled    chan struct{}
+	taskDone     chan struct{}
+	taskWait     sync.WaitGroup
+	taskStop     sync.Once
+	taskMutex    sync.Mutex
+	taskStopping bool
+	cancel       context.CancelFunc
+	reconciling  atomic.Bool
 }
 
 // NewMaster creates a master node.
@@ -152,6 +157,7 @@ func NewMaster(cfg *config.Config, cacheFolder string, standalone bool, configPa
 		},
 		ticker:    time.NewTicker(duration),
 		scheduled: make(chan struct{}, 1),
+		taskDone:  make(chan struct{}),
 		cancel:    func() {},
 	}
 	return m
@@ -359,7 +365,11 @@ func (m *Master) Serve() {
 	}
 
 	go m.watchConfigFile(context.Background())
-	go m.RunTasksLoop()
+	m.taskWait.Add(1)
+	go func() {
+		defer m.taskWait.Done()
+		m.RunTasksLoop()
+	}()
 
 	// start rpc server
 	go func() {
@@ -478,6 +488,7 @@ func (m *Master) checkCollaborativeFilteringVectorCollection(info *vectors.Colle
 }
 
 func (m *Master) Shutdown() {
+	m.stopTasks()
 	// stop http server
 	err := m.HttpServer.Shutdown(context.TODO())
 	if err != nil {
@@ -508,17 +519,45 @@ func (m *Master) RunTasksLoop() {
 	}
 	for {
 		select {
+		case <-m.taskDone:
+			return
 		case <-m.ticker.C:
 		case <-m.scheduled:
 		}
 
 		// download dataset
-		var ctx context.Context
-		ctx, m.cancel = context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(context.Background())
+		m.taskMutex.Lock()
+		if m.taskStopping {
+			m.taskMutex.Unlock()
+			cancel()
+			return
+		}
+		m.cancel = cancel
+		m.taskMutex.Unlock()
 		err := m.runLoadDatasetTask(ctx)
+		cancel()
 		if err != nil {
 			log.Logger().Error("failed to load ranking dataset", zap.Error(err))
 			continue
 		}
 	}
+}
+
+func (m *Master) cancelTask() {
+	m.taskMutex.Lock()
+	defer m.taskMutex.Unlock()
+	m.cancel()
+}
+
+func (m *Master) stopTasks() {
+	m.taskStop.Do(func() {
+		m.taskMutex.Lock()
+		m.taskStopping = true
+		close(m.taskDone)
+		m.ticker.Stop()
+		m.cancel()
+		m.taskMutex.Unlock()
+	})
+	m.taskWait.Wait()
 }

--- a/master/master_test.go
+++ b/master/master_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/common/monitor"
@@ -100,4 +101,42 @@ func (s *MasterTestSuite) TestInitCollaborativeFilteringVectorCollectionRecreate
 
 func TestMaster(t *testing.T) {
 	suite.Run(t, new(MasterTestSuite))
+}
+
+func TestStopTasksWaitsForRunningTask(t *testing.T) {
+	m := NewMaster(config.GetDefaultConfig(), t.TempDir(), true, "")
+	t.Cleanup(m.ticker.Stop)
+
+	taskCanceled := make(chan struct{})
+	allowTaskToFinish := make(chan struct{})
+	m.taskWait.Add(1)
+	go func() {
+		defer m.taskWait.Done()
+		<-m.taskDone
+		close(taskCanceled)
+		<-allowTaskToFinish
+	}()
+
+	stopped := make(chan struct{})
+	go func() {
+		m.stopTasks()
+		close(stopped)
+	}()
+
+	select {
+	case <-taskCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("task was not canceled")
+	}
+	select {
+	case <-stopped:
+		t.Fatal("stopTasks returned before the running task finished")
+	default:
+	}
+	close(allowTaskToFinish)
+	select {
+	case <-stopped:
+	case <-time.After(time.Second):
+		t.Fatal("stopTasks did not wait for the running task")
+	}
 }

--- a/master/rest.go
+++ b/master/rest.go
@@ -579,7 +579,7 @@ func (m *Master) postConfig(request *restful.Request, response *restful.Response
 	m.Config.Recommend = newConfig.Recommend
 	m.ConfigMutex.Unlock()
 
-	m.cancel()
+	m.cancelTask()
 	select {
 	case m.scheduled <- struct{}{}:
 	default:
@@ -617,7 +617,7 @@ func (m *Master) deleteConfig(_request *restful.Request, response *restful.Respo
 	m.Config.Recommend = newConfig.Recommend
 	m.ConfigMutex.Unlock()
 
-	m.cancel()
+	m.cancelTask()
 	select {
 	case m.scheduled <- struct{}{}:
 	default:
@@ -1359,7 +1359,7 @@ func (m *Master) importExportUsers(response http.ResponseWriter, request *http.R
 			}
 		}
 
-		m.cancel()
+		m.cancelTask()
 		select {
 		case m.scheduled <- struct{}{}:
 		default:
@@ -1482,7 +1482,7 @@ func (m *Master) importExportItems(response http.ResponseWriter, request *http.R
 			}
 		}
 
-		m.cancel()
+		m.cancelTask()
 		select {
 		case m.scheduled <- struct{}{}:
 		default:
@@ -1609,7 +1609,7 @@ func (m *Master) importExportFeedback(response http.ResponseWriter, request *htt
 			}
 		}
 
-		m.cancel()
+		m.cancelTask()
 		select {
 		case m.scheduled <- struct{}{}:
 		default:
@@ -1980,7 +1980,7 @@ func (m *Master) restore(response http.ResponseWriter, request *http.Request) {
 		return
 	}
 
-	m.cancel()
+	m.cancelTask()
 	select {
 	case m.scheduled <- struct{}{}:
 	default:


### PR DESCRIPTION
## Summary

- cancel and wait for the master task loop before closing databases during shutdown
- synchronize task cancellation with task startup and REST-triggered rescheduling
- remove the CLI test's reflective double-close workaround so cleanup relies on `Master.Shutdown`
- add coverage that verifies task shutdown waits for running work to finish

## Root cause

A pipeline config patch schedules a new load-dataset task. The CLI test can enter cleanup while that task is still using SQLite. `Master.Shutdown` previously closed the stores without stopping or waiting for `RunTasksLoop`, so Windows could retain a handle to `cache.db` and reject `RemoveAll`.

Failure: https://github.com/gorse-io/gorse/actions/runs/29893340853/job/88838099964

## Verification

- `go test ./cmd/gorse-cli -run '^TestCLI$/^TestPipelinePatchCmd$' -count=100`
- `go test ./cmd/gorse-cli -count=1`
- `go test ./master -count=1`
- `go test -race ./master -run '^TestStopTasksWaitsForRunningTask$' -count=1`
- `go test ./master -run '^TestStopTasksWaitsForRunningTask$' -count=1000`
- `go test -p 1 ./...`
- `go vet ./master ./cmd/gorse-cli`
- `git diff --check`
