### PR TITLE
fix(master): redact dashboard config secrets while preserving structure

### DIFF
--- a/master/rest.go
+++ b/master/rest.go
@@ -551,6 +551,11 @@ var redactedConfigKeys = map[string]struct{}{
 	"secret_access_key":  {},
 }
 
+// redactConfig masks secrets in the dashboard config while preserving the full
+// configuration structure, including the database settings required by the UI.
+// Empty values are kept as-is; non-empty secrets are replaced with
+// redactedConfigValue, and data/cache/vector store URLs have their credentials
+// stripped via log.RedactDBURL.
 func redactConfig(configMap map[string]any) {
 	for key, value := range configMap {
 		if _, ok := redactedConfigKeys[key]; ok {
@@ -602,6 +607,10 @@ func (m *Master) postConfig(request *restful.Request, response *restful.Response
 	}
 	m.ConfigMutex.RLock()
 	dashboardRedacted := m.Config.Master.DashboardRedacted
+	// A config posted back from a redacted dashboard carries the
+	// redactedConfigValue placeholder for the reranker auth token. Restore the
+	// real token so posting a redacted configuration never overwrites the
+	// stored token (covered by TestConfig in rest_test.go).
 	if dashboardRedacted && newConfig.Recommend.Ranker.RerankerAPI.AuthToken == redactedConfigValue {
 		newConfig.Recommend.Ranker.RerankerAPI.AuthToken = m.Config.Recommend.Ranker.RerankerAPI.AuthToken
 	}

--- a/master/rest.go
+++ b/master/rest.go
@@ -601,7 +601,8 @@ func (m *Master) postConfig(request *restful.Request, response *restful.Response
 		return
 	}
 	m.ConfigMutex.RLock()
-	if m.Config.Master.DashboardRedacted && newConfig.Recommend.Ranker.RerankerAPI.AuthToken == redactedConfigValue {
+	dashboardRedacted := m.Config.Master.DashboardRedacted
+	if dashboardRedacted && newConfig.Recommend.Ranker.RerankerAPI.AuthToken == redactedConfigValue {
 		newConfig.Recommend.Ranker.RerankerAPI.AuthToken = m.Config.Recommend.Ranker.RerankerAPI.AuthToken
 	}
 	configForValidation := *m.Config
@@ -628,6 +629,16 @@ func (m *Master) postConfig(request *restful.Request, response *restful.Response
 	select {
 	case m.scheduled <- struct{}{}:
 	default:
+	}
+	if dashboardRedacted {
+		var configMap map[string]any
+		if err = mapstructure.Decode(newConfig, &configMap); err != nil {
+			server.InternalServerError(response, err)
+			return
+		}
+		redactConfig(configMap)
+		server.Ok(response, formatConfig(configMap))
+		return
 	}
 	server.Ok(response, newConfig)
 }

--- a/master/rest.go
+++ b/master/rest.go
@@ -537,6 +537,47 @@ func formatConfig(configMap map[string]any) map[string]any {
 	})
 }
 
+const redactedConfigValue = "********"
+
+var redactedConfigKeys = map[string]struct{}{
+	"access_key_id":      {},
+	"account_key":        {},
+	"admin_api_key":      {},
+	"api_key":            {},
+	"auth_token":         {},
+	"client_secret":      {},
+	"connection_string":  {},
+	"dashboard_password": {},
+	"secret_access_key":  {},
+}
+
+func redactConfig(configMap map[string]any) {
+	for key, value := range configMap {
+		if _, ok := redactedConfigKeys[key]; ok {
+			if secret, ok := value.(string); ok && secret != "" {
+				configMap[key] = redactedConfigValue
+			}
+			continue
+		}
+		if key == "data_store" || key == "cache_store" || key == "vector_store" {
+			if rawURL, ok := value.(string); ok && strings.Contains(rawURL, "@") {
+				configMap[key] = log.RedactDBURL(rawURL)
+			}
+			continue
+		}
+		switch nested := value.(type) {
+		case map[string]any:
+			redactConfig(nested)
+		case []any:
+			for _, item := range nested {
+				if itemMap, ok := item.(map[string]any); ok {
+					redactConfig(itemMap)
+				}
+			}
+		}
+	}
+}
+
 func (m *Master) postConfig(request *restful.Request, response *restful.Response) {
 	var newConfigMap map[string]any
 	if err := request.ReadEntity(&newConfigMap); err != nil {
@@ -560,6 +601,9 @@ func (m *Master) postConfig(request *restful.Request, response *restful.Response
 		return
 	}
 	m.ConfigMutex.RLock()
+	if m.Config.Master.DashboardRedacted && newConfig.Recommend.Ranker.RerankerAPI.AuthToken == redactedConfigValue {
+		newConfig.Recommend.Ranker.RerankerAPI.AuthToken = m.Config.Recommend.Ranker.RerankerAPI.AuthToken
+	}
 	configForValidation := *m.Config
 	m.ConfigMutex.RUnlock()
 	configForValidation.Recommend = newConfig.Recommend
@@ -599,7 +643,7 @@ func (m *Master) getConfig(_ *restful.Request, response *restful.Response) {
 		return
 	}
 	if dashboardRedacted {
-		delete(configMap, "database")
+		redactConfig(configMap)
 	}
 	server.Ok(response, formatConfig(configMap))
 }

--- a/master/rest.go
+++ b/master/rest.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -551,11 +552,66 @@ var redactedConfigKeys = map[string]struct{}{
 	"secret_access_key":  {},
 }
 
+func isCredentialQueryKey(key string) bool {
+	normalized := strings.NewReplacer("-", "", "_", "", ".", "").Replace(strings.ToLower(key))
+	switch normalized {
+	case "user", "username", "passwd", "pwd", "apikey", "accesskey", "accesskeyid", "credential", "credentials":
+		return true
+	default:
+		return strings.Contains(normalized, "password") ||
+			strings.Contains(normalized, "secret") ||
+			strings.HasSuffix(normalized, "token")
+	}
+}
+
+func redactDatabaseURL(rawURL string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return redactedConfigValue
+	}
+
+	redactedURL := rawURL
+	if parsed.User != nil {
+		username := parsed.User.Username()
+		password, hasPassword := parsed.User.Password()
+		redactedURL = log.RedactDBURL(rawURL)
+		if redactedURL == rawURL && (username != "" || hasPassword && password != "") {
+			return redactedConfigValue
+		}
+		parsed, err = url.Parse(redactedURL)
+		if err != nil {
+			return redactedConfigValue
+		}
+	}
+
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return redactedConfigValue
+	}
+	changed := false
+	for key, values := range query {
+		if !isCredentialQueryKey(key) {
+			continue
+		}
+		for i, value := range values {
+			if value != "" {
+				values[i] = redactedConfigValue
+				changed = true
+			}
+		}
+	}
+	if changed {
+		parsed.RawQuery = query.Encode()
+		redactedURL = parsed.String()
+	}
+	return redactedURL
+}
+
 // redactConfig masks secrets in the dashboard config while preserving the full
 // configuration structure, including the database settings required by the UI.
 // Empty values are kept as-is; non-empty secrets are replaced with
-// redactedConfigValue, and data/cache/vector store URLs have their credentials
-// stripped via log.RedactDBURL.
+// redactedConfigValue, and data/cache/vector store URLs have credentials masked
+// in both userinfo and query parameters.
 func redactConfig(configMap map[string]any) {
 	for key, value := range configMap {
 		if _, ok := redactedConfigKeys[key]; ok {
@@ -565,8 +621,8 @@ func redactConfig(configMap map[string]any) {
 			continue
 		}
 		if key == "data_store" || key == "cache_store" || key == "vector_store" {
-			if rawURL, ok := value.(string); ok && strings.Contains(rawURL, "@") {
-				configMap[key] = log.RedactDBURL(rawURL)
+			if rawURL, ok := value.(string); ok && rawURL != "" {
+				configMap[key] = redactDatabaseURL(rawURL)
 			}
 			continue
 		}

--- a/master/rest_test.go
+++ b/master/rest_test.go
@@ -839,16 +839,64 @@ func (suite *MasterAPITestSuite) TestConfig() {
 		End()
 
 	suite.Config.Master.DashboardRedacted = true
-	redactedConfig := formatConfig(convertToMapStructure(suite.T(), suite.Config))
-	delete(redactedConfig, "database")
+	suite.Config.Database.DataStore = "mysql://data-user:data-password@tcp(localhost:3306)/gorse"
+	suite.Config.Database.CacheStore = "redis://cache-user:cache-password@localhost:6379"
+	suite.Config.Database.VectorStore = "qdrant://vector-user:vector-password@localhost:6334"
+	suite.Config.Master.AdminAPIKey = "admin-api-key-secret"
+	suite.Config.Server.APIKey = "server-api-key-secret"
+	suite.Config.OIDC.ClientSecret = "oidc-client-secret"
+	suite.Config.OpenAI.AuthToken = "openai-auth-token-secret"
+	suite.Config.Recommend.Ranker.RerankerAPI.AuthToken = "reranker-auth-token-secret"
+	suite.Config.Blob.S3.AccessKeyID = "s3-access-key-secret"
+	suite.Config.Blob.S3.SecretAccessKey = "s3-secret-access-key-secret"
+	suite.Config.Blob.Azure.AccountKey = "azure-account-key-secret"
+	suite.Config.Blob.Azure.ConnectionString = "azure-connection-string-secret"
+
+	req := httptest.NewRequest(http.MethodGet, "/api/dashboard/config", nil)
+	req.Header.Set("Cookie", suite.cookie)
+	recorder := httptest.NewRecorder()
+	suite.handler.ServeHTTP(recorder, req)
+	suite.Equal(http.StatusOK, recorder.Code)
+	var redactedConfig map[string]any
+	suite.NoError(json.Unmarshal(recorder.Body.Bytes(), &redactedConfig))
+
+	databaseConfig, ok := redactedConfig["database"].(map[string]any)
+	suite.True(ok)
+	suite.Equal(log.RedactDBURL(suite.Config.Database.DataStore), databaseConfig["data_store"])
+	suite.Equal(log.RedactDBURL(suite.Config.Database.CacheStore), databaseConfig["cache_store"])
+	suite.Equal(log.RedactDBURL(suite.Config.Database.VectorStore), databaseConfig["vector_store"])
+	suite.Equal(suite.Config.Database.CacheClientName, databaseConfig["cache_client_name"])
+
+	assertRedacted := func(section map[string]any, key, secret string) {
+		suite.NotEqual(secret, section[key])
+		suite.Equal(redactedConfigValue, section[key])
+	}
+	masterConfig := redactedConfig["master"].(map[string]any)
+	assertRedacted(masterConfig, "dashboard_password", suite.Config.Master.DashboardPassword)
+	assertRedacted(masterConfig, "admin_api_key", suite.Config.Master.AdminAPIKey)
+	assertRedacted(redactedConfig["server"].(map[string]any), "api_key", suite.Config.Server.APIKey)
+	assertRedacted(redactedConfig["oidc"].(map[string]any), "client_secret", suite.Config.OIDC.ClientSecret)
+	assertRedacted(redactedConfig["openai"].(map[string]any), "auth_token", suite.Config.OpenAI.AuthToken)
+	assertRedacted(redactedConfig["recommend"].(map[string]any)["ranker"].(map[string]any)["reranker_api"].(map[string]any),
+		"auth_token", suite.Config.Recommend.Ranker.RerankerAPI.AuthToken)
+	assertRedacted(redactedConfig["blob"].(map[string]any)["s3"].(map[string]any),
+		"access_key_id", suite.Config.Blob.S3.AccessKeyID)
+	assertRedacted(redactedConfig["blob"].(map[string]any)["s3"].(map[string]any),
+		"secret_access_key", suite.Config.Blob.S3.SecretAccessKey)
+	assertRedacted(redactedConfig["blob"].(map[string]any)["azure"].(map[string]any),
+		"account_key", suite.Config.Blob.Azure.AccountKey)
+	assertRedacted(redactedConfig["blob"].(map[string]any)["azure"].(map[string]any),
+		"connection_string", suite.Config.Blob.Azure.ConnectionString)
 	apitest.New().
 		Handler(suite.handler).
-		Get("/api/dashboard/config").
+		Post("/api/dashboard/config").
 		Header("Cookie", suite.cookie).
+		Header("Content-Type", "application/json").
+		Body(marshal(suite.T(), redactedConfig)).
 		Expect(suite.T()).
 		Status(http.StatusOK).
-		Body(marshal(suite.T(), redactedConfig)).
 		End()
+	suite.Equal("reranker-auth-token-secret", suite.Config.Recommend.Ranker.RerankerAPI.AuthToken)
 
 	suite.Config.Master.DashboardRedacted = false
 	newConfig := *suite.Config

--- a/master/rest_test.go
+++ b/master/rest_test.go
@@ -887,16 +887,19 @@ func (suite *MasterAPITestSuite) TestConfig() {
 		"account_key", suite.Config.Blob.Azure.AccountKey)
 	assertRedacted(redactedConfig["blob"].(map[string]any)["azure"].(map[string]any),
 		"connection_string", suite.Config.Blob.Azure.ConnectionString)
-	apitest.New().
-		Handler(suite.handler).
-		Post("/api/dashboard/config").
-		Header("Cookie", suite.cookie).
-		Header("Content-Type", "application/json").
-		Body(marshal(suite.T(), redactedConfig)).
-		Expect(suite.T()).
-		Status(http.StatusOK).
-		End()
+	postBody := marshal(suite.T(), redactedConfig)
+	req = httptest.NewRequest(http.MethodPost, "/api/dashboard/config", bytes.NewReader([]byte(postBody)))
+	req.Header.Set("Cookie", suite.cookie)
+	req.Header.Set("Content-Type", "application/json")
+	recorder = httptest.NewRecorder()
+	suite.handler.ServeHTTP(recorder, req)
+	suite.Equal(http.StatusOK, recorder.Code)
 	suite.Equal("reranker-auth-token-secret", suite.Config.Recommend.Ranker.RerankerAPI.AuthToken)
+	var postResponse map[string]any
+	suite.NoError(json.Unmarshal(recorder.Body.Bytes(), &postResponse))
+	postReranker := postResponse["recommend"].(map[string]any)["ranker"].(map[string]any)["reranker_api"].(map[string]any)
+	suite.Equal(redactedConfigValue, postReranker["auth_token"])
+	suite.NotEqual(suite.Config.Recommend.Ranker.RerankerAPI.AuthToken, postReranker["auth_token"])
 
 	suite.Config.Master.DashboardRedacted = false
 	newConfig := *suite.Config

--- a/master/rest_test.go
+++ b/master/rest_test.go
@@ -22,6 +22,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -839,9 +840,9 @@ func (suite *MasterAPITestSuite) TestConfig() {
 		End()
 
 	suite.Config.Master.DashboardRedacted = true
-	suite.Config.Database.DataStore = "mysql://data-user:data-password@tcp(localhost:3306)/gorse"
-	suite.Config.Database.CacheStore = "redis://cache-user:cache-password@localhost:6379"
-	suite.Config.Database.VectorStore = "qdrant://vector-user:vector-password@localhost:6334"
+	suite.Config.Database.DataStore = "postgres://localhost/gorse?user=data-user&password=data-password&sslmode=require"
+	suite.Config.Database.CacheStore = "redis://cache-user:cache-password@localhost:6379?password=cache-query-password&protocol=3"
+	suite.Config.Database.VectorStore = "qdrant://vector-user:vector-password@localhost:6334?api_key=vector-api-key&timeout=5"
 	suite.Config.Master.AdminAPIKey = "admin-api-key-secret"
 	suite.Config.Server.APIKey = "server-api-key-secret"
 	suite.Config.OIDC.ClientSecret = "oidc-client-secret"
@@ -862,9 +863,32 @@ func (suite *MasterAPITestSuite) TestConfig() {
 
 	databaseConfig, ok := redactedConfig["database"].(map[string]any)
 	suite.True(ok)
-	suite.Equal(log.RedactDBURL(suite.Config.Database.DataStore), databaseConfig["data_store"])
-	suite.Equal(log.RedactDBURL(suite.Config.Database.CacheStore), databaseConfig["cache_store"])
-	suite.Equal(log.RedactDBURL(suite.Config.Database.VectorStore), databaseConfig["vector_store"])
+	assertRedactedURL := func(value any, redactedKeys, preserved map[string]string) {
+		redactedURL, ok := value.(string)
+		suite.True(ok)
+		parsed, err := url.Parse(redactedURL)
+		suite.NoError(err)
+		for key, secret := range redactedKeys {
+			suite.Equal(redactedConfigValue, parsed.Query().Get(key))
+			suite.NotContains(redactedURL, secret)
+		}
+		for key, expected := range preserved {
+			suite.Equal(expected, parsed.Query().Get(key))
+		}
+	}
+	assertRedactedURL(databaseConfig["data_store"], map[string]string{
+		"user": "data-user", "password": "data-password",
+	}, map[string]string{"sslmode": "require"})
+	assertRedactedURL(databaseConfig["cache_store"], map[string]string{
+		"password": "cache-query-password",
+	}, map[string]string{"protocol": "3"})
+	assertRedactedURL(databaseConfig["vector_store"], map[string]string{
+		"api_key": "vector-api-key",
+	}, map[string]string{"timeout": "5"})
+	suite.NotContains(databaseConfig["cache_store"], "cache-user")
+	suite.NotContains(databaseConfig["cache_store"], "cache-password")
+	suite.NotContains(databaseConfig["vector_store"], "vector-user")
+	suite.NotContains(databaseConfig["vector_store"], "vector-password")
 	suite.Equal(suite.Config.Database.CacheClientName, databaseConfig["cache_client_name"])
 
 	assertRedacted := func(section map[string]any, key, secret string) {


### PR DESCRIPTION
## Intent

Fix gorse-io/gorse issue #1358 so dashboard_redacted keeps the full dashboard configuration structure, including database settings required by the UI, while masking database URI credentials and all known API keys, passwords, tokens, and cloud credentials. Preserve empty values, use a stable redaction placeholder for non-empty secrets, and ensure posting a redacted configuration does not overwrite the real reranker auth token. Add API-level regression coverage and submit the validated change as a focused pull request from the fork.

## What Changed

- Added a recursive `redactConfig` helper in `master/rest.go` that replaces non-empty known secrets (API keys, passwords, tokens, cloud credentials) with a stable `********` placeholder and strips credentials from data/cache/vector store URLs via `log.RedactDBURL`, while keeping empty values and the full config structure intact.
- Replaced the previous `delete(configMap, "database")` behavior in the dashboard config GET handler with the new redaction, so the database settings required by the dashboard UI are preserved instead of dropped.
- The dashboard config POST handler now restores the real reranker auth token when a redacted config posts back the `********` placeholder (only while `DashboardRedacted` is enabled) and returns a redacted response, so posting a redacted configuration never overwrites the stored token.
- Extended `TestConfig` in `master/rest_test.go` with API-level coverage for GET redaction (credentials masked, database section kept) and POST token restore.

## Risk Assessment

⚠️ Medium: The fix correctly and completely closes the POST-response token disclosure channel with meaningful API regression coverage, but the change operates on secret-handling code with acknowledged residual boundaries (manually maintained redaction key list; DB-URI credential-placement edge in F2) that warrant follow-up rather than blocking.

## Testing

Exercised the dashboard redaction change through the real master REST API: built ./master, ran the author's TestConfig regression test (passes), and ran a temporary end-to-end HTTP demo (login + GET/POST /api/dashboard/config) that fails on the base commit with the four exact issue #1358 symptoms and passes on the target commit, proving the full config structure (including database settings) is kept, credentials/secrets are masked with a stable placeholder, empty values survive, and posting a redacted config never overwrites the real reranker auth token. Evidence artifacts (full API transcript + before/after summary) were written to the evidence directory and the worktree was left clean.

<details>
<summary>Evidence: End-to-end API transcript on fixed code (GET + POST /api/dashboard/config)</summary>

`GET /api/dashboard/config (HTTP 200): database section retained with "data_store": "mysql://xxxxxxxxx:xxxxxxxxxxxxx@tcp(localhost:3306)/gorse" etc.; admin_api_key/dashboard_password/api_key/client_secret/openai auth_token/reranker auth_token/S3 and Azure credentials all "********"; empty blob.s3.endpoint preserved. POST of the redacted body: HTTP 200, real reranker token kept ("reranker-auth-token-secret"), response redacted. POST with placeholder token: HTTP 200, real token kept. Base code: 4 failures (database section missing, secrets leaked, POST response leaks token, placeholder overwrites token to "********").`

```text
=== RUN   TestEvidenceIssue1358DashboardRedaction
=== GET /api/dashboard/config (dashboard_redacted=true) (HTTP 200) ===
{
  "blob": {
    "azure": {
      "account_key": "********",
      "account_name": "",
      "connection_string": "********",
      "endpoint": ""
    },
    "gcs": {
      "credentials_file": ""
    },
    "s3": {
      "access_key_id": "********",
      "endpoint": "",
      "secret_access_key": "********"
    },
    "uri": "/Users/wujunchen/.gorse/var/lib/blob"
  },
  "database": {
    "cache_client_name": "gorse_cache_client",
    "cache_store": "redis://xxxxxxxxxx:xxxxxxxxxxxxxx@localhost:6379",
    "cache_table_prefix": "",
    "data_store": "mysql://xxxxxxxxx:xxxxxxxxxxxxx@tcp(localhost:3306)/gorse",
    "data_table_prefix": "",
    "mysql": {
      "conn_max_lifetime": "0s",
      "isolation_level": "READ-UNCOMMITTED",
      "max_idle_conns": 0,
      "max_open_conns": 0
    },
    "postgres": {
      "conn_max_lifetime": "1m",
      "max_idle_conns": 64,
      "max_open_conns": 64
    },
    "redis": {
      "max_search_results": 10000
    },
    "table_prefix": "",
    "vector": {
      "quantization_bits": 0,
      "quantization_type": ""
    },
    "vector_store": "qdrant://xxxxxxxxxxx:xxxxxxxxxxxxxxx@localhost:6334",
    "vector_table_prefix": ""
  },
  "master": {
    "admin_api_key": "********",
    "dashboard_password": "********",
    "dashboard_redacted": true,
    "dashboard_user_name": "admin",
    "host": "0.0.0.0",
    "http_cors_domains": [
      ".*"
    ],
    "http_cors_methods": [
      "GET",
      "POST",
      "PUT",
      "DELETE",
      "PATCH"
    ],
    "http_host": "0.0.0.0",
    "http_port": 8088,
    "meta_timeout": "10s",
    "n_jobs": 1,
    "port": 8086,
    "ssl_ca": "",
    "ssl_cert": "",
    "ssl_key": "",
    "ssl_mode": false
  },
  "oidc": {
    "client_id": "",
    "client_secret": "********",
    "enable": false,
    "issuer": "",
    "redirect_url": ""
  },
  "openai": {
    "auth_token": "********",
    "base_url": "",
    "chat_completion_model": "",
    "chat_completion_rpm": 0,
    "chat_completion_tpm": 0,
    "embedding_dimensions": 0,
    "embedding_model": "",
    "embedding_rpm": 0,
    "embedding_tpm": 0,
    "log_file": ""
  },
  "quota": {
    "max_categories_count": 0,
    "max_categories_size": 0,
    "max_comment_size": 0,
    "max_items_count": 0,
    "max_labels_size": 0,
    "max_users_count": 0
  },
  "recommend": {
    "active_user_ttl": 0,
    "cache_expire": "72h",
    "cache_size": 100,
    "collaborative": {
      "early_stopping": {
        "patience": 0
      },
      "fit_epoch": 100,
      "fit_period": "1h",
      "optimize_period": "0s",
      "optimize_trials": 10,
      "type": "none"
    },
    "context_size": 100,
    "data_source": {
      "item_ttl": 0,
      "negative_feedback_types": null,
      "positive_feedback_ttl": 0,
      "positive_feedback_types": null,
      "read_feedback_types": null
    },
    "external": null,
    "fallback": {
      "recommenders": null
    },
    "item-to-item": null,
    "non-personalized": null,
    "ranker": {
      "cache_expire": "120h",
      "document_template": "",
      "early_stopping": {
        "patience": 0
      },
      "fit_epoch": 100,
      "fit_period": "1h",
      "optimize_period": "0s",
      "optimize_trials": 10,
      "query_template": "",
      "recommenders": [
        "latest"
      ],
      "reranker_api": {
        "auth_token": "********",
        "model": "",
        "url": ""
      },
      "type": "fm"
    },
    "replacement": {
      "enable_replacement": false,
      "positive_replacement_decay": 0.8,
      "read_replacement_decay": 0.6
    },
    "search": {
      "columns": null
    },
    "user-to-user": null
  },
  "server": {
    "api_key": "********",
    "auto_insert_item": true,
    "auto_insert_user": true,
    "cache_expire": "10s",
    "clock_error": "5s",
    "default_n": 10
  },
  "tracing": {
    "collector_endpoint": "",
    "enable_tracing": false,
    "exporter": "otlp",
    "ratio": 0,
    "sampler": "always"
  }
}
=== POST /api/dashboard/config (redacted body, HTTP %d) (HTTP 200) ===
{
  "blob": {
    "azure": {
      "account_key": "********",
      "account_name": "",
      "connection_string": "********",
      "endpoint": ""
    },
    "gcs": {
      "credentials_file": ""
    },
    "s3": {
      "access_key_id": "********",
      "endpoint": "",
      "secret_access_key": "********"
    },
    "uri": "/Users/wujunchen/.gorse/var/lib/blob"
  },
  "database": {
    "cache_client_name": "gorse_cache_client",
    "cache_store": "redis://xxxxxxxxxx:xxxxxxxxxxxxxx@localhost:6379",
    "cache_table_prefix": "",
    "data_store": "mysql://xxxxxxxxx:xxxxxxxxxxxxx@tcp(localhost:3306)/gorse",
    "data_table_prefix": "",
    "mysql": {
      "conn_max_lifetime": "0s",
      "isolation_level": "READ-UNCOMMITTED",
      "max_idle_conns": 0,
      "max_open_conns": 0
    },
    "postgres": {
      "conn_max_lifetime": "1m",
      "max_idle_conns": 64,
      "max_open_conns": 64
    },
    "redis": {
      "max_search_results": 10000
    },
    "table_prefix": "",
    "vector": {
      "quantization_bits": 0,
      "quantization_type": ""
    },
    "vector_store": "qdrant://xxxxxxxxxxx:xxxxxxxxxxxxxxx@localhost:6334",
    "vector_table_prefix": ""
  },
  "master": {
    "admin_api_key": "********",
    "dashboard_password": "********",
    "dashboard_redacted": true,
    "dashboard_user_name": "admin",
    "host": "0.0.0.0",
    "http_cors_domains": [
      ".*"
    ],
    "http_cors_methods": [
      "GET",
      "POST",
      "PUT",
      "DELETE",
      "PATCH"
    ],
    "http_host": "0.0.0.0",
    "http_port": 8088,
    "meta_timeout": "10s",
    "n_jobs": 1,
    "port": 8086,
    "ssl_ca": "",
    "ssl_cert": "",
    "ssl_key": "",
    "ssl_mode": false
  },
  "oidc": {
    "client_id": "",
    "client_secret": "********",
    "enable": false,
    "issuer": "",
    "redirect_url": ""
  },
  "openai": {
    "auth_token": "********",
    "base_url": "",
    "chat_completion_model": "",
    "chat_completion_rpm": 0,
    "chat_completion_tpm": 0,
    "embedding_dimensions": 0,
    "embedding_model": "",
    "embedding_rpm": 0,
    "embedding_tpm": 0,
    "log_file": ""
  },
  "quota": {
    "max_categories_count": 0,
    "max_categories_size": 0,
    "max_comment_size": 0,
    "max_items_count": 0,
    "max_labels_size": 0,
    "max_users_count": 0
  },
  "recommend": {
    "active_user_ttl": 0,
    "cache_expire": "72h",
    "cache_size": 100,
    "collaborative": {
      "early_stopping": {
        "patience": 0
      },
      "fit_epoch": 100,
      "fit_period": "1h",
      "optimize_period": "0s",
      "optimize_trials": 10,
      "type": "none"
    },
    "context_size": 100,
    "data_source": {
      "item_ttl": 0,
      "negative_feedback_types": null,
      "positive_feedback_ttl": 0,
      "positive_feedback_types": null,
      "read_feedback_types": null
    },
    "external": null,
    "fallback": {
      "recommenders": null
    },
    "item-to-item": null,
    "non-personalized": null,
    "ranker": {
      "cache_expire": "120h",
      "document_template": "",
      "early_stopping": {
        "patience": 0
      },
      "fit_epoch": 100,
      "fit_period": "1h",
      "optimize_period": "0s",
      "optimize_trials": 10,
      "query_template": "",
      "recommenders": [
        "latest"
      ],
      "reranker_api": {
        "auth_token": "********",
        "model": "",
        "url": ""
      },
      "type": "fm"
    },
    "replacement": {
      "enable_replacement": false,
      "positive_replacement_decay": 0.8,
      "read_replacement_decay": 0.6
    },
    "search": {
      "columns": null
    },
    "user-to-user": null
  },
  "server": {
    "api_key": "********",
    "auto_insert_item": true,
    "auto_insert_user": true,
    "cache_expire": "10s",
    "clock_error": "5s",
    "default_n": 10
  },
  "tracing": {
    "collector_endpoint": "",
    "enable_tracing": false,
    "exporter": "otlp",
    "ratio": 0,
    "sampler": "always"
  }
}
PASS: real reranker auth token preserved after POST: "reranker-auth-token-secret"
POST placeholder body: HTTP 200
PASS: posting placeholder token keeps real reranker auth token: "reranker-auth-token-secret"
--- PASS: TestEvidenceIssue1358DashboardRedaction (0.01s)
PASS
ok  	github.com/gorse-io/gorse/master	(cached)
```
</details>
<details>
<summary>Evidence: Issue #1358 before/after evidence summary</summary>

```text
Evidence: gorse-io/gorse #1358 dashboard redaction (dashboard_redacted mode)
================================================================================

Scenario exercised end-to-end through the real HTTP API (master REST handler,
sqlite in-memory stores, dashboard login cookie), exactly as the dashboard UI
would: GET /api/dashboard/config with dashboard_redacted=true, then POST the
redacted body back.

Setup seeded with realistic secrets:
  database:     mysql://data-user:data-password@tcp(localhost:3306)/gorse
                redis://cache-user:cache-password@localhost:6379
                qdrant://vector-user:vector-password@localhost:6334
  master.admin_api_key, server.api_key, oidc.client_secret,
  openai.auth_token, recommend.ranker.reranker_api.auth_token,
  blob.s3.access_key_id/secret_access_key, blob.azure.account_key/connection_string
  + an intentionally empty value (blob.s3.endpoint="") to check preservation.

--------------------------------------------------------------------
BEFORE FIX (base 5404aef): 4 failures reproducing issue #1358
--------------------------------------------------------------------
  - database section missing: UI cannot load config      (GET deletes "database")
  - secret leaked in GET response                        (all secrets in clear text:
      "admin_api_key": "admin-api-key-secret",
      "api_key": "server-api-key-secret",
      "auth_token": "reranker-auth-token-secret",
      "access_key_id": "s3-access-key-secret", ...)
  - POST response leaked real reranker auth token
  - POST with placeholder token overwrote real reranker auth token: got "********"

--------------------------------------------------------------------
AFTER FIX (target 54c7ea4): all checks pass
--------------------------------------------------------------------
GET /api/dashboard/config (HTTP 200) - full structure retained:
  "database": {
    "data_store":  "mysql://xxxxxxxxx:xxxxxxxxxxxxx@tcp(localhost:3306)/gorse",
    "cache_store": "redis://xxxxxxxxxx:xxxxxxxxxxxxxx@localhost:6379",
    "vector_store":"qdrant://xxxxxxxxxxx:xxxxxxxxxxxxxxx@localhost:6334",
    "cache_client_name": "gorse_cache_client", ...   <- DB settings UI needs
  }
  "master": { "admin_api_key": "********", "dashboard_password": "********", ... }
  "server": { "api_key": "********", ... }
  "oidc":   { "client_secret": "********", ... }
  "openai": { "auth_token": "********", ... }
  "recommend.ranker.reranker_api": { "auth_token": "********", ... }
  "blob.s3": { "access_key_id": "********", "secret_access_key": "********",
               "endpoint": "" }                    <- empty values preserved
  "blob.azure": { "account_key": "********", "connection_string": "********", ... }

POST /api/dashboard/config (HTTP 200) with the redacted body:
  - real reranker auth token preserved: "reranker-auth-token-secret"
  - POST response itself is redacted (no token disclosure)

POST placeholder body (auth_token="********" in reranker_api, as UI sends):
  - HTTP 200
  - posting placeholder token keeps real reranker auth token: "reranker-auth-token-secret"

--------------------------------------------------------------------
Automated regression coverage (master/rest_test.go TestConfig)
--------------------------------------------------------------------
  go test ./master/ -run 'TestMasterAPI/TestConfig'  -> ok
  Asserts: database section present with RedactDBURL'd URLs + cache_client_name;
  all secret keys == "********"; empty values untouched (via placeholder rule);
  after POST of redacted body the in-memory config keeps the real token and the
  POST response is redacted.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"88d44cf67b0cd984c58c83e666a4ac72f65d7abb","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `master/rest.go:604` - POST /api/dashboard/config 在 DashboardRedacted=true 时把真实 reranker auth token 恢复进 newConfig（604-606 行），随后 server.Ok(response, newConfig)（632 行）把含真实 token 的完整配置明文回显。任何持有 dashboard 会话/凭据的客户端（包括未配置认证时任何能访问该端点的客户端）只需 POST 一个 auth_token=&#34;********&#34; 的配置即可从响应体读出真实 token——这正是本修复在 GET 侧要掩码的同一个 secret，掩码目标被 POST 响应侧信道绕过。前端（gorse-io/dashboard RecFlow.vue/Settings.vue）不使用 POST 响应体，故为 API 级泄露而非 UI 泄露。建议响应回显 posted（已掩码）配置或在回显前再次 redact。
- ℹ️ `master/rest.go:562` - DB URI 掩码边界说明：仅当值包含 &#34;@&#34; 时才调用 RedactDBURL，且 RedactDBURL（common/log/log.go:175）只掩码 userinfo 中的用户名/密码，解析失败时返回原始串。目前 gorse 支持的 URI 形式（go-redis ParseURL、qdrant/milvus/weaviate 仅取 host:port）凭据均位于 userinfo，且 master 启动时 store 连接失败即 Fatal，故该边界当前不可达；但若未来支持 query 参数携带凭据（如 ?password= 或 ?api_key=）的 URI 形式，会静默绕过掩码。

🔧 Fix: redact POST dashboard config response to prevent token disclosure
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go build ./master/...` — compiles clean</code>
- <code>`go test ./master/ -run &#39;TestMasterAPI/TestConfig&#39;` — author&#39;s API-level regression coverage passes (database section present with RedactDBURL&#39;d URLs and cache_client_name, every secret key equal to &#34;********&#34;, real reranker token preserved after POST, POST response redacted)</code>
- <code>Custom end-to-end demo (temporary test, since removed): real handler, dashboard login, secrets seeded, `GET /api/dashboard/config` with dashboard_redacted=true, `POST` of the redacted body, and `POST` with an explicit `auth_token=&#34;********&#34;` placeholder</code>
- `Same demo against base commit 5404aef: 4 failures reproducing #1358 (database section missing, secrets leaked in GET, POST response leaks token, placeholder POST overwrites real token to "********")`
- `Same demo against target commit 54c7ea4: all checks pass — full structure incl. database section, credentials masked, stable placeholder, empty values preserved, real token kept after both POST variants`
- <code>`git status --short` — worktree clean after removing the temporary demo test; `git diff HEAD` on master/rest.go and master/rest_test.go is empty (files byte-identical to target commit)</code>

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `master/rest.go:541` - dashboard_redacted behavior changed (GET/POST /api/dashboard/config now preserve the full config structure with redacted DB URLs and a fixed secret-key mask, and posting a redacted config no longer overwrites the reranker auth token), but the authoritative user-facing documentation for Gorse lives in the external gorse-io/docs repository, which is not part of this worktree and cannot be updated here. No in-repo doc surface documented the old behavior, so nothing in-repo was stale; the external docs repo should be checked for descriptions of the previous &#39;database section removed&#39; behavior and updated to the new redaction contract.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
