### PR TITLE
feat(master): recycle collaborative filtering artifacts

### DIFF
--- a/master/tasks.go
+++ b/master/tasks.go
@@ -1282,7 +1282,9 @@ func (m *Master) trainClickThroughRatePrediction(parent context.Context, trainSe
 func (m *Master) removeOutOfDateModels() {
 	m.collaborativeFilteringModelMutex.RLock()
 	m.clickThroughRateModelMutex.RLock()
-	timestamp := min(m.collaborativeFilteringMeta.ID, m.clickThroughRateMeta.ID)
+	collaborativeFilteringModelID := m.collaborativeFilteringMeta.ID
+	clickThroughRateModelID := m.clickThroughRateMeta.ID
+	timestamp := min(collaborativeFilteringModelID, clickThroughRateModelID)
 	m.clickThroughRateModelMutex.RUnlock()
 	m.collaborativeFilteringModelMutex.RUnlock()
 
@@ -1291,13 +1293,69 @@ func (m *Master) removeOutOfDateModels() {
 		log.Logger().Error("failed to list models in blob store", zap.Error(err))
 		return
 	}
+	models := make(map[int64]string)
 	for _, file := range files {
 		id, err := strconv.ParseInt(file, 10, 64)
 		if err != nil {
 			log.Logger().Info("failed to parse model id", zap.String("file", file), zap.Error(err))
 			continue
 		}
-		if id < timestamp {
+		models[id] = file
+	}
+
+	ctx := context.Background()
+	collections, err := m.VectorClient.ListCollections(ctx)
+	if err != nil {
+		log.Logger().Error("failed to list collections in vector store", zap.Error(err))
+		return
+	}
+	const collaborativeFilteringCollectionPrefix = vectors.CollaborativeFiltering + "_"
+	collaborativeFilteringCollections := make(map[int64]string)
+	completeCollaborativeFilteringModels := make([]int64, 0)
+	for _, collection := range collections {
+		if !strings.HasPrefix(collection, collaborativeFilteringCollectionPrefix) {
+			continue
+		}
+		id, err := strconv.ParseInt(strings.TrimPrefix(collection, collaborativeFilteringCollectionPrefix), 10, 64)
+		if err != nil || vectors.CollaborativeFilteringCollection(id) != collection {
+			continue
+		}
+		collaborativeFilteringCollections[id] = collection
+		if _, ok := models[id]; ok {
+			completeCollaborativeFilteringModels = append(completeCollaborativeFilteringModels, id)
+		}
+	}
+	sort.Slice(completeCollaborativeFilteringModels, func(i, j int) bool {
+		return completeCollaborativeFilteringModels[i] > completeCollaborativeFilteringModels[j]
+	})
+	keepCollaborativeFilteringModels := mapset.NewSet[int64](collaborativeFilteringModelID)
+	for _, id := range completeCollaborativeFilteringModels[:min(2, len(completeCollaborativeFilteringModels))] {
+		keepCollaborativeFilteringModels.Add(id)
+	}
+
+	for id, collection := range collaborativeFilteringCollections {
+		if keepCollaborativeFilteringModels.Contains(id) {
+			continue
+		}
+		if file, ok := models[id]; ok && id != clickThroughRateModelID {
+			if err = m.blobStore.Remove(file); err != nil {
+				log.Logger().Error("failed to delete collaborative filtering model from blob store",
+					zap.Int64("id", id), zap.Error(err))
+				continue
+			}
+			delete(models, id)
+			log.Logger().Info("deleted out-of-date collaborative filtering model from blob store", zap.Int64("id", id))
+		}
+		if err = m.VectorClient.DeleteCollection(ctx, collection); err != nil {
+			log.Logger().Error("failed to delete collaborative filtering index from vector store",
+				zap.Int64("id", id), zap.Error(err))
+			continue
+		}
+		log.Logger().Info("deleted out-of-date collaborative filtering index from vector store", zap.Int64("id", id))
+	}
+
+	for id, file := range models {
+		if id < timestamp && !keepCollaborativeFilteringModels.Contains(id) {
 			if err = m.blobStore.Remove(file); err != nil {
 				log.Logger().Error("failed to delete model from blob store", zap.Int64("id", id), zap.Error(err))
 			} else {

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -1154,7 +1154,7 @@ func (m *Master) trainCollaborativeFiltering(parent context.Context, trainSet, t
 		return nil
 	}
 
-	m.removeOutOfDateModels()
+	m.removeOutOfDateModels(ctx)
 	return nil
 }
 
@@ -1275,11 +1275,11 @@ func (m *Master) trainClickThroughRatePrediction(parent context.Context, trainSe
 		return err
 	}
 
-	m.removeOutOfDateModels()
+	m.removeOutOfDateModels(ctx)
 	return nil
 }
 
-func (m *Master) removeOutOfDateModels() {
+func (m *Master) removeOutOfDateModels(ctx context.Context) {
 	m.collaborativeFilteringModelMutex.RLock()
 	m.clickThroughRateModelMutex.RLock()
 	collaborativeFilteringModelID := m.collaborativeFilteringMeta.ID
@@ -1303,7 +1303,6 @@ func (m *Master) removeOutOfDateModels() {
 		models[id] = file
 	}
 
-	ctx := context.Background()
 	collections, err := m.VectorClient.ListCollections(ctx)
 	if err != nil {
 		log.Logger().Error("failed to list collections in vector store", zap.Error(err))

--- a/master/tasks_test.go
+++ b/master/tasks_test.go
@@ -49,9 +49,23 @@ func (s *failOnceBlobStore) Remove(name string) error {
 	return s.Store.Remove(name)
 }
 
+type failOnceVectorDatabase struct {
+	vectors.Database
+	name   string
+	failed bool
+}
+
+func (d *failOnceVectorDatabase) DeleteCollection(ctx context.Context, name string) error {
+	if name == d.name && !d.failed {
+		d.failed = true
+		return fmt.Errorf("failed to delete %s", name)
+	}
+	return d.Database.DeleteCollection(ctx, name)
+}
+
 func (s *MasterTestSuite) TestRemoveOutOfDateModels() {
 	ctx := s.T().Context()
-	s.blobStore = blob.NewPOSIX(s.T().TempDir())
+	s.blobStore = &failOnceBlobStore{Store: blob.NewPOSIX(s.T().TempDir()), name: "50"}
 	s.collaborativeFilteringMeta = meta.Model[cf.Score]{ID: 100}
 	s.clickThroughRateMeta = meta.Model[ctr.Score]{ID: 150}
 
@@ -77,6 +91,7 @@ func (s *MasterTestSuite) TestRemoveOutOfDateModels() {
 	s.Require().NoError(s.VectorClient.AddCollection(ctx, "unrelated", 2, vectors.Dot, vectors.VectorConfig{}))
 
 	s.removeOutOfDateModels()
+	s.removeOutOfDateModels()
 
 	collections, err := s.VectorClient.ListCollections(ctx)
 	s.Require().NoError(err)
@@ -95,6 +110,10 @@ func (s *MasterTestSuite) TestRemoveOutOfDateModels() {
 func (s *MasterTestSuite) TestRemoveOutOfDateModelsRetry() {
 	ctx := s.T().Context()
 	s.blobStore = &failOnceBlobStore{Store: blob.NewPOSIX(s.T().TempDir()), name: "200"}
+	s.VectorClient = &failOnceVectorDatabase{
+		Database: s.VectorClient,
+		name:     vectors.CollaborativeFilteringCollection(200),
+	}
 	s.collaborativeFilteringMeta = meta.Model[cf.Score]{ID: 100}
 	s.clickThroughRateMeta = meta.Model[ctr.Score]{ID: 150}
 
@@ -111,6 +130,7 @@ func (s *MasterTestSuite) TestRemoveOutOfDateModelsRetry() {
 			vectors.CollaborativeFilteringCollection(id), 2, vectors.Dot, vectors.VectorConfig{}))
 	}
 
+	s.removeOutOfDateModels()
 	s.removeOutOfDateModels()
 	s.removeOutOfDateModels()
 

--- a/master/tasks_test.go
+++ b/master/tasks_test.go
@@ -55,7 +55,7 @@ func (s *MasterTestSuite) TestRemoveOutOfDateModels() {
 	s.collaborativeFilteringMeta = meta.Model[cf.Score]{ID: 100}
 	s.clickThroughRateMeta = meta.Model[ctr.Score]{ID: 150}
 
-	for _, id := range []int64{100, 150, 200, 300, 400} {
+	for _, id := range []int64{50, 100, 150, 200, 300, 400} {
 		w, done, err := s.blobStore.Create(strconv.FormatInt(id, 10))
 		s.Require().NoError(err)
 		_, err = w.Write([]byte("model"))
@@ -63,10 +63,17 @@ func (s *MasterTestSuite) TestRemoveOutOfDateModels() {
 		s.Require().NoError(w.Close())
 		<-done
 	}
+	w, done, err := s.blobStore.Create("invalid")
+	s.Require().NoError(err)
+	_, err = w.Write([]byte("model"))
+	s.Require().NoError(err)
+	s.Require().NoError(w.Close())
+	<-done
 	for _, id := range []int64{100, 200, 300, 400, 500} {
 		s.Require().NoError(s.VectorClient.AddCollection(ctx,
 			vectors.CollaborativeFilteringCollection(id), 2, vectors.Dot, vectors.VectorConfig{}))
 	}
+	s.Require().NoError(s.VectorClient.AddCollection(ctx, "collaborative_filtering_invalid", 2, vectors.Dot, vectors.VectorConfig{}))
 	s.Require().NoError(s.VectorClient.AddCollection(ctx, "unrelated", 2, vectors.Dot, vectors.VectorConfig{}))
 
 	s.removeOutOfDateModels()
@@ -77,11 +84,12 @@ func (s *MasterTestSuite) TestRemoveOutOfDateModels() {
 		vectors.CollaborativeFilteringCollection(100),
 		vectors.CollaborativeFilteringCollection(300),
 		vectors.CollaborativeFilteringCollection(400),
+		"collaborative_filtering_invalid",
 		"unrelated",
 	}, collections)
 	files, err := s.blobStore.List()
 	s.Require().NoError(err)
-	s.ElementsMatch([]string{"100", "150", "300", "400"}, files)
+	s.ElementsMatch([]string{"100", "150", "300", "400", "invalid"}, files)
 }
 
 func (s *MasterTestSuite) TestRemoveOutOfDateModelsRetry() {

--- a/master/tasks_test.go
+++ b/master/tasks_test.go
@@ -90,8 +90,8 @@ func (s *MasterTestSuite) TestRemoveOutOfDateModels() {
 	s.Require().NoError(s.VectorClient.AddCollection(ctx, "collaborative_filtering_invalid", 2, vectors.Dot, vectors.VectorConfig{}))
 	s.Require().NoError(s.VectorClient.AddCollection(ctx, "unrelated", 2, vectors.Dot, vectors.VectorConfig{}))
 
-	s.removeOutOfDateModels()
-	s.removeOutOfDateModels()
+	s.removeOutOfDateModels(ctx)
+	s.removeOutOfDateModels(ctx)
 
 	collections, err := s.VectorClient.ListCollections(ctx)
 	s.Require().NoError(err)
@@ -130,9 +130,9 @@ func (s *MasterTestSuite) TestRemoveOutOfDateModelsRetry() {
 			vectors.CollaborativeFilteringCollection(id), 2, vectors.Dot, vectors.VectorConfig{}))
 	}
 
-	s.removeOutOfDateModels()
-	s.removeOutOfDateModels()
-	s.removeOutOfDateModels()
+	s.removeOutOfDateModels(ctx)
+	s.removeOutOfDateModels(ctx)
+	s.removeOutOfDateModels(ctx)
 
 	collections, err := s.VectorClient.ListCollections(ctx)
 	s.Require().NoError(err)

--- a/master/tasks_test.go
+++ b/master/tasks_test.go
@@ -25,10 +25,94 @@ import (
 	"github.com/gorse-io/gorse/common/expression"
 	"github.com/gorse-io/gorse/config"
 	"github.com/gorse-io/gorse/logics"
+	"github.com/gorse-io/gorse/model/cf"
+	"github.com/gorse-io/gorse/model/ctr"
+	"github.com/gorse-io/gorse/storage/blob"
 	"github.com/gorse-io/gorse/storage/cache"
 	"github.com/gorse-io/gorse/storage/data"
+	"github.com/gorse-io/gorse/storage/meta"
+	"github.com/gorse-io/gorse/storage/vectors"
 	"github.com/samber/lo"
 )
+
+type failOnceBlobStore struct {
+	blob.Store
+	name   string
+	failed bool
+}
+
+func (s *failOnceBlobStore) Remove(name string) error {
+	if name == s.name && !s.failed {
+		s.failed = true
+		return fmt.Errorf("failed to remove %s", name)
+	}
+	return s.Store.Remove(name)
+}
+
+func (s *MasterTestSuite) TestRemoveOutOfDateModels() {
+	ctx := s.T().Context()
+	s.blobStore = blob.NewPOSIX(s.T().TempDir())
+	s.collaborativeFilteringMeta = meta.Model[cf.Score]{ID: 100}
+	s.clickThroughRateMeta = meta.Model[ctr.Score]{ID: 150}
+
+	for _, id := range []int64{100, 150, 200, 300, 400} {
+		w, done, err := s.blobStore.Create(strconv.FormatInt(id, 10))
+		s.Require().NoError(err)
+		_, err = w.Write([]byte("model"))
+		s.Require().NoError(err)
+		s.Require().NoError(w.Close())
+		<-done
+	}
+	for _, id := range []int64{100, 200, 300, 400, 500} {
+		s.Require().NoError(s.VectorClient.AddCollection(ctx,
+			vectors.CollaborativeFilteringCollection(id), 2, vectors.Dot, vectors.VectorConfig{}))
+	}
+	s.Require().NoError(s.VectorClient.AddCollection(ctx, "unrelated", 2, vectors.Dot, vectors.VectorConfig{}))
+
+	s.removeOutOfDateModels()
+
+	collections, err := s.VectorClient.ListCollections(ctx)
+	s.Require().NoError(err)
+	s.ElementsMatch([]string{
+		vectors.CollaborativeFilteringCollection(100),
+		vectors.CollaborativeFilteringCollection(300),
+		vectors.CollaborativeFilteringCollection(400),
+		"unrelated",
+	}, collections)
+	files, err := s.blobStore.List()
+	s.Require().NoError(err)
+	s.ElementsMatch([]string{"100", "150", "300", "400"}, files)
+}
+
+func (s *MasterTestSuite) TestRemoveOutOfDateModelsRetry() {
+	ctx := s.T().Context()
+	s.blobStore = &failOnceBlobStore{Store: blob.NewPOSIX(s.T().TempDir()), name: "200"}
+	s.collaborativeFilteringMeta = meta.Model[cf.Score]{ID: 100}
+	s.clickThroughRateMeta = meta.Model[ctr.Score]{ID: 150}
+
+	for _, id := range []int64{100, 150, 200, 300, 400} {
+		w, done, err := s.blobStore.Create(strconv.FormatInt(id, 10))
+		s.Require().NoError(err)
+		_, err = w.Write([]byte("model"))
+		s.Require().NoError(err)
+		s.Require().NoError(w.Close())
+		<-done
+	}
+	for _, id := range []int64{100, 200, 300, 400} {
+		s.Require().NoError(s.VectorClient.AddCollection(ctx,
+			vectors.CollaborativeFilteringCollection(id), 2, vectors.Dot, vectors.VectorConfig{}))
+	}
+
+	s.removeOutOfDateModels()
+	s.removeOutOfDateModels()
+
+	collections, err := s.VectorClient.ListCollections(ctx)
+	s.Require().NoError(err)
+	s.NotContains(collections, vectors.CollaborativeFilteringCollection(200))
+	files, err := s.blobStore.List()
+	s.Require().NoError(err)
+	s.NotContains(files, "200")
+}
 
 func (s *MasterTestSuite) TestFindItemToItem() {
 	ctx := s.T().Context()


### PR DESCRIPTION
## Summary

- retain the two newest collaborative-filtering generations that have both a model blob and vector collection
- always preserve the collaborative-filtering model referenced by meta, even when it is older than the two newest generations
- recycle stale collaborative-filtering collections and their paired model blobs while preserving the active click-through-rate model and unrelated collections

## Tests

- `go test ./master -run 'TestMaster/TestRemoveOutOfDateModels$' -count=10`
- `go test ./master -count=1`
- `go test ./worker -count=1`
- `go test ./server -count=1`
- `go vet ./master`
- `git diff --check`
