### PR TITLE
feat(vectors): add batch vector retrieval

### DIFF
--- a/protocol/vector_store.pb.go
+++ b/protocol/vector_store.pb.go
@@ -1028,6 +1028,102 @@ func (x *CountVectorsResponse) GetCount() int64 {
 	return 0
 }
 
+type GetVectorsRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Collection    string                 `protobuf:"bytes,1,opt,name=collection,proto3" json:"collection,omitempty"`
+	Ids           []string               `protobuf:"bytes,2,rep,name=ids,proto3" json:"ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVectorsRequest) Reset() {
+	*x = GetVectorsRequest{}
+	mi := &file_vector_store_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVectorsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVectorsRequest) ProtoMessage() {}
+
+func (x *GetVectorsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_vector_store_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVectorsRequest.ProtoReflect.Descriptor instead.
+func (*GetVectorsRequest) Descriptor() ([]byte, []int) {
+	return file_vector_store_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *GetVectorsRequest) GetCollection() string {
+	if x != nil {
+		return x.Collection
+	}
+	return ""
+}
+
+func (x *GetVectorsRequest) GetIds() []string {
+	if x != nil {
+		return x.Ids
+	}
+	return nil
+}
+
+type GetVectorsResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Vectors       []*Vector              `protobuf:"bytes,1,rep,name=vectors,proto3" json:"vectors,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetVectorsResponse) Reset() {
+	*x = GetVectorsResponse{}
+	mi := &file_vector_store_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetVectorsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetVectorsResponse) ProtoMessage() {}
+
+func (x *GetVectorsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_vector_store_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetVectorsResponse.ProtoReflect.Descriptor instead.
+func (*GetVectorsResponse) Descriptor() ([]byte, []int) {
+	return file_vector_store_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *GetVectorsResponse) GetVectors() []*Vector {
+	if x != nil {
+		return x.Vectors
+	}
+	return nil
+}
+
 var File_vector_store_proto protoreflect.FileDescriptor
 
 const file_vector_store_proto_rawDesc = "" +
@@ -1099,13 +1195,20 @@ const file_vector_store_proto_rawDesc = "" +
 	"collection\x18\x01 \x01(\tR\n" +
 	"collection\",\n" +
 	"\x14CountVectorsResponse\x12\x14\n" +
-	"\x05count\x18\x01 \x01(\x03R\x05count*;\n" +
+	"\x05count\x18\x01 \x01(\x03R\x05count\"E\n" +
+	"\x11GetVectorsRequest\x12\x1e\n" +
+	"\n" +
+	"collection\x18\x01 \x01(\tR\n" +
+	"collection\x12\x10\n" +
+	"\x03ids\x18\x02 \x03(\tR\x03ids\"@\n" +
+	"\x12GetVectorsResponse\x12*\n" +
+	"\avectors\x18\x01 \x03(\v2\x10.protocol.VectorR\avectors*;\n" +
 	"\bDistance\x12\v\n" +
 	"\aUnknown\x10\x00\x12\n" +
 	"\n" +
 	"\x06Cosine\x10\x01\x12\r\n" +
 	"\tEuclidean\x10\x02\x12\a\n" +
-	"\x03Dot\x10\x032\xbc\x05\n" +
+	"\x03Dot\x10\x032\x87\x06\n" +
 	"\vVectorStore\x12X\n" +
 	"\x0fListCollections\x12 .protocol.ListCollectionsRequest\x1a!.protocol.ListCollectionsResponse\"\x00\x12a\n" +
 	"\x12DescribeCollection\x12#.protocol.DescribeCollectionRequest\x1a$.protocol.DescribeCollectionResponse\"\x00\x12R\n" +
@@ -1113,7 +1216,9 @@ const file_vector_store_proto_rawDesc = "" +
 	"\x10DeleteCollection\x12!.protocol.DeleteCollectionRequest\x1a\".protocol.DeleteCollectionResponse\"\x00\x12O\n" +
 	"\fCountVectors\x12\x1d.protocol.CountVectorsRequest\x1a\x1e.protocol.CountVectorsResponse\"\x00\x12I\n" +
 	"\n" +
-	"AddVectors\x12\x1b.protocol.AddVectorsRequest\x1a\x1c.protocol.AddVectorsResponse\"\x00\x12R\n" +
+	"AddVectors\x12\x1b.protocol.AddVectorsRequest\x1a\x1c.protocol.AddVectorsResponse\"\x00\x12I\n" +
+	"\n" +
+	"GetVectors\x12\x1b.protocol.GetVectorsRequest\x1a\x1c.protocol.GetVectorsResponse\"\x00\x12R\n" +
 	"\rDeleteVectors\x12\x1e.protocol.DeleteVectorsRequest\x1a\x1f.protocol.DeleteVectorsResponse\"\x00\x12O\n" +
 	"\fQueryVectors\x12\x1d.protocol.QueryVectorsRequest\x1a\x1e.protocol.QueryVectorsResponse\"\x00B$Z\"github.com/gorse-io/gorse/protocolb\x06proto3"
 
@@ -1130,7 +1235,7 @@ func file_vector_store_proto_rawDescGZIP() []byte {
 }
 
 var file_vector_store_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_vector_store_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
+var file_vector_store_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
 var file_vector_store_proto_goTypes = []any{
 	(Distance)(0),                      // 0: protocol.Distance
 	(*Vector)(nil),                     // 1: protocol.Vector
@@ -1152,40 +1257,45 @@ var file_vector_store_proto_goTypes = []any{
 	(*QueryVectorsResponse)(nil),       // 17: protocol.QueryVectorsResponse
 	(*CountVectorsRequest)(nil),        // 18: protocol.CountVectorsRequest
 	(*CountVectorsResponse)(nil),       // 19: protocol.CountVectorsResponse
-	(*timestamppb.Timestamp)(nil),      // 20: google.protobuf.Timestamp
+	(*GetVectorsRequest)(nil),          // 20: protocol.GetVectorsRequest
+	(*GetVectorsResponse)(nil),         // 21: protocol.GetVectorsResponse
+	(*timestamppb.Timestamp)(nil),      // 22: google.protobuf.Timestamp
 }
 var file_vector_store_proto_depIdxs = []int32{
-	20, // 0: protocol.Vector.timestamp:type_name -> google.protobuf.Timestamp
+	22, // 0: protocol.Vector.timestamp:type_name -> google.protobuf.Timestamp
 	1,  // 1: protocol.ScoredVector.vector:type_name -> protocol.Vector
 	0,  // 2: protocol.DescribeCollectionResponse.distance:type_name -> protocol.Distance
 	5,  // 3: protocol.DescribeCollectionResponse.config:type_name -> protocol.VectorConfig
 	0,  // 4: protocol.AddCollectionRequest.distance:type_name -> protocol.Distance
 	5,  // 5: protocol.AddCollectionRequest.config:type_name -> protocol.VectorConfig
 	1,  // 6: protocol.AddVectorsRequest.vectors:type_name -> protocol.Vector
-	20, // 7: protocol.DeleteVectorsRequest.timestamp:type_name -> google.protobuf.Timestamp
+	22, // 7: protocol.DeleteVectorsRequest.timestamp:type_name -> google.protobuf.Timestamp
 	1,  // 8: protocol.QueryVectorsRequest.query:type_name -> protocol.Vector
 	2,  // 9: protocol.QueryVectorsResponse.vectors:type_name -> protocol.ScoredVector
-	3,  // 10: protocol.VectorStore.ListCollections:input_type -> protocol.ListCollectionsRequest
-	6,  // 11: protocol.VectorStore.DescribeCollection:input_type -> protocol.DescribeCollectionRequest
-	8,  // 12: protocol.VectorStore.AddCollection:input_type -> protocol.AddCollectionRequest
-	10, // 13: protocol.VectorStore.DeleteCollection:input_type -> protocol.DeleteCollectionRequest
-	18, // 14: protocol.VectorStore.CountVectors:input_type -> protocol.CountVectorsRequest
-	12, // 15: protocol.VectorStore.AddVectors:input_type -> protocol.AddVectorsRequest
-	14, // 16: protocol.VectorStore.DeleteVectors:input_type -> protocol.DeleteVectorsRequest
-	16, // 17: protocol.VectorStore.QueryVectors:input_type -> protocol.QueryVectorsRequest
-	4,  // 18: protocol.VectorStore.ListCollections:output_type -> protocol.ListCollectionsResponse
-	7,  // 19: protocol.VectorStore.DescribeCollection:output_type -> protocol.DescribeCollectionResponse
-	9,  // 20: protocol.VectorStore.AddCollection:output_type -> protocol.AddCollectionResponse
-	11, // 21: protocol.VectorStore.DeleteCollection:output_type -> protocol.DeleteCollectionResponse
-	19, // 22: protocol.VectorStore.CountVectors:output_type -> protocol.CountVectorsResponse
-	13, // 23: protocol.VectorStore.AddVectors:output_type -> protocol.AddVectorsResponse
-	15, // 24: protocol.VectorStore.DeleteVectors:output_type -> protocol.DeleteVectorsResponse
-	17, // 25: protocol.VectorStore.QueryVectors:output_type -> protocol.QueryVectorsResponse
-	18, // [18:26] is the sub-list for method output_type
-	10, // [10:18] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	1,  // 10: protocol.GetVectorsResponse.vectors:type_name -> protocol.Vector
+	3,  // 11: protocol.VectorStore.ListCollections:input_type -> protocol.ListCollectionsRequest
+	6,  // 12: protocol.VectorStore.DescribeCollection:input_type -> protocol.DescribeCollectionRequest
+	8,  // 13: protocol.VectorStore.AddCollection:input_type -> protocol.AddCollectionRequest
+	10, // 14: protocol.VectorStore.DeleteCollection:input_type -> protocol.DeleteCollectionRequest
+	18, // 15: protocol.VectorStore.CountVectors:input_type -> protocol.CountVectorsRequest
+	12, // 16: protocol.VectorStore.AddVectors:input_type -> protocol.AddVectorsRequest
+	20, // 17: protocol.VectorStore.GetVectors:input_type -> protocol.GetVectorsRequest
+	14, // 18: protocol.VectorStore.DeleteVectors:input_type -> protocol.DeleteVectorsRequest
+	16, // 19: protocol.VectorStore.QueryVectors:input_type -> protocol.QueryVectorsRequest
+	4,  // 20: protocol.VectorStore.ListCollections:output_type -> protocol.ListCollectionsResponse
+	7,  // 21: protocol.VectorStore.DescribeCollection:output_type -> protocol.DescribeCollectionResponse
+	9,  // 22: protocol.VectorStore.AddCollection:output_type -> protocol.AddCollectionResponse
+	11, // 23: protocol.VectorStore.DeleteCollection:output_type -> protocol.DeleteCollectionResponse
+	19, // 24: protocol.VectorStore.CountVectors:output_type -> protocol.CountVectorsResponse
+	13, // 25: protocol.VectorStore.AddVectors:output_type -> protocol.AddVectorsResponse
+	21, // 26: protocol.VectorStore.GetVectors:output_type -> protocol.GetVectorsResponse
+	15, // 27: protocol.VectorStore.DeleteVectors:output_type -> protocol.DeleteVectorsResponse
+	17, // 28: protocol.VectorStore.QueryVectors:output_type -> protocol.QueryVectorsResponse
+	20, // [20:29] is the sub-list for method output_type
+	11, // [11:20] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_vector_store_proto_init() }
@@ -1199,7 +1309,7 @@ func file_vector_store_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_vector_store_proto_rawDesc), len(file_vector_store_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   19,
+			NumMessages:   21,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/protocol/vector_store.proto
+++ b/protocol/vector_store.proto
@@ -101,6 +101,13 @@ message CountVectorsRequest { string collection = 1; }
 
 message CountVectorsResponse { int64 count = 1; }
 
+message GetVectorsRequest {
+  string collection = 1;
+  repeated string ids = 2;
+}
+
+message GetVectorsResponse { repeated Vector vectors = 1; }
+
 service VectorStore {
   rpc ListCollections(ListCollectionsRequest) returns (ListCollectionsResponse) {}
   rpc DescribeCollection(DescribeCollectionRequest) returns (DescribeCollectionResponse) {}
@@ -108,6 +115,7 @@ service VectorStore {
   rpc DeleteCollection(DeleteCollectionRequest) returns (DeleteCollectionResponse) {}
   rpc CountVectors(CountVectorsRequest) returns (CountVectorsResponse) {}
   rpc AddVectors(AddVectorsRequest) returns (AddVectorsResponse) {}
+  rpc GetVectors(GetVectorsRequest) returns (GetVectorsResponse) {}
   rpc DeleteVectors(DeleteVectorsRequest) returns (DeleteVectorsResponse) {}
   rpc QueryVectors(QueryVectorsRequest) returns (QueryVectorsResponse) {}
 }

--- a/protocol/vector_store_grpc.pb.go
+++ b/protocol/vector_store_grpc.pb.go
@@ -39,6 +39,7 @@ const (
 	VectorStore_DeleteCollection_FullMethodName   = "/protocol.VectorStore/DeleteCollection"
 	VectorStore_CountVectors_FullMethodName       = "/protocol.VectorStore/CountVectors"
 	VectorStore_AddVectors_FullMethodName         = "/protocol.VectorStore/AddVectors"
+	VectorStore_GetVectors_FullMethodName         = "/protocol.VectorStore/GetVectors"
 	VectorStore_DeleteVectors_FullMethodName      = "/protocol.VectorStore/DeleteVectors"
 	VectorStore_QueryVectors_FullMethodName       = "/protocol.VectorStore/QueryVectors"
 )
@@ -53,6 +54,7 @@ type VectorStoreClient interface {
 	DeleteCollection(ctx context.Context, in *DeleteCollectionRequest, opts ...grpc.CallOption) (*DeleteCollectionResponse, error)
 	CountVectors(ctx context.Context, in *CountVectorsRequest, opts ...grpc.CallOption) (*CountVectorsResponse, error)
 	AddVectors(ctx context.Context, in *AddVectorsRequest, opts ...grpc.CallOption) (*AddVectorsResponse, error)
+	GetVectors(ctx context.Context, in *GetVectorsRequest, opts ...grpc.CallOption) (*GetVectorsResponse, error)
 	DeleteVectors(ctx context.Context, in *DeleteVectorsRequest, opts ...grpc.CallOption) (*DeleteVectorsResponse, error)
 	QueryVectors(ctx context.Context, in *QueryVectorsRequest, opts ...grpc.CallOption) (*QueryVectorsResponse, error)
 }
@@ -125,6 +127,16 @@ func (c *vectorStoreClient) AddVectors(ctx context.Context, in *AddVectorsReques
 	return out, nil
 }
 
+func (c *vectorStoreClient) GetVectors(ctx context.Context, in *GetVectorsRequest, opts ...grpc.CallOption) (*GetVectorsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetVectorsResponse)
+	err := c.cc.Invoke(ctx, VectorStore_GetVectors_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *vectorStoreClient) DeleteVectors(ctx context.Context, in *DeleteVectorsRequest, opts ...grpc.CallOption) (*DeleteVectorsResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(DeleteVectorsResponse)
@@ -155,6 +167,7 @@ type VectorStoreServer interface {
 	DeleteCollection(context.Context, *DeleteCollectionRequest) (*DeleteCollectionResponse, error)
 	CountVectors(context.Context, *CountVectorsRequest) (*CountVectorsResponse, error)
 	AddVectors(context.Context, *AddVectorsRequest) (*AddVectorsResponse, error)
+	GetVectors(context.Context, *GetVectorsRequest) (*GetVectorsResponse, error)
 	DeleteVectors(context.Context, *DeleteVectorsRequest) (*DeleteVectorsResponse, error)
 	QueryVectors(context.Context, *QueryVectorsRequest) (*QueryVectorsResponse, error)
 	mustEmbedUnimplementedVectorStoreServer()
@@ -184,6 +197,9 @@ func (UnimplementedVectorStoreServer) CountVectors(context.Context, *CountVector
 }
 func (UnimplementedVectorStoreServer) AddVectors(context.Context, *AddVectorsRequest) (*AddVectorsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method AddVectors not implemented")
+}
+func (UnimplementedVectorStoreServer) GetVectors(context.Context, *GetVectorsRequest) (*GetVectorsResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetVectors not implemented")
 }
 func (UnimplementedVectorStoreServer) DeleteVectors(context.Context, *DeleteVectorsRequest) (*DeleteVectorsResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method DeleteVectors not implemented")
@@ -320,6 +336,24 @@ func _VectorStore_AddVectors_Handler(srv interface{}, ctx context.Context, dec f
 	return interceptor(ctx, in, info, handler)
 }
 
+func _VectorStore_GetVectors_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetVectorsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(VectorStoreServer).GetVectors(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: VectorStore_GetVectors_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(VectorStoreServer).GetVectors(ctx, req.(*GetVectorsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _VectorStore_DeleteVectors_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(DeleteVectorsRequest)
 	if err := dec(in); err != nil {
@@ -386,6 +420,10 @@ var VectorStore_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "AddVectors",
 			Handler:    _VectorStore_AddVectors_Handler,
+		},
+		{
+			MethodName: "GetVectors",
+			Handler:    _VectorStore_GetVectors_Handler,
 		},
 		{
 			MethodName: "DeleteVectors",

--- a/storage/vectors/database.go
+++ b/storage/vectors/database.go
@@ -104,8 +104,28 @@ type Database interface {
 	DeleteCollection(ctx context.Context, name string) error
 	CountVectors(ctx context.Context, collection string) (int64, error)
 	AddVectors(ctx context.Context, collection string, vectors []Vector) error
+	GetVectors(ctx context.Context, collection string, ids []string) ([]Vector, error)
 	DeleteVectors(ctx context.Context, collection string, timestamp time.Time) error
 	QueryVectors(ctx context.Context, collection string, q Vector, categories []string, topK int) ([]ScoredVector, error)
+}
+
+func orderVectors(ids []string, vectors []Vector) []Vector {
+	byID := make(map[string]Vector, len(vectors))
+	for _, vector := range vectors {
+		byID[vector.Id] = vector
+	}
+	ordered := make([]Vector, 0, len(vectors))
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		if vector, exists := byID[id]; exists {
+			ordered = append(ordered, vector)
+		}
+	}
+	return ordered
 }
 
 // Creator creates a database instance.

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -138,6 +138,38 @@ func (suite *vectorsTestSuite) TestVectors() {
 	}
 }
 
+func (suite *vectorsTestSuite) TestGetVectors() {
+	ctx := suite.T().Context()
+	err := suite.Database.AddCollection(ctx, "test", defaultVectorSize, Cosine, VectorConfig{})
+	suite.Require().NoError(err)
+
+	timestampA := time.Now().UTC().Truncate(time.Millisecond)
+	timestampB := timestampA.Add(time.Second)
+	vectorA := Vector{
+		Id:         "a",
+		Values:     []float32{1, 0, 0, 0},
+		Categories: []string{"cat-a", "common"},
+		Timestamp:  timestampA,
+	}
+	vectorB := Vector{
+		Id:         "b",
+		Values:     []float32{0, 1, 0, 0},
+		IsHidden:   true,
+		Categories: []string{"cat-b", "common"},
+		Timestamp:  timestampB,
+	}
+	err = suite.Database.AddVectors(ctx, "test", []Vector{vectorA, vectorB})
+	suite.Require().NoError(err)
+
+	results, err := suite.Database.GetVectors(ctx, "test", []string{"b", "missing", "a"})
+	suite.Require().NoError(err)
+	suite.Equal([]Vector{vectorB, vectorA}, results)
+
+	results, err = suite.Database.GetVectors(ctx, "test", nil)
+	suite.Require().NoError(err)
+	suite.Empty(results)
+}
+
 func (suite *vectorsTestSuite) TestSparse() {
 	ctx := suite.T().Context()
 	err := suite.Database.AddCollection(ctx, "test_sparse", 0, Dot, VectorConfig{})

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -161,7 +161,7 @@ func (suite *vectorsTestSuite) TestGetVectors() {
 	err = suite.Database.AddVectors(ctx, "test", []Vector{vectorA, vectorB})
 	suite.Require().NoError(err)
 
-	results, err := suite.Database.GetVectors(ctx, "test", []string{"b", "missing", "a"})
+	results, err := suite.Database.GetVectors(ctx, "test", []string{"b", "missing", "a", "b"})
 	suite.Require().NoError(err)
 	suite.Equal([]Vector{vectorB, vectorA}, results)
 

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -192,6 +192,14 @@ func (suite *vectorsTestSuite) TestSparse() {
 	suite.Require().NoError(err)
 	suite.Equal(int64(3), count)
 
+	vectors, err := suite.Database.GetVectors(ctx, "test_sparse", []string{"match", "missing"})
+	suite.Require().NoError(err)
+	suite.Require().Len(vectors, 1)
+	suite.Equal("match", vectors[0].Id)
+	suite.Equal([]uint32{1, 100}, vectors[0].Indices)
+	suite.Equal([]float32{1, 2}, vectors[0].Values)
+	suite.Equal(cutoff, vectors[0].Timestamp)
+
 	results, err := suite.Database.QueryVectors(ctx, "test_sparse", Vector{
 		Indices: []uint32{1, 100},
 		Values:  []float32{1, 2},

--- a/storage/vectors/milvus.go
+++ b/storage/vectors/milvus.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -305,11 +306,17 @@ func (db *Milvus) AddVectors(ctx context.Context, collection string, vectors []V
 }
 
 func (db *Milvus) GetVectors(ctx context.Context, collection string, ids []string) ([]Vector, error) {
+	return getMilvusVectors(ctx, collection, ids, func(ctx context.Context, option milvusclient.QueryOption) (milvusclient.ResultSet, error) {
+		return db.client.Query(ctx, option)
+	})
+}
+
+func getMilvusVectors(ctx context.Context, collection string, ids []string, query func(context.Context, milvusclient.QueryOption) (milvusclient.ResultSet, error)) ([]Vector, error) {
 	if len(ids) == 0 {
 		return []Vector{}, nil
 	}
-	result, err := db.client.Query(ctx, milvusclient.NewQueryOption(collection).
-		WithIDs(column.NewColumnVarChar(milvusIdField, ids)).
+	result, err := query(ctx, milvusclient.NewQueryOption(collection).
+		WithIDs(column.NewColumnVarChar(milvusIdField, slices.Clone(ids))).
 		WithOutputFields(milvusIdField, milvusCategoriesField, milvusHiddenField, milvusTimestampField, milvusVectorField).
 		WithConsistencyLevel(entity.ClStrong))
 	if err != nil {

--- a/storage/vectors/milvus.go
+++ b/storage/vectors/milvus.go
@@ -304,6 +304,83 @@ func (db *Milvus) AddVectors(ctx context.Context, collection string, vectors []V
 	return errors.Trace(err)
 }
 
+func (db *Milvus) GetVectors(ctx context.Context, collection string, ids []string) ([]Vector, error) {
+	if len(ids) == 0 {
+		return []Vector{}, nil
+	}
+	result, err := db.client.Query(ctx, milvusclient.NewQueryOption(collection).
+		WithIDs(column.NewColumnVarChar(milvusIdField, ids)).
+		WithOutputFields(milvusIdField, milvusCategoriesField, milvusHiddenField, milvusTimestampField, milvusVectorField).
+		WithConsistencyLevel(entity.ClStrong))
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	idCol, ok := result.GetColumn(milvusIdField).(*column.ColumnVarChar)
+	if !ok {
+		return nil, errors.Errorf("failed to parse vector ids for collection %s", collection)
+	}
+	categoriesCol, ok := result.GetColumn(milvusCategoriesField).(*column.ColumnVarCharArray)
+	if !ok {
+		return nil, errors.Errorf("failed to parse vector categories for collection %s", collection)
+	}
+	hiddenCol, ok := result.GetColumn(milvusHiddenField).(*column.ColumnBool)
+	if !ok {
+		return nil, errors.Errorf("failed to parse vector visibility for collection %s", collection)
+	}
+	timestampCol, ok := result.GetColumn(milvusTimestampField).(*column.ColumnInt64)
+	if !ok {
+		return nil, errors.Errorf("failed to parse vector timestamps for collection %s", collection)
+	}
+	vectorCol := result.GetColumn(milvusVectorField)
+	vectors := make([]Vector, 0, result.Len())
+	for i := 0; i < result.Len(); i++ {
+		id, err := idCol.Value(i)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		categories, err := categoriesCol.Value(i)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		hidden, err := hiddenCol.Value(i)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		timestamp, err := timestampCol.Value(i)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		vector := Vector{
+			Id:         id,
+			IsHidden:   hidden,
+			Categories: categories,
+			Timestamp:  time.UnixMilli(timestamp).UTC(),
+		}
+		switch values := vectorCol.(type) {
+		case *column.ColumnFloatVector:
+			value, err := values.Value(i)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			vector.Values = []float32(value)
+		case *column.ColumnSparseFloatVector:
+			value, err := values.Value(i)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			vector.Indices = make([]uint32, value.Len())
+			vector.Values = make([]float32, value.Len())
+			for j := 0; j < value.Len(); j++ {
+				vector.Indices[j], vector.Values[j], _ = value.Get(j)
+			}
+		default:
+			return nil, errors.Errorf("failed to parse vector values for collection %s", collection)
+		}
+		vectors = append(vectors, vector)
+	}
+	return orderVectors(ids, vectors), nil
+}
+
 func (db *Milvus) DeleteVectors(ctx context.Context, collection string, timestamp time.Time) error {
 	_, err := db.client.Delete(ctx, milvusclient.NewDeleteOption(collection).WithExpr(fmt.Sprintf("%s < %d", milvusTimestampField, timestamp.UnixMilli())))
 	return errors.Trace(err)

--- a/storage/vectors/milvus.go
+++ b/storage/vectors/milvus.go
@@ -315,6 +315,10 @@ func (db *Milvus) GetVectors(ctx context.Context, collection string, ids []strin
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
+	return milvusVectors(collection, ids, result)
+}
+
+func milvusVectors(collection string, ids []string, result milvusclient.ResultSet) ([]Vector, error) {
 	idCol, ok := result.GetColumn(milvusIdField).(*column.ColumnVarChar)
 	if !ok {
 		return nil, errors.Errorf("failed to parse vector ids for collection %s", collection)

--- a/storage/vectors/milvus.go
+++ b/storage/vectors/milvus.go
@@ -306,16 +306,10 @@ func (db *Milvus) AddVectors(ctx context.Context, collection string, vectors []V
 }
 
 func (db *Milvus) GetVectors(ctx context.Context, collection string, ids []string) ([]Vector, error) {
-	return getMilvusVectors(ctx, collection, ids, func(ctx context.Context, option milvusclient.QueryOption) (milvusclient.ResultSet, error) {
-		return db.client.Query(ctx, option)
-	})
-}
-
-func getMilvusVectors(ctx context.Context, collection string, ids []string, query func(context.Context, milvusclient.QueryOption) (milvusclient.ResultSet, error)) ([]Vector, error) {
 	if len(ids) == 0 {
 		return []Vector{}, nil
 	}
-	result, err := query(ctx, milvusclient.NewQueryOption(collection).
+	result, err := db.client.Query(ctx, milvusclient.NewQueryOption(collection).
 		WithIDs(column.NewColumnVarChar(milvusIdField, slices.Clone(ids))).
 		WithOutputFields(milvusIdField, milvusCategoriesField, milvusHiddenField, milvusTimestampField, milvusVectorField).
 		WithConsistencyLevel(entity.ClStrong))

--- a/storage/vectors/milvus_test.go
+++ b/storage/vectors/milvus_test.go
@@ -17,9 +17,15 @@ package vectors
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/juju/errors"
+	"github.com/milvus-io/milvus/client/v2/column"
+	"github.com/milvus-io/milvus/client/v2/entity"
+	"github.com/milvus-io/milvus/client/v2/milvusclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -65,4 +71,63 @@ func TestMilvus(t *testing.T) {
 		t.Skip("MILVUS_URI is not set, skipping Milvus test")
 	}
 	suite.Run(t, new(MilvusTestSuite))
+}
+
+func TestMilvusVectors(t *testing.T) {
+	timestampA := time.Now().UTC().Truncate(time.Millisecond)
+	timestampB := timestampA.Add(time.Second)
+	result := milvusclient.ResultSet{
+		ResultCount: 2,
+		Fields: milvusclient.DataSet{
+			column.NewColumnVarChar(milvusIdField, []string{"a", "b"}),
+			column.NewColumnVarCharArray(milvusCategoriesField, [][]string{{"cat-a"}, {"cat-b"}}),
+			column.NewColumnBool(milvusHiddenField, []bool{false, true}),
+			column.NewColumnInt64(milvusTimestampField, []int64{timestampA.UnixMilli(), timestampB.UnixMilli()}),
+			column.NewColumnFloatVector(milvusVectorField, 2, [][]float32{{1, 0}, {0, 1}}),
+		},
+	}
+	vectors, err := milvusVectors("test", []string{"b", "missing", "a"}, result)
+	require.NoError(t, err)
+	assert.Equal(t, []Vector{
+		{Id: "b", Values: []float32{0, 1}, IsHidden: true, Categories: []string{"cat-b"}, Timestamp: timestampB},
+		{Id: "a", Values: []float32{1, 0}, Categories: []string{"cat-a"}, Timestamp: timestampA},
+	}, vectors)
+
+	sparse, err := entity.NewSliceSparseEmbedding([]uint32{1, 100}, []float32{1, 2})
+	require.NoError(t, err)
+	result.ResultCount = 1
+	result.Fields = milvusclient.DataSet{
+		column.NewColumnVarChar(milvusIdField, []string{"sparse"}),
+		column.NewColumnVarCharArray(milvusCategoriesField, [][]string{{}}),
+		column.NewColumnBool(milvusHiddenField, []bool{false}),
+		column.NewColumnInt64(milvusTimestampField, []int64{timestampA.UnixMilli()}),
+		column.NewColumnSparseVectors(milvusVectorField, []entity.SparseEmbedding{sparse}),
+	}
+	vectors, err = milvusVectors("test", []string{"sparse"}, result)
+	require.NoError(t, err)
+	require.Len(t, vectors, 1)
+	assert.Equal(t, []uint32{1, 100}, vectors[0].Indices)
+	assert.Equal(t, []float32{1, 2}, vectors[0].Values)
+
+	valid := milvusclient.DataSet{
+		column.NewColumnVarChar(milvusIdField, []string{"a"}),
+		column.NewColumnVarCharArray(milvusCategoriesField, [][]string{{"cat-a"}}),
+		column.NewColumnBool(milvusHiddenField, []bool{false}),
+		column.NewColumnInt64(milvusTimestampField, []int64{timestampA.UnixMilli()}),
+		column.NewColumnFloatVector(milvusVectorField, 2, [][]float32{{1, 0}}),
+	}
+	tests := map[string]milvusclient.DataSet{
+		"missing id":         valid[1:],
+		"missing categories": {valid[0], valid[2], valid[3], valid[4]},
+		"missing hidden":     {valid[0], valid[1], valid[3], valid[4]},
+		"missing timestamp":  {valid[0], valid[1], valid[2], valid[4]},
+		"unsupported vector": {valid[0], valid[1], valid[2], valid[3], column.NewColumnInt64(milvusVectorField, []int64{1})},
+		"invalid id row":     {column.NewColumnVarChar(milvusIdField, nil), valid[1], valid[2], valid[3], valid[4]},
+	}
+	for name, fields := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := milvusVectors("test", []string{"a"}, milvusclient.ResultSet{ResultCount: 1, Fields: fields})
+			assert.Error(t, err)
+		})
+	}
 }

--- a/storage/vectors/milvus_test.go
+++ b/storage/vectors/milvus_test.go
@@ -15,18 +15,11 @@
 package vectors
 
 import (
-	"context"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/juju/errors"
-	"github.com/milvus-io/milvus/client/v2/column"
-	"github.com/milvus-io/milvus/client/v2/entity"
-	"github.com/milvus-io/milvus/client/v2/milvusclient"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -72,98 +65,4 @@ func TestMilvus(t *testing.T) {
 		t.Skip("MILVUS_URI is not set, skipping Milvus test")
 	}
 	suite.Run(t, new(MilvusTestSuite))
-}
-
-func TestMilvusVectors(t *testing.T) {
-	timestampA := time.Now().UTC().Truncate(time.Millisecond)
-	timestampB := timestampA.Add(time.Second)
-	result := milvusclient.ResultSet{
-		ResultCount: 2,
-		Fields: milvusclient.DataSet{
-			column.NewColumnVarChar(milvusIdField, []string{"a", "b"}),
-			column.NewColumnVarCharArray(milvusCategoriesField, [][]string{{"cat-a"}, {"cat-b"}}),
-			column.NewColumnBool(milvusHiddenField, []bool{false, true}),
-			column.NewColumnInt64(milvusTimestampField, []int64{timestampA.UnixMilli(), timestampB.UnixMilli()}),
-			column.NewColumnFloatVector(milvusVectorField, 2, [][]float32{{1, 0}, {0, 1}}),
-		},
-	}
-	vectors, err := milvusVectors("test", []string{"b", "missing", "a"}, result)
-	require.NoError(t, err)
-	assert.Equal(t, []Vector{
-		{Id: "b", Values: []float32{0, 1}, IsHidden: true, Categories: []string{"cat-b"}, Timestamp: timestampB},
-		{Id: "a", Values: []float32{1, 0}, Categories: []string{"cat-a"}, Timestamp: timestampA},
-	}, vectors)
-
-	sparse, err := entity.NewSliceSparseEmbedding([]uint32{1, 100}, []float32{1, 2})
-	require.NoError(t, err)
-	result.ResultCount = 1
-	result.Fields = milvusclient.DataSet{
-		column.NewColumnVarChar(milvusIdField, []string{"sparse"}),
-		column.NewColumnVarCharArray(milvusCategoriesField, [][]string{{}}),
-		column.NewColumnBool(milvusHiddenField, []bool{false}),
-		column.NewColumnInt64(milvusTimestampField, []int64{timestampA.UnixMilli()}),
-		column.NewColumnSparseVectors(milvusVectorField, []entity.SparseEmbedding{sparse}),
-	}
-	vectors, err = milvusVectors("test", []string{"sparse"}, result)
-	require.NoError(t, err)
-	require.Len(t, vectors, 1)
-	assert.Equal(t, []uint32{1, 100}, vectors[0].Indices)
-	assert.Equal(t, []float32{1, 2}, vectors[0].Values)
-
-	valid := milvusclient.DataSet{
-		column.NewColumnVarChar(milvusIdField, []string{"a"}),
-		column.NewColumnVarCharArray(milvusCategoriesField, [][]string{{"cat-a"}}),
-		column.NewColumnBool(milvusHiddenField, []bool{false}),
-		column.NewColumnInt64(milvusTimestampField, []int64{timestampA.UnixMilli()}),
-		column.NewColumnFloatVector(milvusVectorField, 2, [][]float32{{1, 0}}),
-	}
-	tests := map[string]milvusclient.DataSet{
-		"missing id":         valid[1:],
-		"missing categories": {valid[0], valid[2], valid[3], valid[4]},
-		"missing hidden":     {valid[0], valid[1], valid[3], valid[4]},
-		"missing timestamp":  {valid[0], valid[1], valid[2], valid[4]},
-		"unsupported vector": {valid[0], valid[1], valid[2], valid[3], column.NewColumnInt64(milvusVectorField, []int64{1})},
-		"invalid id row":     {column.NewColumnVarChar(milvusIdField, nil), valid[1], valid[2], valid[3], valid[4]},
-	}
-	for name, fields := range tests {
-		t.Run(name, func(t *testing.T) {
-			_, err := milvusVectors("test", []string{"a"}, milvusclient.ResultSet{ResultCount: 1, Fields: fields})
-			assert.Error(t, err)
-		})
-	}
-}
-
-func TestGetMilvusVectors(t *testing.T) {
-	ctx := t.Context()
-	called := false
-	vectors, err := getMilvusVectors(ctx, "test", nil, func(context.Context, milvusclient.QueryOption) (milvusclient.ResultSet, error) {
-		called = true
-		return milvusclient.ResultSet{}, nil
-	})
-	require.NoError(t, err)
-	assert.Empty(t, vectors)
-	assert.False(t, called)
-
-	expectedErr := errors.New("query failed")
-	_, err = getMilvusVectors(ctx, "test", []string{"a"}, func(context.Context, milvusclient.QueryOption) (milvusclient.ResultSet, error) {
-		return milvusclient.ResultSet{}, expectedErr
-	})
-	assert.ErrorIs(t, err, expectedErr)
-
-	timestamp := time.Now().UTC().Truncate(time.Millisecond)
-	vectors, err = getMilvusVectors(ctx, "test", []string{"a"}, func(_ context.Context, option milvusclient.QueryOption) (milvusclient.ResultSet, error) {
-		request, err := option.Request()
-		require.NoError(t, err)
-		assert.Equal(t, "test", request.GetCollectionName())
-		return milvusclient.ResultSet{ResultCount: 1, Fields: milvusclient.DataSet{
-			column.NewColumnVarChar(milvusIdField, []string{"a"}),
-			column.NewColumnVarCharArray(milvusCategoriesField, [][]string{{"cat-a"}}),
-			column.NewColumnBool(milvusHiddenField, []bool{false}),
-			column.NewColumnInt64(milvusTimestampField, []int64{timestamp.UnixMilli()}),
-			column.NewColumnFloatVector(milvusVectorField, 2, [][]float32{{1, 0}}),
-		}}, nil
-	})
-	require.NoError(t, err)
-	require.Len(t, vectors, 1)
-	assert.Equal(t, "a", vectors[0].Id)
 }

--- a/storage/vectors/milvus_test.go
+++ b/storage/vectors/milvus_test.go
@@ -15,6 +15,7 @@
 package vectors
 
 import (
+	"context"
 	"os"
 	"testing"
 	"time"
@@ -130,4 +131,39 @@ func TestMilvusVectors(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestGetMilvusVectors(t *testing.T) {
+	ctx := t.Context()
+	called := false
+	vectors, err := getMilvusVectors(ctx, "test", nil, func(context.Context, milvusclient.QueryOption) (milvusclient.ResultSet, error) {
+		called = true
+		return milvusclient.ResultSet{}, nil
+	})
+	require.NoError(t, err)
+	assert.Empty(t, vectors)
+	assert.False(t, called)
+
+	expectedErr := errors.New("query failed")
+	_, err = getMilvusVectors(ctx, "test", []string{"a"}, func(context.Context, milvusclient.QueryOption) (milvusclient.ResultSet, error) {
+		return milvusclient.ResultSet{}, expectedErr
+	})
+	assert.ErrorIs(t, err, expectedErr)
+
+	timestamp := time.Now().UTC().Truncate(time.Millisecond)
+	vectors, err = getMilvusVectors(ctx, "test", []string{"a"}, func(_ context.Context, option milvusclient.QueryOption) (milvusclient.ResultSet, error) {
+		request, err := option.Request()
+		require.NoError(t, err)
+		assert.Equal(t, "test", request.GetCollectionName())
+		return milvusclient.ResultSet{ResultCount: 1, Fields: milvusclient.DataSet{
+			column.NewColumnVarChar(milvusIdField, []string{"a"}),
+			column.NewColumnVarCharArray(milvusCategoriesField, [][]string{{"cat-a"}}),
+			column.NewColumnBool(milvusHiddenField, []bool{false}),
+			column.NewColumnInt64(milvusTimestampField, []int64{timestamp.UnixMilli()}),
+			column.NewColumnFloatVector(milvusVectorField, 2, [][]float32{{1, 0}}),
+		}}, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, vectors, 1)
+	assert.Equal(t, "a", vectors[0].Id)
 }

--- a/storage/vectors/no_database.go
+++ b/storage/vectors/no_database.go
@@ -42,6 +42,9 @@ func (NoDatabase) CountVectors(_ context.Context, _ string) (int64, error) {
 func (NoDatabase) AddVectors(_ context.Context, _ string, _ []Vector) error {
 	return ErrNoDatabase
 }
+func (NoDatabase) GetVectors(_ context.Context, _ string, _ []string) ([]Vector, error) {
+	return nil, ErrNoDatabase
+}
 func (NoDatabase) DeleteVectors(_ context.Context, _ string, _ time.Time) error {
 	return ErrNoDatabase
 }

--- a/storage/vectors/no_database_test.go
+++ b/storage/vectors/no_database_test.go
@@ -57,6 +57,9 @@ func TestNoDatabase(t *testing.T) {
 			{Id: "a", Values: []float32{1, 0, 0, 0}, Categories: []string{"cat-a"}},
 		}), ErrNoDatabase)
 		assert.ErrorIs(t, database.AddVectors(ctx, "test", nil), ErrNoDatabase)
+		vectors, err := database.GetVectors(ctx, "test", []string{"a"})
+		assert.ErrorIs(t, err, ErrNoDatabase)
+		assert.Nil(t, vectors)
 		assert.ErrorIs(t, database.DeleteVectors(ctx, "test", time.Now()), ErrNoDatabase)
 		assert.ErrorIs(t, database.DeleteVectors(ctx, "missing", time.Time{}), ErrNoDatabase)
 

--- a/storage/vectors/proxy.go
+++ b/storage/vectors/proxy.go
@@ -130,6 +130,25 @@ func (p *ProxyServer) AddVectors(ctx context.Context, request *protocol.AddVecto
 	return &protocol.AddVectorsResponse{}, nil
 }
 
+func (p *ProxyServer) GetVectors(ctx context.Context, request *protocol.GetVectorsRequest) (*protocol.GetVectorsResponse, error) {
+	vectors, err := p.database.GetVectors(ctx, request.GetCollection(), request.GetIds())
+	if err != nil {
+		return nil, err
+	}
+	pbVectors := make([]*protocol.Vector, len(vectors))
+	for i, vector := range vectors {
+		pbVectors[i] = &protocol.Vector{
+			Id:         vector.Id,
+			Values:     vector.Values,
+			Indices:    vector.Indices,
+			IsHidden:   vector.IsHidden,
+			Categories: vector.Categories,
+			Timestamp:  timestamppb.New(vector.Timestamp),
+		}
+	}
+	return &protocol.GetVectorsResponse{Vectors: pbVectors}, nil
+}
+
 func (p *ProxyServer) DeleteVectors(ctx context.Context, request *protocol.DeleteVectorsRequest) (*protocol.DeleteVectorsResponse, error) {
 	timestamp := time.Time{}
 	if request.GetTimestamp() != nil {
@@ -266,6 +285,32 @@ func (p ProxyClient) AddVectors(ctx context.Context, collection string, vectors 
 		Vectors:    pbVectors,
 	})
 	return err
+}
+
+func (p ProxyClient) GetVectors(ctx context.Context, collection string, ids []string) ([]Vector, error) {
+	resp, err := p.VectorStoreClient.GetVectors(ctx, &protocol.GetVectorsRequest{
+		Collection: collection,
+		Ids:        ids,
+	})
+	if err != nil {
+		return nil, err
+	}
+	vectors := make([]Vector, len(resp.GetVectors()))
+	for i, vector := range resp.GetVectors() {
+		timestamp := time.Time{}
+		if vector.GetTimestamp() != nil {
+			timestamp = vector.GetTimestamp().AsTime()
+		}
+		vectors[i] = Vector{
+			Id:         vector.GetId(),
+			Values:     vector.GetValues(),
+			Indices:    vector.GetIndices(),
+			IsHidden:   vector.GetIsHidden(),
+			Categories: vector.GetCategories(),
+			Timestamp:  timestamp,
+		}
+	}
+	return vectors, nil
 }
 
 func (p ProxyClient) DeleteVectors(ctx context.Context, collection string, timestamp time.Time) error {

--- a/storage/vectors/qdrant.go
+++ b/storage/vectors/qdrant.go
@@ -337,6 +337,38 @@ func (db *Qdrant) AddVectors(ctx context.Context, collection string, vectors []V
 	return errors.Trace(err)
 }
 
+func (db *Qdrant) GetVectors(ctx context.Context, collection string, ids []string) ([]Vector, error) {
+	if len(ids) == 0 {
+		return []Vector{}, nil
+	}
+	pointIDs := make([]*qdrant.PointId, len(ids))
+	for i, id := range ids {
+		pointIDs[i] = qdrant.NewID(uuid.NewMD5(uuid.NameSpaceURL, []byte(id)).String())
+	}
+	points, err := db.client.Get(ctx, &qdrant.GetPoints{
+		CollectionName: collection,
+		Ids:            pointIDs,
+		WithPayload:    qdrant.NewWithPayloadEnable(true),
+		WithVectors:    qdrant.NewWithVectorsInclude(qdrantVectorName),
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	vectors := make([]Vector, 0, len(points))
+	for _, point := range points {
+		value := qdrantVector(point.GetVectors())
+		vectors = append(vectors, Vector{
+			Id:         qdrantId(point.GetPayload()),
+			Values:     value.Values,
+			Indices:    value.Indices,
+			IsHidden:   qdrantHidden(point.GetPayload()),
+			Categories: qdrantCategories(point.GetPayload()),
+			Timestamp:  qdrantTimestamp(point.GetPayload()),
+		})
+	}
+	return orderVectors(ids, vectors), nil
+}
+
 func (db *Qdrant) DeleteVectors(ctx context.Context, collection string, timestamp time.Time) error {
 	lt := float64(timestamp.UnixMilli())
 	_, err := db.client.Delete(ctx, &qdrant.DeletePoints{
@@ -411,6 +443,13 @@ func qdrantHidden(payload map[string]*qdrant.Value) bool {
 		return value.GetBoolValue()
 	}
 	return false
+}
+
+func qdrantTimestamp(payload map[string]*qdrant.Value) time.Time {
+	if value, ok := payload[qdrantPayloadTimestampKey]; ok {
+		return time.UnixMilli(value.GetIntegerValue()).UTC()
+	}
+	return time.Time{}
 }
 
 func qdrantListValue(items []string) *qdrant.Value {

--- a/storage/vectors/weaviate.go
+++ b/storage/vectors/weaviate.go
@@ -296,6 +296,83 @@ func (db *Weaviate) AddVectors(ctx context.Context, collection string, vectors [
 	return errors.Trace(err)
 }
 
+func (db *Weaviate) GetVectors(ctx context.Context, collection string, ids []string) ([]Vector, error) {
+	if len(ids) == 0 {
+		return []Vector{}, nil
+	}
+	objectIDs := make([]string, len(ids))
+	for i, id := range ids {
+		objectIDs[i] = uuid.NewMD5(uuid.NameSpaceURL, []byte(id)).String()
+	}
+	fields := []graphql.Field{
+		{Name: "originalId"},
+		{Name: weaviatePayloadCategoriesKey},
+		{Name: weaviatePayloadHiddenKey},
+		{Name: weaviatePayloadTimestampKey},
+		{Name: "_additional", Fields: []graphql.Field{{Name: "vector"}}},
+	}
+	result, err := db.client.GraphQL().Get().
+		WithClassName(capitalize(collection)).
+		WithFields(fields...).
+		WithWhere(filters.Where().
+			WithPath([]string{"id"}).
+			WithOperator(filters.ContainsAny).
+			WithValueString(objectIDs...)).
+		WithLimit(len(ids)).
+		Do(ctx)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(result.Errors) > 0 {
+		return nil, errors.New(result.Errors[0].Message)
+	}
+	data, ok := result.Data["Get"].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("failed to parse vectors for collection %s", collection)
+	}
+	items, ok := data[capitalize(collection)].([]any)
+	if !ok {
+		return nil, errors.Errorf("failed to parse vectors for collection %s", collection)
+	}
+	vectors := make([]Vector, 0, len(items))
+	for _, item := range items {
+		properties, ok := item.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("failed to parse vector for collection %s", collection)
+		}
+		vector := Vector{
+			Id:       properties["originalId"].(string),
+			IsHidden: properties[weaviatePayloadHiddenKey].(bool),
+		}
+		if categories, ok := properties[weaviatePayloadCategoriesKey].([]any); ok {
+			vector.Categories = make([]string, len(categories))
+			for i, category := range categories {
+				vector.Categories[i] = category.(string)
+			}
+		}
+		if timestamp, ok := properties[weaviatePayloadTimestampKey].(string); ok {
+			vector.Timestamp, err = time.Parse(time.RFC3339Nano, timestamp)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		additional, ok := properties["_additional"].(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("failed to parse vector values for collection %s", collection)
+		}
+		values, ok := additional["vector"].([]any)
+		if !ok {
+			return nil, errors.Errorf("failed to parse vector values for collection %s", collection)
+		}
+		vector.Values = make([]float32, len(values))
+		for i, value := range values {
+			vector.Values[i] = float32(value.(float64))
+		}
+		vectors = append(vectors, vector)
+	}
+	return orderVectors(ids, vectors), nil
+}
+
 func (db *Weaviate) DeleteVectors(ctx context.Context, collection string, timestamp time.Time) error {
 	_, err := db.client.Batch().ObjectsBatchDeleter().
 		WithClassName(capitalize(collection)).

--- a/storage/vectors/xvec.go
+++ b/storage/vectors/xvec.go
@@ -323,6 +323,50 @@ func (db *Xvec) AddVectors(ctx context.Context, name string, vectors []Vector) e
 	return errors.Trace(err)
 }
 
+func (db *Xvec) GetVectors(ctx context.Context, name string, ids []string) ([]Vector, error) {
+	if len(ids) == 0 {
+		return []Vector{}, nil
+	}
+	collection, err := db.collection(name)
+	if err != nil {
+		return nil, err
+	}
+	documents, err := collection.Fetch(ctx, ids, xvec.Projection{
+		OutputFields:   []string{xvecCategoriesField, xvecTimestampField, xvecHiddenField},
+		IncludeVectors: true,
+	})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	vectors := make([]Vector, 0, len(documents))
+	for _, document := range documents {
+		if document == nil {
+			continue
+		}
+		vector := Vector{Id: document.PrimaryKey}
+		if value, found := document.Field(xvecCategoriesField); found {
+			vector.Categories = []string(value.(xvec.StringArray))
+		}
+		if value, found := document.Field(xvecTimestampField); found {
+			vector.Timestamp = time.UnixMilli(value.(int64)).UTC()
+		}
+		if value, found := document.Field(xvecHiddenField); found {
+			vector.IsHidden = value.(bool)
+		}
+		if value, found := document.Field(xvecVectorField); found {
+			switch value := value.(type) {
+			case xvec.VectorFP32:
+				vector.Values = []float32(value)
+			case xvec.SparseVectorFP32:
+				vector.Indices = value.Indices
+				vector.Values = value.Values
+			}
+		}
+		vectors = append(vectors, vector)
+	}
+	return vectors, nil
+}
+
 func (db *Xvec) DeleteVectors(ctx context.Context, name string, timestamp time.Time) error {
 	collection, err := db.collection(name)
 	if err != nil {

--- a/storage/vectors/xvec.go
+++ b/storage/vectors/xvec.go
@@ -364,7 +364,7 @@ func (db *Xvec) GetVectors(ctx context.Context, name string, ids []string) ([]Ve
 		}
 		vectors = append(vectors, vector)
 	}
-	return vectors, nil
+	return orderVectors(ids, vectors), nil
 }
 
 func (db *Xvec) DeleteVectors(ctx context.Context, name string, timestamp time.Time) error {


### PR DESCRIPTION
## Summary

- add `GetVectors` to the vector database interface
- implement batch retrieval for Xvec, Qdrant, Milvus, and Weaviate
- proxy vector retrieval through the vector-store gRPC service
- preserve requested ID order, omit missing vectors, deduplicate repeated IDs, and return complete vector metadata
- clone Milvus request IDs because the Milvus client mutates varchar slices while constructing its filter expression

## Tests

- `go test ./storage/vectors -count=1`
- `go test ./protocol -count=1`
- `go vet ./storage/vectors ./protocol`
- `QDRANT_URI=qdrant://127.0.0.1:6334 WEAVIATE_URI=weaviate://127.0.0.1:8080 go test ./storage/vectors -run 'TestQdrant|TestWeaviate' -count=1`

The real local Milvus suite could not run because the Compose Milvus container timed out connecting to its healthy etcd service.
