### PR TITLE
fix: wait for master background tasks on shutdown

### DIFF
--- a/master/master.go
+++ b/master/master.go
@@ -105,15 +105,19 @@ type Master struct {
 	tokenCache   *ttlcache.Cache[string, UserInfo]
 
 	// events
-	ticker      *time.Ticker
-	scheduled   chan struct{}
-	cancel      context.CancelFunc
-	reconciling atomic.Bool
+	ticker              *time.Ticker
+	scheduled           chan struct{}
+	cancel              context.CancelFunc
+	backgroundContext   context.Context
+	backgroundCancel    context.CancelFunc
+	backgroundWaitGroup sync.WaitGroup
+	reconciling         atomic.Bool
 }
 
 // NewMaster creates a master node.
 func NewMaster(cfg *config.Config, cacheFolder string, standalone bool, configPath string) *Master {
 	rand.Seed(time.Now().UnixNano())
+	backgroundContext, backgroundCancel := context.WithCancel(context.Background())
 
 	// setup trace provider
 	tp, err := cfg.Tracing.NewTracerProvider()
@@ -150,9 +154,11 @@ func NewMaster(cfg *config.Config, cacheFolder string, standalone bool, configPa
 			HttpPort:     cfg.Master.HttpPort,
 			WebService:   new(restful.WebService),
 		},
-		ticker:    time.NewTicker(duration),
-		scheduled: make(chan struct{}, 1),
-		cancel:    func() {},
+		ticker:            time.NewTicker(duration),
+		scheduled:         make(chan struct{}, 1),
+		cancel:            func() {},
+		backgroundContext: backgroundContext,
+		backgroundCancel:  backgroundCancel,
 	}
 	return m
 }
@@ -354,8 +360,12 @@ func (m *Master) Serve() {
 		}
 	}
 
-	go m.watchConfigFile(context.Background())
-	go m.RunTasksLoop()
+	m.backgroundWaitGroup.Go(func() {
+		m.watchConfigFile(m.backgroundContext)
+	})
+	m.backgroundWaitGroup.Go(func() {
+		m.RunTasksLoop()
+	})
 
 	// start rpc server
 	go func() {
@@ -425,6 +435,10 @@ func (m *Master) Shutdown() {
 	}
 	// stop grpc server
 	m.grpcServer.GracefulStop()
+	// stop background tasks before closing databases
+	m.backgroundCancel()
+	m.ticker.Stop()
+	m.backgroundWaitGroup.Wait()
 	// close databases
 	if err = m.metaStore.Close(); err != nil {
 		log.Logger().Error("failed to close meta database", zap.Error(err))
@@ -448,14 +462,20 @@ func (m *Master) RunTasksLoop() {
 	}
 	for {
 		select {
+		case <-m.backgroundContext.Done():
+			return
 		case <-m.ticker.C:
 		case <-m.scheduled:
 		}
 
 		// download dataset
 		var ctx context.Context
-		ctx, m.cancel = context.WithCancel(context.Background())
+		ctx, m.cancel = context.WithCancel(m.backgroundContext)
 		err := m.runLoadDatasetTask(ctx)
+		m.cancel()
+		if m.backgroundContext.Err() != nil {
+			return
+		}
 		if err != nil {
 			log.Logger().Error("failed to load ranking dataset", zap.Error(err))
 			continue

--- a/master/tasks.go
+++ b/master/tasks.go
@@ -81,7 +81,7 @@ func (m *Master) loadDataset(parent context.Context) (datasets Datasets, err err
 	defer span.End()
 
 	searchConfig := config.SearchConfig{Columns: append([]string(nil), m.Config.Recommend.Search.Columns...)}
-	go func() {
+	m.backgroundWaitGroup.Go(func() {
 		if !m.reconciling.CompareAndSwap(false, true) {
 			log.Logger().Info("skip reconciling data store since previous reconciliation is still running")
 			return
@@ -90,7 +90,7 @@ func (m *Master) loadDataset(parent context.Context) (datasets Datasets, err err
 		if err := m.DataClient.Reconcile(searchConfig); err != nil {
 			log.Logger().Error("failed to reconcile data store", zap.Error(err))
 		}
-	}()
+	})
 
 	// Build non-personalized recommenders
 	initialStartTime := time.Now()


### PR DESCRIPTION
## Summary

- cancel the master's background context during shutdown
- wait for the task loop, config watcher, and data-store reconciliation before closing databases
- use `sync.WaitGroup.Go` for tracked background goroutines

## Root cause

Restoring a dump schedules a new Load Dataset task. The CLI test could finish and close the SQLite stores while that task was still using `cache.db`. Windows then failed to remove the temporary directory because the database file was still open.

Failure observed in GitHub Actions: https://github.com/gorse-io/gorse/actions/runs/32448349634/job/96672004792

## Testing

- `go test ./master ./client ./cmd/gorse-cli`
- `go test ./cmd/gorse-cli -run 'TestCLI/TestDumpRestore$' -count=100`