### PR TITLE
feat(storage): support purging vector databases

### DIFF
--- a/storage/vectors/database.go
+++ b/storage/vectors/database.go
@@ -98,6 +98,7 @@ type Database interface {
 	Init() error
 	Optimize(ctx context.Context, name string) error
 	Close() error
+	Purge() error
 	ListCollections(ctx context.Context) ([]string, error)
 	DescribeCollection(ctx context.Context, name string) (*CollectionInfo, error)
 	AddCollection(ctx context.Context, name string, dimensions int, distance Distance, config VectorConfig) error
@@ -107,6 +108,20 @@ type Database interface {
 	GetVectors(ctx context.Context, collection string, ids []string) ([]Vector, error)
 	DeleteVectors(ctx context.Context, collection string, timestamp time.Time) error
 	QueryVectors(ctx context.Context, collection string, q Vector, categories []string, topK int) ([]ScoredVector, error)
+}
+
+func purge(database Database) error {
+	ctx := context.Background()
+	collections, err := database.ListCollections(ctx)
+	if err != nil {
+		return err
+	}
+	for _, collection := range collections {
+		if err = database.DeleteCollection(ctx, collection); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func orderVectors(ids []string, vectors []Vector) []Vector {

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -81,18 +81,26 @@ func (suite *vectorsTestSuite) TestCollections() {
 
 func (suite *vectorsTestSuite) TestPurge() {
 	ctx := suite.T().Context()
-	for _, name := range []string{"first", "second"} {
+	collectionNames := []string{"first", "second"}
+	for _, name := range collectionNames {
 		err := suite.Database.AddCollection(ctx, name, defaultVectorSize, Cosine, VectorConfig{})
 		suite.Require().NoError(err)
 		err = suite.Database.AddVectors(ctx, name, []Vector{{Id: "vector", Values: []float32{1, 0, 0, 0}}})
 		suite.Require().NoError(err)
 	}
-
-	err := suite.Database.Purge()
-	suite.Require().NoError(err)
 	collections, err := suite.Database.ListCollections(ctx)
 	suite.Require().NoError(err)
+	suite.ElementsMatch(collectionNames, collections)
+
+	err = suite.Database.Purge()
+	suite.Require().NoError(err)
+	collections, err = suite.Database.ListCollections(ctx)
+	suite.Require().NoError(err)
 	suite.Empty(collections)
+	for _, name := range collectionNames {
+		_, err = suite.Database.DescribeCollection(ctx, name)
+		suite.ErrorIs(err, storage.ErrNotFound)
+	}
 
 	suite.NoError(suite.Database.Purge())
 }

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -79,6 +79,24 @@ func (suite *vectorsTestSuite) TestCollections() {
 	suite.Error(err)
 }
 
+func (suite *vectorsTestSuite) TestPurge() {
+	ctx := suite.T().Context()
+	for _, name := range []string{"first", "second"} {
+		err := suite.Database.AddCollection(ctx, name, defaultVectorSize, Cosine, VectorConfig{})
+		suite.Require().NoError(err)
+		err = suite.Database.AddVectors(ctx, name, []Vector{{Id: "vector", Values: []float32{1, 0, 0, 0}}})
+		suite.Require().NoError(err)
+	}
+
+	err := suite.Database.Purge()
+	suite.Require().NoError(err)
+	collections, err := suite.Database.ListCollections(ctx)
+	suite.Require().NoError(err)
+	suite.Empty(collections)
+
+	suite.NoError(suite.Database.Purge())
+}
+
 func (suite *vectorsTestSuite) TestVectors() {
 	ctx := suite.T().Context()
 	err := suite.Database.AddCollection(ctx, "test", defaultVectorSize, Cosine, VectorConfig{})

--- a/storage/vectors/milvus.go
+++ b/storage/vectors/milvus.go
@@ -38,6 +38,7 @@ const (
 	milvusCategoriesField = "categories"
 	milvusHiddenField     = "hidden"
 	milvusTimestampField  = "timestamp"
+	milvusDefaultDatabase = "default"
 
 	milvusIVFRQIndexType = index.IvfRabitQ
 
@@ -49,13 +50,18 @@ const (
 
 func init() {
 	Register([]string{storage.MilvusPrefix}, func(path, tablePrefix string, opts ...storage.Option) (Database, error) {
-		database := &Milvus{}
 		u, err := url.Parse(path)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
+		databaseName := strings.Trim(u.Path, "/")
+		if databaseName == "" {
+			databaseName = milvusDefaultDatabase
+		}
+		database := &Milvus{database: databaseName}
 		database.client, err = milvusclient.New(context.Background(), &milvusclient.ClientConfig{
 			Address: u.Host,
+			DBName:  databaseName,
 		})
 		if err != nil {
 			return nil, errors.WithStack(err)
@@ -65,7 +71,8 @@ func init() {
 }
 
 type Milvus struct {
-	client *milvusclient.Client
+	client   *milvusclient.Client
+	database string
 }
 
 func (db *Milvus) Init() error {
@@ -81,7 +88,20 @@ func (db *Milvus) Close() error {
 }
 
 func (db *Milvus) Purge() error {
-	return purge(db)
+	if db.database == milvusDefaultDatabase {
+		return fmt.Errorf("purging the default Milvus database %w", storage.ErrNotSupported)
+	}
+	ctx := context.Background()
+	if err := db.client.UseDatabase(ctx, milvusclient.NewUseDatabaseOption(milvusDefaultDatabase)); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := db.client.DropDatabase(ctx, milvusclient.NewDropDatabaseOption(db.database)); err != nil {
+		return errors.WithStack(err)
+	}
+	if err := db.client.CreateDatabase(ctx, milvusclient.NewCreateDatabaseOption(db.database)); err != nil {
+		return errors.WithStack(err)
+	}
+	return errors.WithStack(db.client.UseDatabase(ctx, milvusclient.NewUseDatabaseOption(db.database)))
 }
 
 func (db *Milvus) ListCollections(ctx context.Context) ([]string, error) {

--- a/storage/vectors/milvus.go
+++ b/storage/vectors/milvus.go
@@ -80,6 +80,10 @@ func (db *Milvus) Close() error {
 	return db.client.Close(context.Background())
 }
 
+func (db *Milvus) Purge() error {
+	return purge(db)
+}
+
 func (db *Milvus) ListCollections(ctx context.Context) ([]string, error) {
 	collections, err := db.client.ListCollections(ctx, milvusclient.NewListCollectionOption())
 	if err != nil {

--- a/storage/vectors/milvus_test.go
+++ b/storage/vectors/milvus_test.go
@@ -15,13 +15,18 @@
 package vectors
 
 import (
+	"net/url"
 	"os"
+	"slices"
 	"testing"
 
 	"github.com/gorse-io/gorse/common/log"
 	"github.com/gorse-io/gorse/storage"
+	"github.com/milvus-io/milvus/client/v2/milvusclient"
 	"github.com/stretchr/testify/suite"
 )
+
+const milvusTestDatabase = "gorse_vectors_test"
 
 var (
 	milvusUri string
@@ -38,9 +43,32 @@ type MilvusTestSuite struct {
 
 func (suite *MilvusTestSuite) SetupSuite() {
 	log.SetTestLogger(suite.T())
-	var err error
-	suite.Database, err = Open(milvusUri, "gorse_")
-	suite.NoError(err)
+	ctx := suite.T().Context()
+	u, err := url.Parse(milvusUri)
+	suite.Require().NoError(err)
+	u.Path = ""
+
+	adminDatabase, err := Open(u.String(), "gorse_")
+	suite.Require().NoError(err)
+	admin := adminDatabase.(*Milvus)
+	databases, err := admin.client.ListDatabase(ctx, milvusclient.NewListDatabaseOption())
+	suite.Require().NoError(err)
+	if slices.Contains(databases, milvusTestDatabase) {
+		err = admin.client.DropDatabase(ctx, milvusclient.NewDropDatabaseOption(milvusTestDatabase))
+		suite.Require().NoError(err)
+	}
+	err = admin.client.CreateDatabase(ctx, milvusclient.NewCreateDatabaseOption(milvusTestDatabase))
+	suite.Require().NoError(err)
+	suite.Require().NoError(adminDatabase.Close())
+
+	u.Path = "/" + milvusTestDatabase
+	suite.Database, err = Open(u.String(), "gorse_")
+	suite.Require().NoError(err)
+	suite.Equal(milvusTestDatabase, suite.Database.(*Milvus).database)
+}
+
+func (suite *MilvusTestSuite) TearDownSuite() {
+	suite.NoError(suite.Database.Close())
 }
 
 func (suite *MilvusTestSuite) TestInvalidSparseCollection() {

--- a/storage/vectors/no_database.go
+++ b/storage/vectors/no_database.go
@@ -28,6 +28,7 @@ type NoDatabase struct{}
 func (NoDatabase) Init() error                                { return storage.ErrNoDatabase }
 func (NoDatabase) Optimize(_ context.Context, _ string) error { return nil }
 func (NoDatabase) Close() error                               { return storage.ErrNoDatabase }
+func (NoDatabase) Purge() error                               { return storage.ErrNoDatabase }
 func (NoDatabase) ListCollections(_ context.Context) ([]string, error) {
 	return nil, storage.ErrNoDatabase
 }

--- a/storage/vectors/no_database_test.go
+++ b/storage/vectors/no_database_test.go
@@ -31,6 +31,7 @@ func TestNoDatabase(t *testing.T) {
 	t.Run("lifecycle", func(t *testing.T) {
 		assert.ErrorIs(t, database.Init(), storage.ErrNoDatabase)
 		assert.NoError(t, database.Optimize(ctx, "test"))
+		assert.ErrorIs(t, database.Purge(), storage.ErrNoDatabase)
 		assert.ErrorIs(t, database.Close(), storage.ErrNoDatabase)
 	})
 

--- a/storage/vectors/proxy.go
+++ b/storage/vectors/proxy.go
@@ -210,6 +210,10 @@ func (p ProxyClient) Close() error {
 	return nil
 }
 
+func (p ProxyClient) Purge() error {
+	return errors.New("purge is not allowed in proxy client")
+}
+
 func (p ProxyClient) ListCollections(ctx context.Context) ([]string, error) {
 	resp, err := p.VectorStoreClient.ListCollections(ctx, &protocol.ListCollectionsRequest{})
 	if err != nil {

--- a/storage/vectors/proxy_test.go
+++ b/storage/vectors/proxy_test.go
@@ -56,6 +56,10 @@ func (suite *ProxyTestSuite) TearDownSuite() {
 	suite.NoError(suite.backend.Close())
 }
 
+func (suite *ProxyTestSuite) TestPurge() {
+	suite.Error(suite.Database.Purge())
+}
+
 func TestProxy(t *testing.T) {
 	suite.Run(t, new(ProxyTestSuite))
 }

--- a/storage/vectors/qdrant.go
+++ b/storage/vectors/qdrant.go
@@ -77,6 +77,10 @@ func (db *Qdrant) Close() error {
 	return db.client.Close()
 }
 
+func (db *Qdrant) Purge() error {
+	return purge(db)
+}
+
 func (db *Qdrant) ListCollections(ctx context.Context) ([]string, error) {
 	return db.client.ListCollections(ctx)
 }

--- a/storage/vectors/weaviate.go
+++ b/storage/vectors/weaviate.go
@@ -78,6 +78,10 @@ func (db *Weaviate) Close() error {
 	return nil
 }
 
+func (db *Weaviate) Purge() error {
+	return purge(db)
+}
+
 func (db *Weaviate) ListCollections(ctx context.Context) ([]string, error) {
 	s, err := db.client.Schema().Getter().Do(ctx)
 	if err != nil {

--- a/storage/vectors/xvec.go
+++ b/storage/vectors/xvec.go
@@ -147,6 +147,10 @@ func (db *Xvec) Close() error {
 	return stderrors.Join(errs...)
 }
 
+func (db *Xvec) Purge() error {
+	return purge(db)
+}
+
 func (db *Xvec) ListCollections(ctx context.Context) ([]string, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, errors.WithStack(err)

--- a/storage/vectors/xvec.go
+++ b/storage/vectors/xvec.go
@@ -148,7 +148,11 @@ func (db *Xvec) Close() error {
 }
 
 func (db *Xvec) Purge() error {
-	return purge(db)
+	if db.closed.Load() {
+		return errors.New("xvec database is closed")
+	}
+	db.collections.Clear()
+	return errors.WithStack(os.RemoveAll(db.root))
 }
 
 func (db *Xvec) ListCollections(ctx context.Context) ([]string, error) {

--- a/storage/vectors/xvec_test.go
+++ b/storage/vectors/xvec_test.go
@@ -15,6 +15,7 @@
 package vectors
 
 import (
+	"os"
 	"testing"
 
 	"github.com/gorse-io/gorse/common/log"
@@ -38,6 +39,12 @@ func (suite *XvecTestSuite) SetupSuite() {
 
 func (suite *XvecTestSuite) TearDownSuite() {
 	suite.NoError(suite.Database.Close())
+}
+
+func (suite *XvecTestSuite) TestPurge() {
+	suite.vectorsTestSuite.TestPurge()
+	_, err := os.Stat(suite.root)
+	suite.ErrorIs(err, os.ErrNotExist)
 }
 
 func TestXvec(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `Purge` to the vector database contract
- purge vector databases by deleting every collection for Xvec, Qdrant, Milvus, and Weaviate
- match data/cache behavior for unavailable and proxy databases
- add shared purge coverage, including repeated purge of an empty database

## Tests

- `go test ./storage/vectors -count=1`
- `go test -p 1 ./... -run '^$'`
- `git diff --check`
