### PR TITLE
feat: use inner product for IDF similarity

### DIFF
--- a/dataset/dataset.go
+++ b/dataset/dataset.go
@@ -153,30 +153,28 @@ func (d *Dataset) GetCategories() map[string]int {
 
 // GetUserIDF returns the IDF of users.
 //
-//	IDF(u) = log(I/freq(u))
+//	IDF(u) = log(1 + I/freq(u))
 //
 // I is the number of items.
 // freq(u) is the frequency of user u in all feedback.
 func (d *Dataset) GetUserIDF() []float32 {
 	idf := make([]float32, d.userDict.Count())
 	for i := int32(0); i < d.userDict.Count(); i++ {
-		// Since zero IDF will cause NaN in the future, we set the minimum value to 1e-3.
-		idf[i] = max(math32.Log(float32(len(d.items))/float32(d.userDict.Freq(i))), 1e-3)
+		idf[i] = math32.Log(1 + float32(len(d.items))/float32(d.userDict.Freq(i)))
 	}
 	return idf
 }
 
 // GetItemIDF returns the IDF of items.
 //
-//	IDF(i) = log(U/freq(i))
+//	IDF(i) = log(1 + U/freq(i))
 //
 // U is the number of users.
 // freq(i) is the frequency of item i in all feedback.
 func (d *Dataset) GetItemIDF() []float32 {
 	idf := make([]float32, d.itemDict.Count())
 	for i := int32(0); i < d.itemDict.Count(); i++ {
-		// Since zero IDF will cause NaN in the future, we set the minimum value to 1e-3.
-		idf[i] = max(math32.Log(float32(len(d.users))/float32(d.itemDict.Freq(i))), 1e-3)
+		idf[i] = math32.Log(1 + float32(len(d.users))/float32(d.itemDict.Freq(i)))
 	}
 	return idf
 }
@@ -184,8 +182,7 @@ func (d *Dataset) GetItemIDF() []float32 {
 func (d *Dataset) GetUserColumnValuesIDF() []float32 {
 	idf := make([]float32, d.userLabels.values.Count())
 	for i := int32(0); i < d.userLabels.values.Count(); i++ {
-		// Since zero IDF will cause NaN in the future, we set the minimum value to 1e-3.
-		idf[i] = max(math32.Log(float32(len(d.users))/float32(d.userLabels.values.Freq(i))), 1e-3)
+		idf[i] = math32.Log(1 + float32(len(d.users))/float32(d.userLabels.values.Freq(i)))
 	}
 	return idf
 }
@@ -193,8 +190,7 @@ func (d *Dataset) GetUserColumnValuesIDF() []float32 {
 func (d *Dataset) GetItemColumnValuesIDF() []float32 {
 	idf := make([]float32, d.itemLabels.values.Count())
 	for i := int32(0); i < d.itemLabels.values.Count(); i++ {
-		// Since zero IDF will cause NaN in the future, we set the minimum value to 1e-3.
-		idf[i] = max(math32.Log(float32(len(d.items))/float32(d.itemLabels.values.Freq(i))), 1e-3)
+		idf[i] = math32.Log(1 + float32(len(d.items))/float32(d.itemLabels.values.Freq(i)))
 	}
 	return idf
 }

--- a/dataset/dataset_test.go
+++ b/dataset/dataset_test.go
@@ -126,8 +126,8 @@ func TestDataset_GetItemColumnValuesIDF(t *testing.T) {
 	})
 	idf := dataSet.GetItemColumnValuesIDF()
 	assert.Len(t, idf, 4)
-	assert.InDelta(t, 1e-3, idf[0], 1e-6)
-	assert.InDelta(t, math32.Log(2), idf[1], 1e-6)
+	assert.InDelta(t, math32.Log(2), idf[0], 1e-6)
+	assert.InDelta(t, math32.Log(3), idf[1], 1e-6)
 }
 
 func TestDataset_AddUser(t *testing.T) {
@@ -163,8 +163,8 @@ func TestDataset_GetUserColumnValuesIDF(t *testing.T) {
 	})
 	idf := dataSet.GetUserColumnValuesIDF()
 	assert.Len(t, idf, 4)
-	assert.InDelta(t, 1e-3, idf[0], 1e-6)
-	assert.InDelta(t, math32.Log(2), idf[1], 1e-6)
+	assert.InDelta(t, math32.Log(2), idf[0], 1e-6)
+	assert.InDelta(t, math32.Log(3), idf[1], 1e-6)
 }
 
 func TestDataset_AddFeedback(t *testing.T) {
@@ -190,8 +190,8 @@ func TestDataset_AddFeedback(t *testing.T) {
 		assert.Len(t, dataSet.GetUserFeedback()[i], 10-i)
 		assert.Len(t, dataSet.GetItemFeedback()[i], i+1)
 		assert.Len(t, dataSet.timestamps[i], 10-i)
-		assert.InDelta(t, math32.Log(float32(10)/float32(10-i)), userIDF[i], 1e-2)
-		assert.InDelta(t, math32.Log(float32(10)/float32(i+1)), itemIDF[i], 1e-2)
+		assert.InDelta(t, math32.Log(1+float32(10)/float32(10-i)), userIDF[i], 1e-2)
+		assert.InDelta(t, math32.Log(1+float32(10)/float32(i+1)), itemIDF[i], 1e-2)
 	}
 }
 

--- a/logics/item_to_item.go
+++ b/logics/item_to_item.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v5"
-	"github.com/chewxy/math32"
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/expr-lang/expr"
 	"github.com/expr-lang/expr/vm"
@@ -105,6 +104,10 @@ type baseItemToItem[T any] struct {
 	index      *ann.HNSW[T]
 	items      []*data.Item
 	itemsLock  sync.Mutex
+	// innerProduct indicates that index distances are negative inner-product
+	// similarities. Such distances need explicit self/zero-similarity filtering
+	// and conversion back to similarity scores.
+	innerProduct bool
 	// Hidden items are stored separately without adding to the index,
 	// and they have neighbors but are not neighbors of other items.
 	hiddenItems   []*data.Item
@@ -148,23 +151,40 @@ func (b *baseItemToItem[T]) PopAll(i int) []cache.Score {
 	if i < len(b.items) {
 		// Non-hidden item: search by index
 		var err error
-		results, err = b.index.SearchIndex(i, b.n+1, true)
+		results, err = b.index.SearchIndex(i, b.n+1, !b.innerProduct)
 		if err != nil {
 			log.Logger().Error("failed to search index", zap.Error(err))
 			return nil
 		}
 	} else {
 		// Hidden item: search by vector
-		results = b.index.SearchVector(b.hiddenVectors[i-len(b.items)], b.n, true)
+		results = b.index.SearchVector(b.hiddenVectors[i-len(b.items)], b.n, !b.innerProduct)
 	}
-	return lo.Map(results, func(v lo.Tuple2[int, float32], _ int) cache.Score {
-		return cache.Score{
+	scores := make([]cache.Score, 0, b.n)
+	for _, v := range results {
+		if b.innerProduct {
+			if i < len(b.items) && v.A == i {
+				continue
+			}
+			if v.B >= 0 {
+				continue
+			}
+		}
+		score := 1.0 / (1.0 + float64(v.B))
+		if b.innerProduct {
+			score = -float64(v.B)
+		}
+		scores = append(scores, cache.Score{
 			Id:         b.items[v.A].ItemId,
 			Categories: b.items[v.A].Categories,
-			Score:      1.0 / (1.0 + float64(v.B)),
+			Score:      score,
 			Timestamp:  b.timestamp,
+		})
+		if len(scores) == b.n {
+			break
 		}
-	})
+	}
+	return scores
 }
 
 type embeddingItemToItem struct {
@@ -234,11 +254,12 @@ func newTagsItemToItem(cfg config.ItemToItemConfig, n int, timestamp time.Time, 
 	}
 	t := &tagsItemToItem{IDF: idf}
 	t.baseItemToItem = baseItemToItem[[]dataset.ID]{
-		name:       cfg.Name,
-		n:          n,
-		timestamp:  timestamp,
-		columnFunc: columnFunc,
-		index:      ann.NewHNSW(t.distance),
+		name:         cfg.Name,
+		n:            n,
+		timestamp:    timestamp,
+		columnFunc:   columnFunc,
+		index:        ann.NewHNSW(t.distance),
+		innerProduct: true,
 	}
 	return t, nil
 }
@@ -272,10 +293,11 @@ func newUsersItemToItem(cfg config.ItemToItemConfig, n int, timestamp time.Time,
 	}
 	u := &usersItemToItem{IDF: idf}
 	u.baseItemToItem = baseItemToItem[[]int32]{
-		name:      cfg.Name,
-		n:         n,
-		timestamp: timestamp,
-		index:     ann.NewHNSW(u.distance),
+		name:         cfg.Name,
+		n:            n,
+		timestamp:    timestamp,
+		index:        ann.NewHNSW(u.distance),
+		innerProduct: true,
 	}
 	return u, nil
 }
@@ -298,10 +320,11 @@ func newAutoItemToItem(cfg config.ItemToItemConfig, n int, timestamp time.Time, 
 		uIDF: uIDF,
 	}
 	a.baseItemToItem = baseItemToItem[lo.Tuple2[[]dataset.ID, []int32]]{
-		name:      cfg.Name,
-		n:         n,
-		timestamp: timestamp,
-		index:     ann.NewHNSW[lo.Tuple2[[]dataset.ID, []int32]](a.distance),
+		name:         cfg.Name,
+		n:            n,
+		timestamp:    timestamp,
+		index:        ann.NewHNSW[lo.Tuple2[[]dataset.ID, []int32]](a.distance),
+		innerProduct: true,
 	}
 	return a, nil
 }
@@ -324,28 +347,14 @@ func (a *autoItemToItem) distance(u, v lo.Tuple2[[]dataset.ID, []int32]) float32
 type IDF[T dataset.ID | int32] []float32
 
 func (idf IDF[T]) distance(a, b []T) float32 {
-	commonSum, commonCount := idf.weightedSumCommonElements(a, b)
-	if len(a) == len(b) && commonCount == float32(len(a)) {
-		// If two items have the same tags, its distance is zero.
-		return 0
-	} else if commonCount > 0 && len(a) > 0 && len(b) > 0 {
-		// Add shrinkage to avoid division by zero
-		return 1 - commonSum*commonCount/
-			math32.Sqrt(idf.weightedSum(a))/
-			math32.Sqrt(idf.weightedSum(b))/
-			(commonCount+100)
-	} else {
-		// If two items have no common tags, its distance is one.
-		return 1
-	}
+	return -idf.similarity(a, b)
 }
 
-func (idf IDF[T]) weightedSumCommonElements(a, b []T) (float32, float32) {
-	i, j, sum, count := 0, 0, float32(0), float32(0)
+func (idf IDF[T]) similarity(a, b []T) float32 {
+	i, j, sum := 0, 0, float32(0)
 	for i < len(a) && j < len(b) {
 		if a[i] == b[j] {
 			sum += idf[a[i]]
-			count++
 			i++
 			j++
 		} else if a[i] < b[j] {
@@ -353,14 +362,6 @@ func (idf IDF[T]) weightedSumCommonElements(a, b []T) (float32, float32) {
 		} else if a[i] > b[j] {
 			j++
 		}
-	}
-	return sum, count
-}
-
-func (idf IDF[T]) weightedSum(a []T) float32 {
-	var sum float32
-	for _, i := range a {
-		sum += idf[i]
 	}
 	return sum
 }

--- a/logics/item_to_item_test.go
+++ b/logics/item_to_item_test.go
@@ -158,6 +158,31 @@ func (suite *ItemToItemTestSuite) TestHidden() {
 	}
 }
 
+func (suite *ItemToItemTestSuite) TestIDFInnerProduct() {
+	idf := IDF[dataset.ID]{0, 1, 2, 3, 4}
+
+	suite.InDelta(5, idf.similarity([]dataset.ID{1, 2, 3}, []dataset.ID{2, 3, 4}), 1e-6)
+	suite.InDelta(0, idf.similarity([]dataset.ID{1}, []dataset.ID{4}), 1e-6)
+}
+
+func (suite *ItemToItemTestSuite) TestTagsInnerProductScores() {
+	item2item, err := newTagsItemToItem(config.ItemToItemConfig{
+		Column: "item.Labels",
+	}, 2, time.Now(), []float32{0, 1, 2})
+	suite.NoError(err)
+
+	item2item.Push(&data.Item{ItemId: "query", Labels: []dataset.ID{1, 2}}, nil)
+	item2item.Push(&data.Item{ItemId: "idf-2", Labels: []dataset.ID{2}}, nil)
+	item2item.Push(&data.Item{ItemId: "idf-1", Labels: []dataset.ID{1}}, nil)
+
+	scores := item2item.PopAll(0)
+	suite.Require().Len(scores, 2)
+	suite.Equal("idf-2", scores[0].Id)
+	suite.InDelta(2, scores[0].Score, 1e-6)
+	suite.Equal("idf-1", scores[1].Id)
+	suite.InDelta(1, scores[1].Score, 1e-6)
+}
+
 func (suite *ItemToItemTestSuite) TestTags() {
 	timestamp := time.Now()
 	idf := make([]float32, 101)

--- a/logics/user_to_user.go
+++ b/logics/user_to_user.go
@@ -70,13 +70,14 @@ func NewUserToUser(cfg config.UserToUserConfig, n int, timestamp time.Time, opts
 }
 
 type baseUserToUser[T any] struct {
-	name       string
-	n          int
-	timestamp  time.Time
-	columnFunc *vm.Program
-	index      *ann.HNSW[T]
-	users      []*data.User
-	usersLock  sync.Mutex
+	name         string
+	n            int
+	timestamp    time.Time
+	columnFunc   *vm.Program
+	index        *ann.HNSW[T]
+	users        []*data.User
+	usersLock    sync.Mutex
+	innerProduct bool
 }
 
 func (b *baseUserToUser[T]) Users() []*data.User {
@@ -88,18 +89,32 @@ func (b *baseUserToUser[T]) Timestamp() time.Time {
 }
 
 func (b *baseUserToUser[T]) PopAll(i int) []cache.Score {
-	scores, err := b.index.SearchIndex(i, b.n+1, true)
+	results, err := b.index.SearchIndex(i, b.n+1, !b.innerProduct)
 	if err != nil {
 		log.Logger().Error("failed to search index", zap.Error(err))
 		return nil
 	}
-	return lo.Map(scores, func(v lo.Tuple2[int, float32], _ int) cache.Score {
-		return cache.Score{
-			Id:        b.users[v.A].UserId,
-			Score:     1.0 / (1.0 + float64(v.B)),
-			Timestamp: b.timestamp,
+	scores := make([]cache.Score, 0, b.n)
+	for _, v := range results {
+		if b.innerProduct {
+			if v.A == i || v.B >= 0 {
+				continue
+			}
 		}
-	})
+		score := 1.0 / (1.0 + float64(v.B))
+		if b.innerProduct {
+			score = -float64(v.B)
+		}
+		scores = append(scores, cache.Score{
+			Id:        b.users[v.A].UserId,
+			Score:     score,
+			Timestamp: b.timestamp,
+		})
+		if len(scores) == b.n {
+			break
+		}
+	}
+	return scores
 }
 
 type embeddingUserToUser struct {
@@ -172,11 +187,12 @@ func newTagsUserToUser(cfg config.UserToUserConfig, n int, timestamp time.Time, 
 	}
 	t := &tagsUserToUser{IDF: idf}
 	t.baseUserToUser = baseUserToUser[[]dataset.ID]{
-		name:       cfg.Name,
-		n:          n,
-		timestamp:  timestamp,
-		columnFunc: columnFunc,
-		index:      ann.NewHNSW[[]dataset.ID](t.distance),
+		name:         cfg.Name,
+		n:            n,
+		timestamp:    timestamp,
+		columnFunc:   columnFunc,
+		index:        ann.NewHNSW[[]dataset.ID](t.distance),
+		innerProduct: true,
 	}
 	return t, nil
 }
@@ -216,10 +232,11 @@ func newItemsUserToUser(cfg config.UserToUserConfig, n int, timestamp time.Time,
 	}
 	i := &itemsUserToUser{IDF: idf}
 	i.baseUserToUser = baseUserToUser[[]int32]{
-		name:      cfg.Name,
-		n:         n,
-		timestamp: timestamp,
-		index:     ann.NewHNSW[[]int32](i.distance),
+		name:         cfg.Name,
+		n:            n,
+		timestamp:    timestamp,
+		index:        ann.NewHNSW[[]int32](i.distance),
+		innerProduct: true,
 	}
 	return i, nil
 }
@@ -249,10 +266,11 @@ func newAutoUserToUser(cfg config.UserToUserConfig, n int, timestamp time.Time, 
 		iIDF: iIDF,
 	}
 	a.baseUserToUser = baseUserToUser[lo.Tuple2[[]dataset.ID, []int32]]{
-		name:      cfg.Name,
-		n:         n,
-		timestamp: timestamp,
-		index:     ann.NewHNSW[lo.Tuple2[[]dataset.ID, []int32]](a.distance),
+		name:         cfg.Name,
+		n:            n,
+		timestamp:    timestamp,
+		index:        ann.NewHNSW[lo.Tuple2[[]dataset.ID, []int32]](a.distance),
+		innerProduct: true,
 	}
 	return a, nil
 }

--- a/logics/user_to_user_test.go
+++ b/logics/user_to_user_test.go
@@ -61,6 +61,22 @@ func (suite *UserToUserTestSuite) TestEmbedding() {
 	}
 }
 
+func (suite *UserToUserTestSuite) TestIDFInnerProductScores() {
+	user2user, err := newItemsUserToUser(config.UserToUserConfig{}, 2, time.Now(), []float32{0, 1, 2})
+	suite.NoError(err)
+
+	user2user.Push(&data.User{UserId: "query"}, []int32{1, 2})
+	user2user.Push(&data.User{UserId: "idf-2"}, []int32{2})
+	user2user.Push(&data.User{UserId: "idf-1"}, []int32{1})
+
+	scores := user2user.PopAll(0)
+	suite.Require().Len(scores, 2)
+	suite.Equal("idf-2", scores[0].Id)
+	suite.InDelta(2, scores[0].Score, 1e-6)
+	suite.Equal("idf-1", scores[1].Id)
+	suite.InDelta(1, scores[1].Score, 1e-6)
+}
+
 func (suite *UserToUserTestSuite) TestTags() {
 	timestamp := time.Now()
 	idf := make([]float32, 101)


### PR DESCRIPTION
## Summary

- change IDF to `log(1 + N/df)`
- replace weighted cosine with sparse inner-product similarity, equivalent to storing `sqrt(IDF)` values
- keep HNSW distance ordering by using negative similarity internally and restore positive scores in recommendation caches
- update both item-to-item and user-to-user IDF recommenders

## Testing

- `go test ./dataset ./logics -count=1`
- `go vet ./dataset ./logics`
- `git diff --check`