### PR TITLE
chore: upgrade to Go 1.27

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -140,23 +140,23 @@ func NewAdminClient(endpoint, apiKey string) *AdminClient {
 }
 
 func (c *AdminClient) GetCluster() ([]Node, error) {
-	return get[[]Node](c, "/dashboard/cluster", nil)
+	return c.get[[]Node]("/dashboard/cluster", nil)
 }
 
 func (c *AdminClient) GetTasks() ([]Progress, error) {
-	return get[[]Progress](c, "/dashboard/tasks", nil)
+	return c.get[[]Progress]("/dashboard/tasks", nil)
 }
 
 func (c *AdminClient) GetConfig() (map[string]any, error) {
-	return get[map[string]any](c, "/dashboard/config", nil)
+	return c.get[map[string]any]("/dashboard/config", nil)
 }
 
 func (c *AdminClient) GetConfigMap() (map[string]any, error) {
-	return get[map[string]any](c, "/dashboard/config", nil)
+	return c.get[map[string]any]("/dashboard/config", nil)
 }
 
 func (c *AdminClient) GetConfigSchema() (map[string]any, error) {
-	return get[map[string]any](c, "/dashboard/config/schema", nil)
+	return c.get[map[string]any]("/dashboard/config/schema", nil)
 }
 
 func (c *AdminClient) UpdateConfig(configPatch map[string]any) (map[string]any, error) {
@@ -190,11 +190,11 @@ func (c *AdminClient) ResetConfig() (map[string]any, error) {
 }
 
 func (c *AdminClient) GetCategories() ([]string, error) {
-	return get[[]string](c, "/dashboard/categories", nil)
+	return c.get[[]string]("/dashboard/categories", nil)
 }
 
 func (c *AdminClient) GetStats() (Status, error) {
-	return get[Status](c, "/dashboard/stats", nil)
+	return c.get[Status]("/dashboard/stats", nil)
 }
 
 func (c *AdminClient) GetTimeseries(name, begin, end, duration string) ([]TimeSeriesPoint, error) {
@@ -208,7 +208,7 @@ func (c *AdminClient) GetTimeseries(name, begin, end, duration string) ([]TimeSe
 	if duration != "" {
 		params.Set("duration", duration)
 	}
-	return get[[]TimeSeriesPoint](c, "/dashboard/timeseries/"+url.PathEscape(name), params)
+	return c.get[[]TimeSeriesPoint]("/dashboard/timeseries/"+url.PathEscape(name), params)
 }
 
 func (c *AdminClient) GetFeedback(n int) (FeedbackIterator, error) {
@@ -216,7 +216,7 @@ func (c *AdminClient) GetFeedback(n int) (FeedbackIterator, error) {
 	if n != 0 {
 		params.Set("n", fmt.Sprint(n))
 	}
-	return get[FeedbackIterator](c, "/feedback", params)
+	return c.get[FeedbackIterator]("/feedback", params)
 }
 
 func (c *AdminClient) GetTypedFeedback(feedbackType string, n int) (FeedbackIterator, error) {
@@ -224,31 +224,31 @@ func (c *AdminClient) GetTypedFeedback(feedbackType string, n int) (FeedbackIter
 	if n != 0 {
 		params.Set("n", fmt.Sprint(n))
 	}
-	return get[FeedbackIterator](c, "/feedback/"+url.PathEscape(feedbackType), params)
+	return c.get[FeedbackIterator]("/feedback/"+url.PathEscape(feedbackType), params)
 }
 
 func (c *AdminClient) GetUserItemFeedback(userID, itemID string) ([]Feedback, error) {
-	return get[[]Feedback](c, "/feedback/"+url.PathEscape(userID)+"/"+url.PathEscape(itemID), nil)
+	return c.get[[]Feedback]("/feedback/"+url.PathEscape(userID)+"/"+url.PathEscape(itemID), nil)
 }
 
 func (c *AdminClient) GetTypedUserItemFeedback(feedbackType, userID, itemID string) (Feedback, error) {
-	return get[Feedback](c, "/feedback/"+url.PathEscape(feedbackType)+"/"+url.PathEscape(userID)+"/"+url.PathEscape(itemID), nil)
+	return c.get[Feedback]("/feedback/"+url.PathEscape(feedbackType)+"/"+url.PathEscape(userID)+"/"+url.PathEscape(itemID), nil)
 }
 
 func (c *AdminClient) GetUserFeedback(userID string) ([]Feedback, error) {
-	return get[[]Feedback](c, "/user/"+url.PathEscape(userID)+"/feedback", nil)
+	return c.get[[]Feedback]("/user/"+url.PathEscape(userID)+"/feedback", nil)
 }
 
 func (c *AdminClient) GetTypedUserFeedback(userID, feedbackType string) ([]Feedback, error) {
-	return get[[]Feedback](c, "/user/"+url.PathEscape(userID)+"/feedback/"+url.PathEscape(feedbackType), nil)
+	return c.get[[]Feedback]("/user/"+url.PathEscape(userID)+"/feedback/"+url.PathEscape(feedbackType), nil)
 }
 
 func (c *AdminClient) GetItemFeedback(itemID string) ([]Feedback, error) {
-	return get[[]Feedback](c, "/item/"+url.PathEscape(itemID)+"/feedback/", nil)
+	return c.get[[]Feedback]("/item/"+url.PathEscape(itemID)+"/feedback/", nil)
 }
 
 func (c *AdminClient) GetTypedItemFeedback(itemID, feedbackType string) ([]Feedback, error) {
-	return get[[]Feedback](c, "/item/"+url.PathEscape(itemID)+"/feedback/"+url.PathEscape(feedbackType), nil)
+	return c.get[[]Feedback]("/item/"+url.PathEscape(itemID)+"/feedback/"+url.PathEscape(feedbackType), nil)
 }
 
 func (c *AdminClient) GetLatest(n int, categories []string) ([]ScoredItem, error) {
@@ -259,7 +259,7 @@ func (c *AdminClient) GetLatest(n int, categories []string) ([]ScoredItem, error
 	for _, category := range categories {
 		params.Add("category", category)
 	}
-	return get[[]ScoredItem](c, "/dashboard/latest", params)
+	return c.get[[]ScoredItem]("/dashboard/latest", params)
 }
 
 func (c *AdminClient) GetNonPersonalized(name string, n int, userID string, categories []string) ([]ScoredItem, error) {
@@ -273,7 +273,7 @@ func (c *AdminClient) GetNonPersonalized(name string, n int, userID string, cate
 	for _, category := range categories {
 		params.Add("category", category)
 	}
-	return get[[]ScoredItem](c, "/dashboard/non-personalized/"+url.PathEscape(name), params)
+	return c.get[[]ScoredItem]("/dashboard/non-personalized/"+url.PathEscape(name), params)
 }
 
 func (c *AdminClient) GetRecommend(userID, recommender, name string, n int, categories []string) ([]ScoredItem, error) {
@@ -291,7 +291,7 @@ func (c *AdminClient) GetRecommend(userID, recommender, name string, n int, cate
 	for _, category := range categories {
 		params.Add("category", category)
 	}
-	return get[[]ScoredItem](c, path, params)
+	return c.get[[]ScoredItem](path, params)
 }
 
 func (c *AdminClient) GetItemToItem(name, itemID string, n int, categories []string) ([]ScoredItem, error) {
@@ -302,7 +302,7 @@ func (c *AdminClient) GetItemToItem(name, itemID string, n int, categories []str
 	for _, category := range categories {
 		params.Add("category", category)
 	}
-	return get[[]ScoredItem](c, "/dashboard/item-to-item/"+url.PathEscape(name)+"/"+url.PathEscape(itemID), params)
+	return c.get[[]ScoredItem]("/dashboard/item-to-item/"+url.PathEscape(name)+"/"+url.PathEscape(itemID), params)
 }
 
 func (c *AdminClient) GetUserToUser(name, userID string, n int) ([]ScoreUser, error) {
@@ -310,7 +310,7 @@ func (c *AdminClient) GetUserToUser(name, userID string, n int) ([]ScoreUser, er
 	if n != 0 {
 		params.Set("n", fmt.Sprint(n))
 	}
-	return get[[]ScoreUser](c, "/dashboard/user-to-user/"+url.PathEscape(name)+"/"+url.PathEscape(userID), params)
+	return c.get[[]ScoreUser]("/dashboard/user-to-user/"+url.PathEscape(name)+"/"+url.PathEscape(userID), params)
 }
 
 func (c *AdminClient) Restore(reader io.Reader) (*DumpStats, error) {
@@ -347,7 +347,7 @@ func (c *AdminClient) Dump(output io.Writer) error {
 	return nil
 }
 
-func get[T any](c *AdminClient, path string, params url.Values) (T, error) {
+func (c *AdminClient) get[T any](path string, params url.Values) (T, error) {
 	var result T
 	if len(params) > 0 {
 		path += "?" + params.Encode()

--- a/cmd/gorse-in-one/Dockerfile
+++ b/cmd/gorse-in-one/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26
+FROM --platform=$BUILDPLATFORM golang:1.27
 
 WORKDIR /src
 

--- a/cmd/gorse-in-one/Dockerfile.cuda
+++ b/cmd/gorse-in-one/Dockerfile.cuda
@@ -5,7 +5,7 @@
 ############################
 FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
 
-COPY --from=golang:1.26 /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.27 /usr/local/go/ /usr/local/go/
 
 ENV PATH=/usr/local/go/bin:$PATH
 

--- a/cmd/gorse-in-one/Dockerfile.mkl
+++ b/cmd/gorse-in-one/Dockerfile.mkl
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.26-bookworm
+FROM golang:1.27-bookworm
 
 # Install Intel® oneAPI Toolkits
 

--- a/cmd/gorse-in-one/Dockerfile.openblas
+++ b/cmd/gorse-in-one/Dockerfile.openblas
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26
+FROM --platform=$BUILDPLATFORM golang:1.27
 
 # Install OpenBLAS
 

--- a/cmd/gorse-in-one/Dockerfile.windows
+++ b/cmd/gorse-in-one/Dockerfile.windows
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.26
+FROM golang:1.27
 
 WORKDIR /src
 

--- a/cmd/gorse-master/Dockerfile
+++ b/cmd/gorse-master/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26
+FROM --platform=$BUILDPLATFORM golang:1.27
 
 WORKDIR /src
 

--- a/cmd/gorse-master/Dockerfile.cuda
+++ b/cmd/gorse-master/Dockerfile.cuda
@@ -5,7 +5,7 @@
 ############################
 FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
 
-COPY --from=golang:1.26 /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.27 /usr/local/go/ /usr/local/go/
 
 ENV PATH=/usr/local/go/bin:$PATH
 

--- a/cmd/gorse-master/Dockerfile.mkl
+++ b/cmd/gorse-master/Dockerfile.mkl
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.26-bookworm
+FROM golang:1.27-bookworm
 
 # Install Intel® oneAPI Toolkits
 

--- a/cmd/gorse-master/Dockerfile.openblas
+++ b/cmd/gorse-master/Dockerfile.openblas
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26
+FROM --platform=$BUILDPLATFORM golang:1.27
 
 # Install OpenBLAS
 

--- a/cmd/gorse-master/Dockerfile.windows
+++ b/cmd/gorse-master/Dockerfile.windows
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.26
+FROM golang:1.27
 
 WORKDIR /src
 

--- a/cmd/gorse-server/Dockerfile
+++ b/cmd/gorse-server/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26
+FROM --platform=$BUILDPLATFORM golang:1.27
 
 WORKDIR /src
 

--- a/cmd/gorse-server/Dockerfile.cuda
+++ b/cmd/gorse-server/Dockerfile.cuda
@@ -5,7 +5,7 @@
 ############################
 FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
 
-COPY --from=golang:1.26 /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.27 /usr/local/go/ /usr/local/go/
 
 ENV PATH=/usr/local/go/bin:$PATH
 

--- a/cmd/gorse-server/Dockerfile.mkl
+++ b/cmd/gorse-server/Dockerfile.mkl
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.26-bookworm
+FROM golang:1.27-bookworm
 
 # Install Intel® oneAPI Toolkits
 

--- a/cmd/gorse-server/Dockerfile.openblas
+++ b/cmd/gorse-server/Dockerfile.openblas
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26
+FROM --platform=$BUILDPLATFORM golang:1.27
 
 # Install OpenBLAS
 

--- a/cmd/gorse-server/Dockerfile.windows
+++ b/cmd/gorse-server/Dockerfile.windows
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.26
+FROM golang:1.27
 
 WORKDIR /src
 

--- a/cmd/gorse-worker/Dockerfile
+++ b/cmd/gorse-worker/Dockerfile
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26
+FROM --platform=$BUILDPLATFORM golang:1.27
 
 WORKDIR /src
 

--- a/cmd/gorse-worker/Dockerfile.cuda
+++ b/cmd/gorse-worker/Dockerfile.cuda
@@ -5,7 +5,7 @@
 ############################
 FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
 
-COPY --from=golang:1.26 /usr/local/go/ /usr/local/go/
+COPY --from=golang:1.27 /usr/local/go/ /usr/local/go/
 
 ENV PATH=/usr/local/go/bin:$PATH
 

--- a/cmd/gorse-worker/Dockerfile.mkl
+++ b/cmd/gorse-worker/Dockerfile.mkl
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.26-bookworm
+FROM golang:1.27-bookworm
 
 # Install Intel® oneAPI Toolkits
 

--- a/cmd/gorse-worker/Dockerfile.openblas
+++ b/cmd/gorse-worker/Dockerfile.openblas
@@ -3,7 +3,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM --platform=$BUILDPLATFORM golang:1.26
+FROM --platform=$BUILDPLATFORM golang:1.27
 
 # Install OpenBLAS
 

--- a/cmd/gorse-worker/Dockerfile.windows
+++ b/cmd/gorse-worker/Dockerfile.windows
@@ -1,7 +1,7 @@
 ############################
 # STEP 1 build executable binary
 ############################
-FROM golang:1.26
+FROM golang:1.27
 
 WORKDIR /src
 

--- a/common/monitor/progress.go
+++ b/common/monitor/progress.go
@@ -26,7 +26,7 @@ import (
 
 type spanKeyType string
 
-var spanKeyName = spanKeyType(uuid.New().String())
+var spanKeyName = spanKeyType(uuid.NewV4().String())
 
 type Status string
 

--- a/common/monitor/progress.go
+++ b/common/monitor/progress.go
@@ -19,8 +19,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"uuid"
 
-	"github.com/google/uuid"
 	"github.com/gorse-io/gorse/protocol"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/pebble/v2 v2.1.6 // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
-	github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b // indirect
+	github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/containerd/cgroups/v3 v3.0.3 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gorse-io/gorse
 
-go 1.26
+go 1.27
 
 require (
 	cloud.google.com/go/storage v1.61.3

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwP
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b h1:VXvSNzmr8hMj8XTuY0PT9Ane9qZGul/p67vGYwl9BFI=
 github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
+github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258 h1:IJ+uNItEm0qx9FE2AgIc1PMsCUtk8nbSIzhQE1t5GWw=
+github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/containerd/cgroups/v3 v3.0.3 h1:S5ByHZ/h9PMe5IOQoN7E+nMc2UcLEM/V48DGDJ9kip0=

--- a/master/rest.go
+++ b/master/rest.go
@@ -1934,15 +1934,13 @@ func (m *Master) Restore(r io.ReadCloser, delta *time.Duration) (stats DumpStats
 					}
 				}
 				feedbacks = append(feedbacks, data.Feedback{
-					FeedbackKey: data.FeedbackKey{
-						FeedbackType: feedback.FeedbackType,
-						UserId:       feedback.UserId,
-						ItemId:       feedback.ItemId,
-					},
-					Value:     feedback.Value,
-					Timestamp: timestamp,
-					Labels:    labels,
-					Comment:   feedback.Comment,
+					FeedbackType: feedback.FeedbackType,
+					UserId:       feedback.UserId,
+					ItemId:       feedback.ItemId,
+					Value:        feedback.Value,
+					Timestamp:    timestamp,
+					Labels:       labels,
+					Comment:      feedback.Comment,
 				})
 				stats.Feedback++
 				if len(feedbacks) == batchSize {

--- a/server/rest.go
+++ b/server/rest.go
@@ -149,7 +149,7 @@ func (s *RestServer) StartHttpServer(container *restful.Container) {
 
 func (s *RestServer) LogFilter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 	// generate request id
-	requestId := uuid.New().String()
+	requestId := uuid.NewV4().String()
 	resp.AddHeader("X-Request-ID", requestId)
 
 	var requestReader *CountingReadCloser

--- a/server/rest.go
+++ b/server/rest.go
@@ -24,12 +24,12 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"uuid"
 
 	"github.com/araddon/dateparse"
 	mapset "github.com/deckarep/golang-set/v2"
 	restfulspec "github.com/emicklei/go-restful-openapi/v2"
 	"github.com/emicklei/go-restful/v3"
-	"github.com/google/uuid"
 	"github.com/gorse-io/gorse/common/event"
 	"github.com/gorse-io/gorse/common/expression"
 	"github.com/gorse-io/gorse/common/heap"
@@ -119,6 +119,7 @@ func (s *RestServer) StartHttpServer(container *restful.Container) {
 	container.Handle("/debug/pprof/allocs", pprof.Handler("allocs"))
 	container.Handle("/debug/pprof/block", pprof.Handler("block"))
 	container.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	container.Handle("/debug/pprof/goroutineleak", pprof.Handler("goroutineleak"))
 	container.Handle("/debug/pprof/heap", pprof.Handler("heap"))
 	container.Handle("/debug/pprof/mutex", pprof.Handler("mutex"))
 	container.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
@@ -945,12 +946,10 @@ func (s *RestServer) getRecommend(request *restful.Request, response *restful.Re
 		for _, itemId := range results {
 			// insert to data store
 			feedback := data.Feedback{
-				FeedbackKey: data.FeedbackKey{
-					UserId:       userId,
-					ItemId:       itemId,
-					FeedbackType: writeBackFeedback,
-				},
-				Timestamp: startTime.Add(writeBackDelay),
+				UserId:       userId,
+				ItemId:       itemId,
+				FeedbackType: writeBackFeedback,
+				Timestamp:    startTime.Add(writeBackDelay),
 			}
 			err = s.DataClient.BatchInsertFeedback(ctx, []data.Feedback{feedback}, false, false, false)
 			if err != nil {


### PR DESCRIPTION
## Summary

- upgrade the module and all build images from Go 1.26 to Go 1.27
- update `cockroachdb/swiss` to its Go 1.27-compatible revision
- adopt Go 1.27 generic methods for the admin client's typed GET helper
- use the new standard-library `uuid` package for random UUID generation
- expose the generally available `goroutineleak` pprof profile
- simplify embedded feedback struct literals with promoted field keys

## Verification

- `gofmt` with Go 1.27
- `git diff --check`
- local tests were not run as requested; GitHub CI is the verification source

## Notes

The experimental `simd` packages and the stricter `encoding/json/v2` API are intentionally not adopted in this PR because they require separate compatibility and performance evaluation.
