### PR TITLE
chore: upgrade xvec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/gorilla/securecookie v1.1.2
 	github.com/gorse-io/dashboard v0.5.20260714
 	github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2
-	github.com/gorse-io/xvec v0.0.0-20260821023012-cf0c34c6025f
+	github.com/gorse-io/xvec v0.0.0-20260824032339-17cad6e9fa2d
 	github.com/invopop/jsonschema v0.13.0
 	github.com/jaswdr/faker v1.19.1
 	github.com/jellydator/ttlcache/v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,6 @@ github.com/cockroachdb/pebble/v2 v2.1.6 h1:GDo7Z2+LgFZ7LJLdLmBXhDeTVIwgSPGxIT15h
 github.com/cockroachdb/pebble/v2 v2.1.6/go.mod h1:Reo1RTniv1UjVTAu/Fv74y5i3kJ5gmVrPhO9UtFiKn8=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b h1:VXvSNzmr8hMj8XTuY0PT9Ane9qZGul/p67vGYwl9BFI=
-github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258 h1:IJ+uNItEm0qx9FE2AgIc1PMsCUtk8nbSIzhQE1t5GWw=
 github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
@@ -381,8 +379,8 @@ github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2 h1:tx7
 github.com/gorse-io/gorse-go v0.5.0-alpha.3.0.20260613082921-062d740c10a2/go.mod h1:ZxmVHzZPKm5pmEIlqaRDwK0rkfTRHlfziO033XZ+RW0=
 github.com/gorse-io/sqlite v1.3.3-0.20260620140844-3b4da3e2b9f2 h1:5URyKN9bYIO+WG3hbfaOkTBHmdLT4U8JQSe2vSEWJDE=
 github.com/gorse-io/sqlite v1.3.3-0.20260620140844-3b4da3e2b9f2/go.mod h1:2A/iJg34FXGCljLiSsmdilFooNtjmfQr7CmcD+2sh68=
-github.com/gorse-io/xvec v0.0.0-20260821023012-cf0c34c6025f h1:IVQvoAE/aQ7i6xnFvrWf+9qbawpLVAYsDMrgKMkddO4=
-github.com/gorse-io/xvec v0.0.0-20260821023012-cf0c34c6025f/go.mod h1:Ga2ZBLZxjsBgxAiZznGc3r1DyZmEINl0j827aEc3tVw=
+github.com/gorse-io/xvec v0.0.0-20260824032339-17cad6e9fa2d h1:mPAFExW1OAPckZiur9Uf2BL/4RKiccJQIhp/xKMVzKU=
+github.com/gorse-io/xvec v0.0.0-20260824032339-17cad6e9fa2d/go.mod h1:F22vQhlaDZxKJNSN6QHVvPpskaz6CcNAxEAzyZHDOIs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1 h1:qnpSQwGEnkcRpTqNOIR6bJbR0gAorgP9CSALpRcKoAA=


### PR DESCRIPTION
## Summary

- upgrade `github.com/gorse-io/xvec` to `v0.0.0-20260824032339-17cad6e9fa2d`
- keep DiskANN as the default dense-vector index and query path
- refresh module checksums with `go mod tidy`

## Tests

- `go test ./storage/vectors -count=1`
- `go test ./config -count=1`
- `go vet ./storage/vectors`
- `git diff --check`

A local `go test ./... -count=1` run passed all completed packages, but `client` and `master` could not link because the local root filesystem hit `disk quota exceeded`. This was an environment failure rather than a source compilation error; CI is expected to provide full-suite coverage.
