### PR TITLE
fix(worker): snapshot config per recommend cycle to fix Sync race

### DIFF
--- a/worker/pipeline.go
+++ b/worker/pipeline.go
@@ -79,6 +79,7 @@ func compressLabelsEmbeddings(pool *strutil.GoPool, labels any) any {
 
 type Pipeline struct {
 	Config                   *config.Config
+	configMutex              sync.RWMutex
 	CacheClient              cache.Database
 	DataClient               data.Database
 	VectorClient             vectors.Database
@@ -89,6 +90,18 @@ type Pipeline struct {
 	MatrixFactorizationMutex sync.RWMutex
 	ClickThroughRateModel    ctr.FactorizationMachines
 	dontskipColdStartUsers   bool
+}
+
+func (p *Pipeline) getConfig() *config.Config {
+	p.configMutex.RLock()
+	defer p.configMutex.RUnlock()
+	return p.Config
+}
+
+func (p *Pipeline) setConfig(cfg *config.Config) {
+	p.configMutex.Lock()
+	p.Config = cfg
+	p.configMutex.Unlock()
 }
 
 func (p *Pipeline) UpdateMatrixFactorization(
@@ -122,12 +135,13 @@ func (p *Pipeline) GetMatrixFactorization() (*logics.MatrixFactorizationUsers, i
 }
 
 func (p *Pipeline) Recommend(ctx context.Context, users []data.User, progress func(completed, throughput int)) {
+	cfg := p.getConfig()
 	startRecommendTime := time.Now()
 	itemCache := NewItemCache(p.DataClient)
 	log.Logger().Info("ranking recommendation",
 		zap.Int("n_working_users", len(users)),
 		zap.Int("n_jobs", p.Jobs),
-		zap.Int("cache_size", p.Config.Recommend.CacheSize))
+		zap.Int("cache_size", cfg.Recommend.CacheSize))
 
 	// progress tracker
 	completed := make(chan struct{}, 1000)
@@ -171,20 +185,20 @@ func (p *Pipeline) Recommend(ctx context.Context, users []data.User, progress fu
 	)
 
 	defer MemoryInuseBytesVec.WithLabelValues("user_feedback_cache").Set(0)
-	if err := parallel.Detachable(ctx, len(users), p.Jobs, p.Config.OpenAI.ChatCompletionRPM, func(pCtx *parallel.Context, jobId int) {
+	if err := parallel.Detachable(ctx, len(users), p.Jobs, cfg.OpenAI.ChatCompletionRPM, func(pCtx *parallel.Context, jobId int) {
 		defer func() {
 			completed <- struct{}{}
 		}()
 		user := users[jobId]
 		userId := user.UserId
 		// skip inactive users before max recommend period
-		if !p.checkUserActiveTime(ctx, userId) || !p.checkRecommendCacheOutOfDate(ctx, userId) {
+		if !p.checkUserActiveTimeWithConfig(ctx, cfg, userId) || !p.checkRecommendCacheOutOfDateWithConfig(ctx, cfg, userId) {
 			return
 		}
 		updateUserCount.Add(1)
 
 		recommendTime := time.Now()
-		recommender, err := logics.NewRecommender(p.Config.Recommend, p.CacheClient, p.DataClient, p.VectorClient, false, userId, nil)
+		recommender, err := logics.NewRecommender(cfg.Recommend, p.CacheClient, p.DataClient, p.VectorClient, false, userId, nil)
 		if err != nil {
 			log.Logger().Error("failed to create recommender", zap.String("user_id", userId), zap.Error(err))
 			return
@@ -195,9 +209,9 @@ func (p *Pipeline) Recommend(ctx context.Context, users []data.User, progress fu
 		}
 
 		// Update collaborative filtering recommendation.
-		if matrixFactorizationUsers, matrixFactorizationID := p.GetMatrixFactorization(); !strings.EqualFold(p.Config.Recommend.Collaborative.Type, "none") && matrixFactorizationUsers != nil {
+		if matrixFactorizationUsers, matrixFactorizationID := p.GetMatrixFactorization(); !strings.EqualFold(cfg.Recommend.Collaborative.Type, "none") && matrixFactorizationUsers != nil {
 			if userEmbedding, ok := matrixFactorizationUsers.Get(userId); ok {
-				if err := p.updateCollaborativeRecommend(ctx, matrixFactorizationID, userId, userEmbedding, recommender.ExcludeSet()); err != nil {
+				if err := p.updateCollaborativeRecommendWithConfig(ctx, cfg, matrixFactorizationID, userId, userEmbedding, recommender.ExcludeSet()); err != nil {
 					log.Logger().Error("failed to recommend by collaborative filtering",
 						zap.String("user_id", userId), zap.Error(err))
 					return
@@ -214,10 +228,10 @@ func (p *Pipeline) Recommend(ctx context.Context, users []data.User, progress fu
 			digest           string
 			recommenderNames []string
 		)
-		if len(p.Config.Recommend.Ranker.Recommenders) > 0 {
-			recommenderNames = p.Config.Recommend.Ranker.Recommenders
+		if len(cfg.Recommend.Ranker.Recommenders) > 0 {
+			recommenderNames = cfg.Recommend.Ranker.Recommenders
 		} else {
-			recommenderNames = p.Config.Recommend.ListRecommenders()
+			recommenderNames = cfg.Recommend.ListRecommenders()
 		}
 		scores, digest, err = recommender.RecommendSequential(ctx, scores, 0, recommenderNames...)
 		if err != nil {
@@ -244,9 +258,9 @@ func (p *Pipeline) Recommend(ctx context.Context, users []data.User, progress fu
 
 		// Insert replacement items into the candidate set before ranking so all rankers (including LLM) can order them.
 		var replacementPositiveItems, replacementNegativeItems mapset.Set[string]
-		if p.Config.Recommend.Replacement.EnableReplacement && p.Config.Recommend.Ranker.Type != "none" {
-			candidates, replacementPositiveItems, replacementNegativeItems, err = p.addReplacementCandidates(
-				ctx, candidates, candidateSet, recommender.UserFeedback(), itemCache, recommendTime,
+		if cfg.Recommend.Replacement.EnableReplacement && cfg.Recommend.Ranker.Type != "none" {
+			candidates, replacementPositiveItems, replacementNegativeItems, err = p.addReplacementCandidatesWithConfig(
+				ctx, cfg, candidates, candidateSet, recommender.UserFeedback(), itemCache, recommendTime,
 			)
 			if err != nil {
 				log.Logger().Error("failed to prepare replacement candidates", zap.Error(err))
@@ -256,22 +270,22 @@ func (p *Pipeline) Recommend(ctx context.Context, users []data.User, progress fu
 
 		// rank by click-through-rate
 		var results []cache.Score
-		if p.Config.Recommend.Ranker.Type == "fm" && p.ClickThroughRateModel != nil && !p.ClickThroughRateModel.Invalid() {
+		if cfg.Recommend.Ranker.Type == "fm" && p.ClickThroughRateModel != nil && !p.ClickThroughRateModel.Invalid() {
 			results, err = p.rankByClickTroughRate(ctx, p.ClickThroughRateModel, &user, candidates, itemCache, recommendTime)
 			if err != nil {
 				log.Logger().Error("failed to rank items", zap.Error(err))
 				return
 			}
-		} else if p.Config.Recommend.Ranker.Type == "llm" && p.Config.OpenAI.ChatCompletionModel != "" {
+		} else if cfg.Recommend.Ranker.Type == "llm" && cfg.OpenAI.ChatCompletionModel != "" {
 			ranker, err := logics.NewChatReranker(
-				p.Config.Recommend.Ranker.RerankerAPI,
-				p.Config.Recommend.Ranker.QueryTemplate,
-				p.Config.Recommend.Ranker.DocumentTemplate)
+				cfg.Recommend.Ranker.RerankerAPI,
+				cfg.Recommend.Ranker.QueryTemplate,
+				cfg.Recommend.Ranker.DocumentTemplate)
 			if err != nil {
 				log.Logger().Error("failed to create LLM ranker", zap.Error(err))
 				return
 			}
-			results, err = p.rankByLLM(ctx, pCtx, ranker, &user, recommender.UserFeedback(), candidates, itemCache, recommendTime)
+			results, err = p.rankByLLMWithConfig(ctx, pCtx, cfg, ranker, &user, recommender.UserFeedback(), candidates, itemCache, recommendTime)
 			if err != nil {
 				log.Logger().Error("failed to rank items by LLM", zap.Error(err))
 				return
@@ -281,8 +295,8 @@ func (p *Pipeline) Recommend(ctx context.Context, users []data.User, progress fu
 		}
 
 		// Apply replacement decay after ranking so weights don't bypass the ranker ordering.
-		if p.Config.Recommend.Replacement.EnableReplacement && p.Config.Recommend.Ranker.Type != "none" {
-			results = p.applyReplacementDecay(results, replacementPositiveItems, replacementNegativeItems)
+		if cfg.Recommend.Replacement.EnableReplacement && cfg.Recommend.Ranker.Type != "none" {
+			results = p.applyReplacementDecayWithConfig(cfg, results, replacementPositiveItems, replacementNegativeItems)
 		}
 
 		// cache recommendation
@@ -320,7 +334,11 @@ func (p *Pipeline) Recommend(ctx context.Context, users []data.User, progress fu
 
 // checkUserActiveTime checks if a user is active based on their last modification time.
 func (p *Pipeline) checkUserActiveTime(ctx context.Context, userId string) bool {
-	if p.Config.Recommend.ActiveUserTTL == 0 {
+	return p.checkUserActiveTimeWithConfig(ctx, p.getConfig(), userId)
+}
+
+func (p *Pipeline) checkUserActiveTimeWithConfig(ctx context.Context, cfg *config.Config, userId string) bool {
+	if cfg.Recommend.ActiveUserTTL == 0 {
 		return true
 	}
 	// read active time
@@ -333,7 +351,7 @@ func (p *Pipeline) checkUserActiveTime(ctx context.Context, userId string) bool 
 		return true
 	}
 	// check active time
-	if time.Since(activeTime) < time.Duration(p.Config.Recommend.ActiveUserTTL*24)*time.Hour {
+	if time.Since(activeTime) < time.Duration(cfg.Recommend.ActiveUserTTL*24)*time.Hour {
 		return true
 	}
 	// remove recommend cache for inactive users
@@ -346,6 +364,10 @@ func (p *Pipeline) checkUserActiveTime(ctx context.Context, userId string) bool 
 
 // checkRecommendCacheOutOfDate checks if recommend cache stale.
 func (p *Pipeline) checkRecommendCacheOutOfDate(ctx context.Context, userId string) bool {
+	return p.checkRecommendCacheOutOfDateWithConfig(ctx, p.getConfig(), userId)
+}
+
+func (p *Pipeline) checkRecommendCacheOutOfDateWithConfig(ctx context.Context, cfg *config.Config, userId string) bool {
 	var (
 		activeTime    time.Time
 		recommendTime time.Time
@@ -370,7 +392,7 @@ func (p *Pipeline) checkRecommendCacheOutOfDate(ctx context.Context, userId stri
 	if digest == "" {
 		return true
 	}
-	if digest != p.Config.Recommend.Hash() {
+	if digest != cfg.Recommend.Hash() {
 		return true
 	}
 
@@ -388,13 +410,13 @@ func (p *Pipeline) checkRecommendCacheOutOfDate(ctx context.Context, userId stri
 	}
 
 	// 4. If update time + cache expire > current time, not stale.
-	if recommendTime.Before(time.Now().Add(-p.Config.Recommend.CacheExpire)) {
+	if recommendTime.Before(time.Now().Add(-cfg.Recommend.CacheExpire)) {
 		return true
 	}
 
 	// 5. If active time > recommend time, not stale.
 	if activeTime.Before(recommendTime) {
-		timeoutTime := recommendTime.Add(p.Config.Recommend.Ranker.CacheExpire)
+		timeoutTime := recommendTime.Add(cfg.Recommend.Ranker.CacheExpire)
 		return timeoutTime.Before(time.Now())
 	}
 	return true
@@ -407,13 +429,24 @@ func (p *Pipeline) updateCollaborativeRecommend(
 	userEmbedding []float32,
 	excludeSet mapset.Set[string],
 ) error {
+	return p.updateCollaborativeRecommendWithConfig(ctx, p.getConfig(), matrixFactorizationID, userID, userEmbedding, excludeSet)
+}
+
+func (p *Pipeline) updateCollaborativeRecommendWithConfig(
+	ctx context.Context,
+	cfg *config.Config,
+	matrixFactorizationID int64,
+	userID string,
+	userEmbedding []float32,
+	excludeSet mapset.Set[string],
+) error {
 	localStartTime := time.Now()
 	scoredVectors, err := p.VectorClient.QueryVectors(
 		ctx,
 		vectors.CollaborativeFilteringCollection(matrixFactorizationID),
 		vectors.Vector{Values: userEmbedding},
 		nil,
-		p.Config.Recommend.CacheSize+excludeSet.Cardinality(),
+		cfg.Recommend.CacheSize+excludeSet.Cardinality(),
 	)
 	if err != nil {
 		return errors.WithStack(err)
@@ -435,7 +468,7 @@ func (p *Pipeline) updateCollaborativeRecommend(
 	}
 	if err := p.CacheClient.Set(ctx,
 		cache.Time(cache.Key(cache.CollaborativeFilteringUpdateTime, userID), localStartTime),
-		cache.String(cache.Key(cache.CollaborativeFilteringDigest, userID), p.Config.Recommend.Collaborative.Hash(&p.Config.Recommend)),
+		cache.String(cache.Key(cache.CollaborativeFilteringDigest, userID), cfg.Recommend.Collaborative.Hash(&cfg.Recommend)),
 	); err != nil {
 		log.Logger().Error("failed to cache collaborative filtering recommendation time", zap.String("user_id", userID), zap.Error(err))
 		return errors.WithStack(err)
@@ -508,6 +541,20 @@ func (p *Pipeline) rankByLLM(
 	itemCache *ItemCache,
 	recommendTime time.Time,
 ) ([]cache.Score, error) {
+	return p.rankByLLMWithConfig(ctx, pCtx, p.getConfig(), ranker, user, feedback, candidates, itemCache, recommendTime)
+}
+
+func (p *Pipeline) rankByLLMWithConfig(
+	ctx context.Context,
+	pCtx *parallel.Context,
+	cfg *config.Config,
+	ranker *logics.ChatReranker,
+	user *data.User,
+	feedback []data.Feedback,
+	candidates []cache.Score,
+	itemCache *ItemCache,
+	recommendTime time.Time,
+) ([]cache.Score, error) {
 	// download items
 	items, err := itemCache.GetSlice(ctx, lo.Map(candidates, func(score cache.Score, _ int) string {
 		return score.Id
@@ -517,12 +564,12 @@ func (p *Pipeline) rankByLLM(
 	}
 	// convert feedback
 	data.SortFeedbacks(feedback)
-	contextUserFeedback := make([]data.Feedback, 0, p.Config.Recommend.ContextSize)
+	contextUserFeedback := make([]data.Feedback, 0, cfg.Recommend.ContextSize)
 	for _, f := range feedback {
-		if p.Config.Recommend.ContextSize <= len(contextUserFeedback) {
+		if cfg.Recommend.ContextSize <= len(contextUserFeedback) {
 			break
 		}
-		if expression.MatchFeedbackTypeExpressions(p.Config.Recommend.DataSource.PositiveFeedbackTypes, f.FeedbackType, f.Value) {
+		if expression.MatchFeedbackTypeExpressions(cfg.Recommend.DataSource.PositiveFeedbackTypes, f.FeedbackType, f.Value) {
 			contextUserFeedback = append(contextUserFeedback, f)
 		}
 	}
@@ -578,13 +625,25 @@ func (p *Pipeline) addReplacementCandidates(
 	itemCache *ItemCache,
 	recommendTime time.Time,
 ) ([]cache.Score, mapset.Set[string], mapset.Set[string], error) {
+	return p.addReplacementCandidatesWithConfig(ctx, p.getConfig(), candidates, candidateSet, feedbacks, itemCache, recommendTime)
+}
+
+func (p *Pipeline) addReplacementCandidatesWithConfig(
+	ctx context.Context,
+	cfg *config.Config,
+	candidates []cache.Score,
+	candidateSet mapset.Set[string],
+	feedbacks []data.Feedback,
+	itemCache *ItemCache,
+	recommendTime time.Time,
+) ([]cache.Score, mapset.Set[string], mapset.Set[string], error) {
 	positiveItems := mapset.NewSet[string]()
 	distinctItems := mapset.NewSet[string]()
 	for _, feedback := range feedbacks {
-		if expression.MatchFeedbackTypeExpressions(p.Config.Recommend.DataSource.PositiveFeedbackTypes, feedback.FeedbackType, feedback.Value) {
+		if expression.MatchFeedbackTypeExpressions(cfg.Recommend.DataSource.PositiveFeedbackTypes, feedback.FeedbackType, feedback.Value) {
 			positiveItems.Add(feedback.ItemId)
 			distinctItems.Add(feedback.ItemId)
-		} else if expression.MatchFeedbackTypeExpressions(p.Config.Recommend.DataSource.ReadFeedbackTypes, feedback.FeedbackType, feedback.Value) {
+		} else if expression.MatchFeedbackTypeExpressions(cfg.Recommend.DataSource.ReadFeedbackTypes, feedback.FeedbackType, feedback.Value) {
 			distinctItems.Add(feedback.ItemId)
 		}
 	}
@@ -619,6 +678,15 @@ func (p *Pipeline) applyReplacementDecay(
 	positiveItems mapset.Set[string],
 	negativeItems mapset.Set[string],
 ) []cache.Score {
+	return p.applyReplacementDecayWithConfig(p.getConfig(), results, positiveItems, negativeItems)
+}
+
+func (p *Pipeline) applyReplacementDecayWithConfig(
+	cfg *config.Config,
+	results []cache.Score,
+	positiveItems mapset.Set[string],
+	negativeItems mapset.Set[string],
+) []cache.Score {
 	if (positiveItems == nil || positiveItems.Cardinality() == 0) && (negativeItems == nil || negativeItems.Cardinality() == 0) {
 		return results
 	}
@@ -629,10 +697,10 @@ func (p *Pipeline) applyReplacementDecay(
 	for i := range updated {
 		switch {
 		case positiveItems != nil && positiveItems.Contains(updated[i].Id):
-			updated[i].Score *= p.Config.Recommend.Replacement.PositiveReplacementDecay
+			updated[i].Score *= cfg.Recommend.Replacement.PositiveReplacementDecay
 			changed = true
 		case negativeItems != nil && negativeItems.Contains(updated[i].Id):
-			updated[i].Score *= p.Config.Recommend.Replacement.ReadReplacementDecay
+			updated[i].Score *= cfg.Recommend.Replacement.ReadReplacementDecay
 			changed = true
 		}
 	}

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -144,10 +144,12 @@ func NewWorker(
 // Sync this worker to the master.
 func (w *Worker) Sync() {
 	var nextBlobConfig config.BlobConfig
-	log.Logger().Info("start meta sync", zap.Duration("meta_timeout", w.Config.Master.MetaTimeout))
+	currentConfig := w.getConfig()
+	log.Logger().Info("start meta sync", zap.Duration("meta_timeout", currentConfig.Master.MetaTimeout))
 	for {
 		var meta *protocol.Meta
 		var err error
+		nextConfig := new(config.Config)
 		if meta, err = w.masterClient.GetMeta(context.Background(),
 			&protocol.NodeInfo{
 				NodeType:      protocol.NodeType_Worker,
@@ -160,52 +162,54 @@ func (w *Worker) Sync() {
 		}
 
 		// load master config
-		err = json.Unmarshal([]byte(meta.Config), &w.Config)
+		err = json.Unmarshal([]byte(meta.Config), nextConfig)
 		if err != nil {
 			log.Logger().Error("failed to parse master config", zap.Error(err))
 			goto sleep
 		}
+		w.setConfig(nextConfig)
+		currentConfig = nextConfig
 
 		// connect to data store
-		if w.dataPath != w.Config.Database.DataStore || w.dataPrefix != w.Config.Database.DataTablePrefix {
-			if strings.HasPrefix(w.Config.Database.DataStore, storage.SQLitePrefix) {
+		if w.dataPath != nextConfig.Database.DataStore || w.dataPrefix != nextConfig.Database.DataTablePrefix {
+			if strings.HasPrefix(nextConfig.Database.DataStore, storage.SQLitePrefix) {
 				log.Logger().Info("connect data store via master")
 				w.DataClient = data.NewProxyClient(w.conn)
 			} else {
 				log.Logger().Info("connect data store",
-					zap.String("database", log.RedactDBURL(w.Config.Database.DataStore)))
-				dataOpts := w.Config.Database.StorageOptions(w.Config.Database.DataStore)
-				if w.DataClient, err = data.Open(w.Config.Database.DataStore, w.Config.Database.DataTablePrefix, dataOpts...); err != nil {
+					zap.String("database", log.RedactDBURL(nextConfig.Database.DataStore)))
+				dataOpts := nextConfig.Database.StorageOptions(nextConfig.Database.DataStore)
+				if w.DataClient, err = data.Open(nextConfig.Database.DataStore, nextConfig.Database.DataTablePrefix, dataOpts...); err != nil {
 					log.Logger().Error("failed to connect data store", zap.Error(err))
 					goto sleep
 				}
 			}
-			w.dataPath = w.Config.Database.DataStore
-			w.dataPrefix = w.Config.Database.DataTablePrefix
+			w.dataPath = nextConfig.Database.DataStore
+			w.dataPrefix = nextConfig.Database.DataTablePrefix
 		}
 
 		// connect to cache store
-		if w.cachePath != w.Config.Database.CacheStore || w.cachePrefix != w.Config.Database.CacheTablePrefix {
-			if strings.HasPrefix(w.Config.Database.CacheStore, storage.SQLitePrefix) {
+		if w.cachePath != nextConfig.Database.CacheStore || w.cachePrefix != nextConfig.Database.CacheTablePrefix {
+			if strings.HasPrefix(nextConfig.Database.CacheStore, storage.SQLitePrefix) {
 				log.Logger().Info("connect cache store via master")
 				w.CacheClient = cache.NewProxyClient(w.conn)
 			} else {
 				log.Logger().Info("connect cache store",
-					zap.String("database", log.RedactDBURL(w.Config.Database.CacheStore)))
-				cacheOpts := w.Config.Database.StorageOptions(w.Config.Database.CacheStore)
-				if w.CacheClient, err = cache.Open(w.Config.Database.CacheStore, w.Config.Database.CacheTablePrefix, cacheOpts...); err != nil {
+					zap.String("database", log.RedactDBURL(nextConfig.Database.CacheStore)))
+				cacheOpts := nextConfig.Database.StorageOptions(nextConfig.Database.CacheStore)
+				if w.CacheClient, err = cache.Open(nextConfig.Database.CacheStore, nextConfig.Database.CacheTablePrefix, cacheOpts...); err != nil {
 					log.Logger().Error("failed to connect cache store", zap.Error(err))
 					goto sleep
 				}
 			}
-			w.cachePath = w.Config.Database.CacheStore
-			w.cachePrefix = w.Config.Database.CacheTablePrefix
+			w.cachePath = nextConfig.Database.CacheStore
+			w.cachePrefix = nextConfig.Database.CacheTablePrefix
 		}
 
 		// connect to blob store
-		nextBlobConfig = w.Config.Blob
+		nextBlobConfig = nextConfig.Blob
 		if w.blobConfig != nextBlobConfig.URI {
-			w.blobStore, err = blob.NewStore(w.Config.Blob, w.conn)
+			w.blobStore, err = blob.NewStore(nextConfig.Blob, w.conn)
 			if err != nil {
 				log.Logger().Error("failed to connect blob store", zap.Error(err))
 				goto sleep
@@ -214,18 +218,18 @@ func (w *Worker) Sync() {
 		}
 
 		// connect to vector store
-		if w.vectorPath != w.Config.Database.VectorStore || w.vectorPrefix != w.Config.Database.VectorTablePrefix {
-			if strings.HasPrefix(w.Config.Database.VectorStore, storage.XvecPrefix) {
+		if w.vectorPath != nextConfig.Database.VectorStore || w.vectorPrefix != nextConfig.Database.VectorTablePrefix {
+			if strings.HasPrefix(nextConfig.Database.VectorStore, storage.XvecPrefix) {
 				log.Logger().Info("connect vector store via master")
 				w.vectorStore = vectors.NewProxyClient(w.conn)
 			} else {
-				if w.vectorStore, err = vectors.Open(w.Config.Database.VectorStore, w.Config.Database.VectorTablePrefix); err != nil {
+				if w.vectorStore, err = vectors.Open(nextConfig.Database.VectorStore, nextConfig.Database.VectorTablePrefix); err != nil {
 					log.Logger().Error("failed to connect vector store", zap.Error(err))
 					goto sleep
 				}
 			}
-			w.vectorPath = w.Config.Database.VectorStore
-			w.vectorPrefix = w.Config.Database.VectorTablePrefix
+			w.vectorPath = nextConfig.Database.VectorStore
+			w.vectorPrefix = nextConfig.Database.VectorTablePrefix
 			w.VectorClient = w.vectorStore
 		}
 
@@ -262,7 +266,7 @@ func (w *Worker) Sync() {
 			return
 		}
 		select {
-		case <-time.After(w.Config.Master.MetaTimeout):
+		case <-time.After(currentConfig.Master.MetaTimeout):
 		case <-w.done:
 			return
 		}

--- a/worker/worker_test.go
+++ b/worker/worker_test.go
@@ -730,6 +730,55 @@ func TestWorker_Sync(t *testing.T) {
 	master.Stop()
 }
 
+func TestWorker_SyncRecommend(t *testing.T) {
+	master := newMockMaster(t)
+	go master.Start(t)
+	address := <-master.addr
+	conn, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	assert.NoError(t, err)
+	serv := &Worker{
+		Pipeline: Pipeline{
+			Config:       config.GetDefaultConfig(),
+			CacheClient:  new(cache.NoDatabase),
+			DataClient:   new(data.NoDatabase),
+			VectorClient: vectors.NoDatabase{},
+			Tracer:       monitor.NewTracer("test"),
+			Jobs:         1,
+		},
+		testMode:     true,
+		conn:         conn,
+		masterClient: protocol.NewMasterClient(conn),
+		syncedChan:   make(chan struct{}, 1),
+		ticker:       time.NewTicker(time.Minute),
+	}
+
+	serv.Sync()
+	done := make(chan struct{})
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				serv.Sync()
+			}
+		}
+	}()
+
+	for range 10 {
+		serv.Recommend(t.Context(), []data.User{{UserId: "1"}}, nil)
+	}
+	close(done)
+	<-finished
+
+	assert.NoError(t, serv.DataClient.Close())
+	assert.NoError(t, serv.CacheClient.Close())
+	assert.NoError(t, conn.Close())
+	master.Stop()
+}
+
 type mockFactorizationMachine struct {
 	ctr.BaseFactorizationMachines
 }


### PR DESCRIPTION
## Intent

Fix gorse-io/gorse issue #606 by eliminating the data race between worker Sync and Recommend. A recommendation cycle must use one consistent configuration snapshot while Sync can publish newer immutable configurations for later cycles. Preserve existing recommendation behavior, add a race regression test that fails before the fix, and submit the validated change as a focused pull request from the fork.

## What Changed

- `Recommend` now captures a single configuration snapshot at the start of each cycle via a new `getConfig()` accessor guarded by an `sync.RWMutex` on `Pipeline`, and threads that snapshot through the `*WithConfig` helper variants (`checkUserActiveTime`, `checkRecommendCacheOutOfDate`, `updateCollaborativeRecommend`, `rankByLLM`, `addReplacementCandidates`, `applyReplacementDecay`), so a cycle never observes a config that changes mid-flight.
- `Sync` unmarshals the master config into a fresh `nextConfig` and publishes it atomically through `setConfig` instead of mutating the shared `w.Config` in place; the sync loop's own sleep timeout reads its local `currentConfig` snapshot.
- Added `TestWorker_SyncRecommend` regression test that runs `Sync` concurrently with ten `Recommend` cycles, exercising the previously racy interleaving.

## Risk Assessment

⚠️ Medium: 核心配置竞争已被正确且持久地修复（单次不可变快照 + 不可变发布，与 issue 维护者指示一致），但 Sync 与 Recommend 之间仍存在既有的存储客户端指针竞争（需运行期变更存储路径才可达，非本次引入），且新回归测试在无 -race 的 CI 中不生效，建议合并后以跟进项处理。

## Testing

本次测试阶段针对 gorse #606 的 worker 配置竞态修复做了定向验证：先用 -race 跑新增回归测试 TestWorker_SyncRecommend 确认修复后通过；再临时反向应用修复（仅 worker.go/pipeline.go，保留新测试）复现 base commit 场景，测试以 26 处 DATA RACE 失败，竞态报告精确对应 issue 描述的 Sync（json.Unmarshal 写入 w.Config，worker.go:163）与 Recommend（读取 p.Config，pipeline.go:187/358）并发冲突，证明该测试确实在修复前失败；随后恢复修复并以 -race 跑完整 TestWorker 套件（TestRecommend 全系列、TestReplacement、TestRankByLLM、TestRankByClickTroughRate、TestUserActivity、TestCheckRecommendCacheTimeout、TestPullUsers、TestHealth、TestWorker_Sync）全部通过，证明推荐行为未被破坏。工作树最终恢复为与目标提交一致（git status 干净）。修复的核心机制（getConfig/setConfig 加 RWMutex、Recommend 周期开始取一次性配置快照、Sync 发布新的不可变配置）经运行验证有效。PR 提交属于外层执行器职责，未在本阶段执行。

<details>
<summary>Evidence: base-commit 竞态回归失败日志（26 处 DATA RACE，Sync 写 w.Config 与 Recommend 读 p.Config 冲突）</summary>

<code>WARNING: DATA RACE&#10;Write at 0x00c000ba47f8 by goroutine 143:&#10;encoding/json.Unmarshal()&#10;github.com/gorse-io/gorse/worker.(*Worker).Sync()&#10;worker/worker.go:163 (json.Unmarshal(meta.Config, &amp;w.Config))&#10;Previous read at 0x00c000ba47f8 by goroutine 145:&#10;github.com/gorse-io/gorse/worker.(*Pipeline).Recommend.func2()&#10;worker/pipeline.go:187&#10;github.com/gorse-io/gorse/worker.(*Pipeline).checkRecommendCacheOutOfDate()&#10;worker/pipeline.go:358&#10;--- FAIL: TestWorker_SyncRecommend (0.02s)&#10;FAIL (26 WARNING: DATA RACE 总计)</code>

```text
{"level":"info","ts":1787377042.8446422,"caller":"ctr/fm.go:308","msg":"fit AFM","train_set_size":0,"test_set_size":0,"params":{"NEpochs":0},"config":{"Jobs":0,"Verbose":0,"Patience":0}}
{"level":"info","ts":1787377042.844998,"caller":"ctr/fm.go:326","msg":"fit AFM 0/0","eval_time":"13.041µs","Accuracy":0,"Precision":0,"Recall":0,"AUC":0}
{"level":"info","ts":1787377042.845325,"caller":"cf/model.go:409","msg":"fit bpr","train_set_size":0,"test_set_size":0,"params":{"NEpochs":0},"config":{"Jobs":1,"Verbose":10,"Candidates":100,"TopK":10,"Patience":0}}
{"level":"info","ts":1787377042.845495,"caller":"cf/model.go:521","msg":"fit bpr complete","NDCG@10":"NaN","Precision@10":"NaN","Recall@10":"NaN"}
{"level":"info","ts":1787377042.847702,"caller":"worker/worker.go:147","msg":"start meta sync","meta_timeout":10}
{"level":"info","ts":1787377042.849223,"caller":"worker/worker.go:172","msg":"connect data store via master"}
{"level":"info","ts":1787377042.849243,"caller":"worker/worker.go:190","msg":"connect cache store via master"}
{"level":"info","ts":1787377042.849269,"caller":"worker/worker.go:219","msg":"connect vector store via master"}
{"level":"info","ts":1787377042.84929,"caller":"worker/worker.go:235","msg":"new ranking model found","old_version":0,"new_version":2}
{"level":"info","ts":1787377042.849304,"caller":"worker/worker.go:248","msg":"new click model found","old_version":0,"new_version":1}
{"level":"info","ts":1787377042.849328,"caller":"worker/pipeline.go:127","msg":"ranking recommendation","n_working_users":1,"n_jobs":1,"cache_size":100}
{"level":"info","ts":1787377042.8493462,"caller":"worker/worker.go:147","msg":"start meta sync","meta_timeout":10}
{"level":"error","ts":1787377042.8497999,"caller":"worker/pipeline.go:358","msg":"failed to load offline recommendation","user_id":"1","error":"rpc error: code = Unimplemented desc = unknown service protocol.CacheStore","stacktrace":"github.com/gorse-io/gorse/worker.(*Pipeline).checkRecommendCacheOutOfDate\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:358\ngithub.com/gorse-io/gorse/worker.(*Pipeline).Recommend.func2\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:181\ngithub.com/gorse-io/gorse/common/parallel.Detachable.func1\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/common/parallel/parallel.go:254\nsync.(*WaitGroup).Go.func1\n\t/Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/sync/waitgroup.go:258"}
==================
WARNING: DATA RACE
Write at 0x00c000ba47f8 by goroutine 143:
  reflect.Value.SetInt()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/reflect/value.go:2254 +0xa8
  encoding/json/v2.makeIntArshaler.func2()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/encoding/json/v2/arshal_default.go:557 +0x518
  encoding/json/v2.makeStructArshaler.func3()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/encoding/json/v2/arshal_default.go:1401 +0x8cc
  encoding/json/v2.makeStructArshaler.func3()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/encoding/json/v2/arshal_default.go:1401 +0x8cc
  encoding/json/v2.makePointerArshaler.func3()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/encoding/json/v2/arshal_default.go:1776 +0x298
  encoding/json/v2.unmarshalDecode()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/encoding/json/v2/arshal.go:471 +0x3a4
  encoding/json/v2.Unmarshal()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/encoding/json/v2/arshal.go:390 +0xc0
  encoding/json.Unmarshal()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/encoding/json/v2_decode.go:111 +0x4c8
  github.com/gorse-io/gorse/worker.(*Worker).Sync()
      /Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/worker.go:163 +0x454
  google.golang.org/grpc.invoke()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/call.go:73 +0xe4
  google.golang.org/grpc/internal/transport.(*http2Client).NewStream()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/internal/transport/http2_client.go:781 +0x290
  google.golang.org/grpc.(*csAttempt).newStream()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/stream.go:551 +0x17c
  google.golang.org/grpc.newClientStreamWithParams.func2()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/stream.go:387 +0x3c
  google.golang.org/grpc.(*clientStream).withRetry()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/stream.go:840 +0xf8
  google.golang.org/grpc.newClientStreamWithParams()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/stream.go:396 +0x1148
  google.golang.org/grpc.newClientStream.func3()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/stream.go:247 +0xc8
  google.golang.org/grpc.newClientStream()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/stream.go:282 +0xa9c
  google.golang.org/grpc.invoke()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/call.go:66 +0x88
  google.golang.org/grpc.(*ClientConn).Invoke()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/call.go:37 +0x1c8
  github.com/gorse-io/gorse/protocol.(*masterClient).GetMeta()
      /Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/protocol/protocol_grpc.pb.go:60 +0x154
  github.com/gorse-io/gorse/worker.(*Worker).Sync()
      /Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/worker.go:151 +0x338
  go.uber.org/zap.(*Logger).check()
      /Users/wujunchen/go/pkg/mod/go.uber.org/zap@v1.27.1/logger.go:331 +0x6c
  go.uber.org/zap.(*Logger).check()
      /Users/wujunchen/go/pkg/mod/go.uber.org/zap@v1.27.1/logger.go:331 +0x6c
  go.uber.org/zap.(*Logger).Info()
      /Users/wujunchen/go/pkg/mod/go.uber.org/zap@v1.27.1/logger.go:246 +0x48
  github.com/gorse-io/gorse/worker.(*Worker).Sync()
      /Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/worker.go:147 +0x138
  github.com/gorse-io/gorse/worker.TestWorker_SyncRecommend.func1()
      /Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/worker_test.go:765 +0x88

Previous read at 0x00c000ba47f8 by goroutine 145:
  github.com/gorse-io/gorse/worker.(*Pipeline).Recommend.func2()
      /Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:187 +0x20c
  go.uber.org/zap.(*Logger).check()
      /Users/wujunchen/go/pkg/mod/go.uber.org/zap@v1.27.1/logger.go:331 +0x6c
  go.uber.org/zap.(*Logger).Error()
      /Users/wujunchen/go/pkg/mod/go.uber.org/zap@v1.27.1/logger.go:262 +0x48
  github.com/gorse-io/gorse/worker.(*Pipeline).checkRecommendCacheOutOfDate()
      /Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:358 +0xa14
  google.golang.org/grpc.invoke()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/call.go:70 +0xa8
  google.golang.org/grpc/internal/transport.(*http2Client).createHeaderFields()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/internal/transport/http2_client.go:567 +0x250
  google.golang.org/grpc/internal/transport.(*http2Client).createHeaderFields()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/internal/transport/http2_client.go:567 +0x250
  google.golang.org/grpc/internal/transport.(*http2Client).NewStream()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/internal/transport/http2_client.go:781 +0x290
  google.golang.org/grpc.(*csAttempt).newStream()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/stream.go:551 +0x17c
  google.golang.org/grpc.newClientStreamWithParams.func2()
      /Users/wujunchen/go/pkg/mod/google.golang.org/grpc@v1.80.0/stream.go:387 +0x3c
 

... [1262367 bytes truncated] ...

nal/filetype.Builder.Build()
      /Users/wujunchen/go/pkg/mod/google.golang.org/protobuf@v1.36.11/internal/filetype/build.go:138 +0x1ec
  github.com/milvus-io/milvus-proto/go-api/v2/commonpb.file_common_proto_init()
      /Users/wujunchen/go/pkg/mod/github.com/milvus-io/milvus-proto/go-api/v2@v2.6.17/commonpb/common.pb.go:4561 +0x1f4
  github.com/milvus-io/milvus-proto/go-api/v2/commonpb.init.0()
      /Users/wujunchen/go/pkg/mod/github.com/milvus-io/milvus-proto/go-api/v2@v2.6.17/commonpb/common.pb.go:4227 +0x20
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
  runtime.doInit1()
      /Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/proc.go:8154 +0xc0
==================
{"level":"info","ts":1787377042.8669639,"caller":"worker/worker.go:235","msg":"new ranking model found","old_version":0,"new_version":2}
{"level":"info","ts":1787377042.8669848,"caller":"worker/worker.go:248","msg":"new click model found","old_version":0,"new_version":1}
{"level":"info","ts":1787377042.866998,"caller":"worker/worker.go:147","msg":"start meta sync","meta_timeout":10}
{"level":"error","ts":1787377042.8670049,"caller":"worker/pipeline.go:189","msg":"failed to create recommender","user_id":"1","error":"rpc error: code = Unimplemented desc = unknown service protocol.DataStore","errorVerbose":"rpc error: code = Unimplemented desc = unknown service protocol.DataStore\ngithub.com/gorse-io/gorse/logics.NewRecommender\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/logics/recommend.go:65\ngithub.com/gorse-io/gorse/worker.(*Pipeline).Recommend.func2\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:187\ngithub.com/gorse-io/gorse/common/parallel.Detachable.func1\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/common/parallel/parallel.go:254\nsync.(*WaitGroup).Go.func1\n\t/Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/sync/waitgroup.go:258\nruntime.goexit\n\t/Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/asm_arm64.s:1039","stacktrace":"github.com/gorse-io/gorse/worker.(*Pipeline).Recommend.func2\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:189\ngithub.com/gorse-io/gorse/common/parallel.Detachable.func1\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/common/parallel/parallel.go:254\nsync.(*WaitGroup).Go.func1\n\t/Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/sync/waitgroup.go:258"}
{"level":"info","ts":1787377042.8670568,"caller":"worker/pipeline.go:310","msg":"complete ranking recommendation","used_time":"1.96425ms"}
{"level":"info","ts":1787377042.867075,"caller":"worker/pipeline.go:127","msg":"ranking recommendation","n_working_users":1,"n_jobs":1,"cache_size":100}
{"level":"error","ts":1787377042.867321,"caller":"worker/pipeline.go:358","msg":"failed to load offline recommendation","user_id":"1","error":"rpc error: code = Unimplemented desc = unknown service protocol.CacheStore","stacktrace":"github.com/gorse-io/gorse/worker.(*Pipeline).checkRecommendCacheOutOfDate\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:358\ngithub.com/gorse-io/gorse/worker.(*Pipeline).Recommend.func2\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:181\ngithub.com/gorse-io/gorse/common/parallel.Detachable.func1\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/common/parallel/parallel.go:254\nsync.(*WaitGroup).Go.func1\n\t/Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/sync/waitgroup.go:258"}
{"level":"info","ts":1787377042.8675048,"caller":"worker/worker.go:235","msg":"new ranking model found","old_version":0,"new_version":2}
{"level":"info","ts":1787377042.86752,"caller":"worker/worker.go:248","msg":"new click model found","old_version":0,"new_version":1}
{"level":"info","ts":1787377042.867532,"caller":"worker/worker.go:147","msg":"start meta sync","meta_timeout":10}
{"level":"error","ts":1787377042.867502,"caller":"worker/pipeline.go:189","msg":"failed to create recommender","user_id":"1","error":"rpc error: code = Unimplemented desc = unknown service protocol.DataStore","errorVerbose":"rpc error: code = Unimplemented desc = unknown service protocol.DataStore\ngithub.com/gorse-io/gorse/logics.NewRecommender\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/logics/recommend.go:65\ngithub.com/gorse-io/gorse/worker.(*Pipeline).Recommend.func2\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:187\ngithub.com/gorse-io/gorse/common/parallel.Detachable.func1\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/common/parallel/parallel.go:254\nsync.(*WaitGroup).Go.func1\n\t/Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/sync/waitgroup.go:258\nruntime.goexit\n\t/Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/runtime/asm_arm64.s:1039","stacktrace":"github.com/gorse-io/gorse/worker.(*Pipeline).Recommend.func2\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/worker/pipeline.go:189\ngithub.com/gorse-io/gorse/common/parallel.Detachable.func1\n\t/Users/wujunchen/.no-mistakes/worktrees/76cc582e2299/01M0KXBMT49EVH56A3ZXM6MEME/common/parallel/parallel.go:254\nsync.(*WaitGroup).Go.func1\n\t/Users/wujunchen/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.27.0.darwin-arm64/src/sync/waitgroup.go:258"}
{"level":"info","ts":1787377042.8675551,"caller":"worker/pipeline.go:310","msg":"complete ranking recommendation","used_time":"458.084µs"}
{"level":"info","ts":1787377042.868025,"caller":"worker/worker.go:235","msg":"new ranking model found","old_version":0,"new_version":2}
{"level":"info","ts":1787377042.868038,"caller":"worker/worker.go:248","msg":"new click model found","old_version":0,"new_version":1}
--- FAIL: TestWorker_SyncRecommend (0.02s)
    testing.go:1865: race detected during execution of test
FAIL
FAIL	github.com/gorse-io/gorse/worker	1.027s
FAIL
```
</details>
<details>
<summary>Evidence: 修复后 -race 回归测试通过</summary>

<code>--- PASS: TestWorker_SyncRecommend (0.01s)&#10;PASS&#10;ok github.com/gorse-io/gorse/worker 2.061s</code>

```text
--- PASS: TestWorker_SyncRecommend (0.01s)
PASS
ok  	github.com/gorse-io/gorse/worker	2.061s
```
</details>
<details>
<summary>Evidence: 修复后 -race 完整 worker 套件（含全部推荐行为测试）通过</summary>

`ok github.com/gorse-io/gorse/worker 5.433s`

```text
ok  	github.com/gorse-io/gorse/worker	5.433s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"b16ea2ab137c4f426ef8c485b751e3ee1557ad52","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 issues (1 warning, 1 info)</summary>

- ⚠️ `worker/worker.go:177` - 配置竞争已被正确修复（Recommend 每次循环只取一次不可变快照，Sync unmarshal 到全新 Config 后经 setConfig 加锁发布，已发布配置无任何后续写路径），但 Sync 与 Recommend 之间仍存在未同步的共享状态：当 master 在运行期修改 Database.DataStore/CacheStore/VectorStore 时，Sync 无锁写入 w.DataClient/w.CacheClient/w.VectorClient（worker.go:177/182/195/200 及 vector 段），而进行中的 Recommend 循环并发读取 p.DataClient/p.CacheClient/p.VectorClient（pipeline.go:140 NewItemCache、pipeline.go:190 NewRecommender）；w.peers/w.me（worker.go:262-263）每次同步写入，loop() 的 pullUsers（worker.go:430）并发读取。具体可达路径：master 运行期变更存储路径 → Sync 重连并替换客户端 → 该循环持有旧路径配置快照却读取新存储，且 -race 仍会报告数据竞争。此为修复前已存在的问题，issue #606 维护者指示的修复范围就是配置副本，不属于本次引入的回归；是否需一并处理（如存储重连也采用快照/加锁发布）请确认。
- ℹ️ `worker/worker_test.go:733` - TestWorker_SyncRecommend 只有在 go test -race 下才会在修复前失败、修复后通过；仓库 CI 各测试 job 均使用不带 -race 的 go test（.github/workflows/build_test.yml:127/187/245），因此该回归测试在 CI 中恒为通过，无法提供持续守护，只能保护本地 -race 运行。测试本身通过执行真实并发行为（并发 Sync + Recommend，非源码解析断言）验证，符合测试质量要求；此处仅为覆盖缺口观察——若希望 CI 拦截该回归，需在 worker 测试 job 追加 -race。

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `go build ./worker/`
- `go vet ./worker/`
- `go test -race -run 'TestWorker_SyncRecommend' -count=1 -v ./worker/（修复后：PASS）`
- `git apply -R /tmp/fix.patch（临时还原 worker.go/pipeline.go 到 base commit，保留新测试）后 go test -race -run 'TestWorker_SyncRecommend' ./worker/（base：FAIL，26 处 DATA RACE，写入方 worker.go:163 json.Unmarshal &w.Config，读取方 pipeline.go:187/358 p.Config），随后 git apply 恢复`
- `go test -race -run 'TestWorker' -count=1 -v ./worker/（整个 WorkerTestSuite + TestWorker_Sync + TestWorker_SyncRecommend 全部 PASS）`
- `git status --short 确认工作树已恢复干净`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `.golangci.yml` - Configured golangci-lint could not be executed in this environment: the installed binary (v2.12.2, built with go1.25) refuses to load modules targeting Go 1.27 (go.mod), and no network access exists to fetch a compatible build. CI runs the same linter via golangci/golangci-lint-action@v9, which will download a compatible version. Substitutes run locally all pass: gofmt and goimports (clean), go vet including copylocks (clean), go build ./worker/... (clean). Manual review of the changed code against the enabled linters (errcheck, govet, ineffassign, staticcheck, unused) found no issues.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
