### PR TITLE
ci: update Redis cluster action address

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -302,7 +302,7 @@ jobs:
           packages: qemu-user-static
 
       - name: Setup Redis cluster
-        uses: gorse-cloud/redis-cluster@v1.0.0
+        uses: gorse-io/redis-cluster@v1.0.0
 
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v5


### PR DESCRIPTION
## Summary

- update the Redis cluster setup action to use its new `gorse-io/redis-cluster` repository address

## Verification

- confirmed `gorse-io/redis-cluster@v1.0.0` exists
- `git diff --check`
- verified no stale `gorse-cloud/redis-cluster` reference remains in the workflow
