### PR TITLE
fix: require all vector query categories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorse-io/dashboard v0.5.20260714
 	github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2
-	github.com/gorse-io/xvec v0.0.0-20260812164402-6979a74830c8
+	github.com/gorse-io/xvec v0.0.0-20260821023012-cf0c34c6025f
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jaswdr/faker v1.19.1
 	github.com/jellydator/ttlcache/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2 h1:tx7
 github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2/go.mod h1:ZxmVHzZPKm5pmEIlqaRDwK0rkfTRHlfziO033XZ+RW0=
 github.com/gorse-io/sqlite v1.3.3-0.20260620140844-3b4da3e2b9f2 h1:5URyKN9bYIO+WG3hbfaOkTBHmdLT4U8JQSe2vSEWJDE=
 github.com/gorse-io/sqlite v1.3.3-0.20260620140844-3b4da3e2b9f2/go.mod h1:2A/iJg34FXGCljLiSsmdilFooNtjmfQr7CmcD+2sh68=
-github.com/gorse-io/xvec v0.0.0-20260812164402-6979a74830c8 h1:Kaq9lnLlt9LvJcClgALQna89lwX1FsLOe/S/vQFX3PM=
-github.com/gorse-io/xvec v0.0.0-20260812164402-6979a74830c8/go.mod h1:Ga2ZBLZxjsBgxAiZznGc3r1DyZmEINl0j827aEc3tVw=
+github.com/gorse-io/xvec v0.0.0-20260821023012-cf0c34c6025f h1:IVQvoAE/aQ7i6xnFvrWf+9qbawpLVAYsDMrgKMkddO4=
+github.com/gorse-io/xvec v0.0.0-20260821023012-cf0c34c6025f/go.mod h1:Ga2ZBLZxjsBgxAiZznGc3r1DyZmEINl0j827aEc3tVw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=

--- a/storage/vectors/database_test.go
+++ b/storage/vectors/database_test.go
@@ -126,9 +126,10 @@ func (suite *vectorsTestSuite) TestVectors() {
 		suite.NotEmpty(result.Categories)
 	}
 
-	results, err = suite.Database.QueryVectors(ctx, "test", Vector{Values: vectorA}, []string{"cat-a", "cat-b"}, 10)
+	results, err = suite.Database.QueryVectors(ctx, "test", Vector{Values: vectorA}, []string{"cat-a", "common"}, 10)
 	suite.NoError(err)
-	suite.Len(results, 2)
+	suite.Len(results, 1)
+	suite.Equal("a", results[0].Id)
 
 	results, err = suite.Database.QueryVectors(ctx, "test", Vector{Values: vectorA}, nil, 1)
 	suite.NoError(err)

--- a/storage/vectors/milvus.go
+++ b/storage/vectors/milvus.go
@@ -402,7 +402,7 @@ func (db *Milvus) QueryVectors(ctx context.Context, collection string, q Vector,
 		for i := range categories {
 			conditions = append(conditions, fmt.Sprintf("array_contains(%s, {category_%d})", milvusCategoriesField, i))
 		}
-		expr += " and (" + strings.Join(conditions, " or ") + ")"
+		expr += " and (" + strings.Join(conditions, " and ") + ")"
 	}
 
 	searchParam, distance, err := db.searchParam(ctx, collection)

--- a/storage/vectors/qdrant.go
+++ b/storage/vectors/qdrant.go
@@ -404,9 +404,9 @@ func (db *Qdrant) QueryVectors(ctx context.Context, collection string, q Vector,
 	}
 	request.Using = new(qdrantVectorName)
 	request.WithVectors = qdrant.NewWithVectorsInclude(qdrantVectorName)
-	if len(categories) > 0 {
+	for _, category := range categories {
 		request.Filter.Must = append(request.Filter.Must,
-			qdrant.NewMatchKeywords(qdrantPayloadCategoriesKey, categories...))
+			qdrant.NewMatchKeyword(qdrantPayloadCategoriesKey, category))
 	}
 	response, err := db.client.Query(ctx, request)
 	if err != nil {

--- a/storage/vectors/weaviate.go
+++ b/storage/vectors/weaviate.go
@@ -411,7 +411,7 @@ func (db *Weaviate) QueryVectors(ctx context.Context, collection string, q Vecto
 	if len(categories) > 0 {
 		categoriesWhere := filters.Where().
 			WithPath([]string{weaviatePayloadCategoriesKey}).
-			WithOperator(filters.ContainsAny).
+			WithOperator(filters.ContainsAll).
 			WithValueString(categories...)
 		where = filters.Where().
 			WithOperator(filters.And).

--- a/storage/vectors/xvec.go
+++ b/storage/vectors/xvec.go
@@ -390,7 +390,7 @@ func (db *Xvec) QueryVectors(ctx context.Context, name string, q Vector, categor
 			escaped := strings.NewReplacer(`\`, `\\`, `'`, `\'`).Replace(category)
 			quoted[i] = "'" + escaped + "'"
 		}
-		filter += fmt.Sprintf(" AND %s CONTAIN_ANY (%s)", xvecCategoriesField, strings.Join(quoted, ", "))
+		filter += fmt.Sprintf(" AND %s CONTAIN_ALL (%s)", xvecCategoriesField, strings.Join(quoted, ", "))
 	}
 	query := xvec.VectorQuery{
 		Field:  xvecVectorField,


### PR DESCRIPTION
## Summary

- require vectors to contain every requested category in `QueryVectors`
- align Milvus, Qdrant, Weaviate, and Xvec filters with AND semantics
- update Xvec to `v0.0.0-20260821023012-cf0c34c6025f`
- update the shared vector database contract test to cover multiple categories

## Testing

- `go test ./storage/vectors -run '^(TestXvec|TestProxy)$/^TestVectors$' -count=1`
- `go test ./storage/vectors -count=1`
- `go vet ./storage/vectors`

Full cross-backend verification is delegated to CI.
